### PR TITLE
fix sanity check for withdrawals root

### DIFF
--- a/crates/api/src/builder/error.rs
+++ b/crates/api/src/builder/error.rs
@@ -74,8 +74,14 @@ pub enum BuilderApiError {
     #[error("missing withdrawls")]
     MissingWithdrawls,
 
+    #[error("invalid withdrawls root")]
+    InvalidWithdrawlsRoot,
+
+    #[error("missing withdrawls root")]
+    MissingWithdrawlsRoot,
+
     #[error("withdrawls root mismatch. got: {got:?}, expected: {expected:?}")]
-    WithdrawalsRootMismatch { got: [u8; 32], expected: [u8; 32] },
+    WithdrawalsRootMismatch { got: Hash32, expected: Hash32 },
 
     #[error("signature verification failed")]
     SignatureVerificationFailed,
@@ -218,6 +224,12 @@ impl IntoResponse for BuilderApiError {
             },
             BuilderApiError::MissingWithdrawls => {
                 (StatusCode::BAD_REQUEST, "missing withdrawals").into_response()
+            },
+            BuilderApiError::InvalidWithdrawlsRoot => {
+                (StatusCode::BAD_REQUEST, "invalid withdrawals root").into_response()
+            },
+            BuilderApiError::MissingWithdrawlsRoot => {
+                (StatusCode::BAD_REQUEST, "missing withdrawals root").into_response()
             },
             BuilderApiError::WithdrawalsRootMismatch { got, expected } => {
                 (StatusCode::BAD_REQUEST, format!("Withdrawals root mismatch. got: {got:?}, expected: {expected:?}")).into_response()

--- a/crates/common/src/bid_submission/mod.rs
+++ b/crates/common/src/bid_submission/mod.rs
@@ -58,6 +58,8 @@ pub trait BidSubmission {
 
     fn withdrawals(&self) -> Option<&[Withdrawal]>;
 
+    fn withdrawals_root(&self) -> Option<Node>;
+
     fn consensus_version(&self) -> Fork;
 
     /// True if full submission payload, false if not (e.g. Optimistic V2)

--- a/crates/common/src/bid_submission/submission.rs
+++ b/crates/common/src/bid_submission/submission.rs
@@ -183,6 +183,26 @@ impl BidSubmission for SignedBidSubmission {
         }
     }
 
+    fn withdrawals_root(&self) -> Option<Node> {
+        match &self.execution_payload() {
+            ExecutionPayload::Bellatrix(_) => None,
+            ExecutionPayload::Capella(payload) => {
+                let mut withdrawals = payload.withdrawals.clone();
+                match withdrawals.hash_tree_root() {
+                    Ok(root) => Some(root),
+                    Err(_) => None,
+                }
+            },
+            ExecutionPayload::Deneb(payload) => {
+                let mut withdrawals = payload.withdrawals.clone();
+                match withdrawals.hash_tree_root() {
+                    Ok(root) => Some(root),
+                    Err(_) => None,
+                }
+            },
+        }
+    }
+
     fn consensus_version(&self) -> Fork {
         match self {
             SignedBidSubmission::Deneb(_) => Fork::Deneb,

--- a/crates/common/src/bid_submission/v2/header_submission.rs
+++ b/crates/common/src/bid_submission/v2/header_submission.rs
@@ -266,6 +266,17 @@ impl BidSubmission for SignedHeaderSubmission {
         None
     }
 
+    fn withdrawals_root(&self) -> Option<Node> {
+        match self {
+            Self::Capella(signed_header_submission) => {
+                Some(signed_header_submission.message.execution_payload_header.withdrawals_root)
+            }
+            Self::Deneb(signed_header_submission) => {
+                Some(signed_header_submission.message.execution_payload_header().withdrawals_root)
+            }
+        }
+    }
+
     fn consensus_version(&self) -> Fork {
         match self {
             Self::Capella(_) => Fork::Capella,


### PR DESCRIPTION
It was flagged here https://github.com/flashbots/mev-boost/issues/661 that an invalid payload was being returned when the header api was called on the titan relay. Upon further investigation it was found that the withdrawal root was not being checked when an optimistic v2 header was submitted to the relay.

This PR fixed the bug. 