### PR TITLE
publish blobs to beacon node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1795,6 +1795,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "ethereum_hashing"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea7b408432c13f71af01197b1d3d0069c48a27bfcfbe72a81fc346e47f6defb"
+dependencies = [
+ "cpufeatures",
+ "lazy_static",
+ "ring 0.17.8",
+ "sha2 0.10.8",
+]
+
+[[package]]
+name = "ethereum_hashing"
+version = "1.0.0-beta.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233dc6f434ce680dbabf4451ee3380cec46cb3c45d66660445a435619710dd35"
+dependencies = [
+ "cpufeatures",
+ "lazy_static",
+ "ring 0.16.20",
+ "sha2 0.10.8",
+]
+
+[[package]]
+name = "ethereum_serde_utils"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de4d5951468846963c24e8744c133d44f39dff2cd3a233f6be22b370d08a524f"
+dependencies = [
+ "ethereum-types",
+ "hex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+]
+
+[[package]]
+name = "ethereum_ssz"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d3627f83d8b87b432a5fad9934b4565260722a141a2c40f371f8080adec9425"
+dependencies = [
+ "ethereum-types",
+ "itertools 0.10.5",
+ "smallvec",
+]
+
+[[package]]
 name = "ethers"
 version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2567,13 +2615,16 @@ dependencies = [
  "clap",
  "deadpool-redis",
  "ethereum-consensus",
+ "ethereum-types",
  "helix-utils",
+ "merkle_proof",
  "redis",
  "reqwest",
  "reth-primitives 0.1.0-alpha.10",
  "serde",
  "serde_json",
  "serde_yaml 0.9.25",
+ "ssz_types",
  "thiserror",
  "tokio",
  "tokio-postgres",
@@ -3105,7 +3156,7 @@ checksum = "6971da4d9c3aa03c3d8f3ff0f4155b534aad021292003895a469716b2a230378"
 dependencies = [
  "base64 0.21.2",
  "pem",
- "ring",
+ "ring 0.16.20",
  "serde",
  "serde_json",
  "simple_asn1",
@@ -3180,7 +3231,7 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 dependencies = [
- "spin",
+ "spin 0.5.2",
 ]
 
 [[package]]
@@ -3191,9 +3242,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.147"
+version = "0.2.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 
 [[package]]
 name = "libloading"
@@ -3297,6 +3348,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "merkle_proof"
+version = "0.2.0"
+source = "git+https://github.com/sigp/lighthouse.git?tag=v5.3.0#d6ba8c397557f5c977b70f0d822a9228e98ca214"
+dependencies = [
+ "ethereum-types",
+ "ethereum_hashing 0.6.0",
+ "lazy_static",
+ "safe_arith",
 ]
 
 [[package]]
@@ -4694,10 +4756,25 @@ dependencies = [
  "cc",
  "libc",
  "once_cell",
- "spin",
- "untrusted",
+ "spin 0.5.2",
+ "untrusted 0.7.1",
  "web-sys",
  "winapi",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom",
+ "libc",
+ "spin 0.9.8",
+ "untrusted 0.9.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4817,7 +4894,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd8d6c9f025a446bc4d18ad9632e69aec8f287aa84499ee335599fabd20c3fd8"
 dependencies = [
  "log",
- "ring",
+ "ring 0.16.20",
  "rustls-webpki",
  "sct",
 ]
@@ -4837,8 +4914,8 @@ version = "0.101.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c7d5dece342910d9ba34d259310cae3e0154b873b35408b787b59bce53d34fe"
 dependencies = [
- "ring",
- "untrusted",
+ "ring 0.16.20",
+ "untrusted 0.7.1",
 ]
 
 [[package]]
@@ -4864,6 +4941,11 @@ name = "ryu"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+
+[[package]]
+name = "safe_arith"
+version = "0.1.0"
+source = "git+https://github.com/sigp/lighthouse.git?tag=v5.3.0#d6ba8c397557f5c977b70f0d822a9228e98ca214"
 
 [[package]]
 name = "salsa20"
@@ -4949,8 +5031,8 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
- "ring",
- "untrusted",
+ "ring 0.16.20",
+ "untrusted 0.7.1",
 ]
 
 [[package]]
@@ -5454,6 +5536,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
 name = "spki"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5494,6 +5582,23 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "ssz_types"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "382939886cb24ee8ac885d09116a60f6262d827c7a9e36012b4f6d3d0116d0b3"
+dependencies = [
+ "derivative",
+ "ethereum_serde_utils",
+ "ethereum_ssz",
+ "itertools 0.10.5",
+ "serde",
+ "serde_derive",
+ "smallvec",
+ "tree_hash",
+ "typenum",
 ]
 
 [[package]]
@@ -6239,6 +6344,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree_hash"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c998ac5fe2b07c025444bdd522e6258110b63861c6698eedc610c071980238d"
+dependencies = [
+ "ethereum-types",
+ "ethereum_hashing 1.0.0-beta.2",
+ "smallvec",
+]
+
+[[package]]
 name = "triomphe"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6397,6 +6513,12 @@ name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"

--- a/crates/api/src/integration_tests/replay_validator_registrations.rs
+++ b/crates/api/src/integration_tests/replay_validator_registrations.rs
@@ -5,14 +5,15 @@ use ethereum_consensus::{
     primitives::{BlsPublicKey, Slot},
     serde::as_str,
 };
-use helix_beacon_client::BeaconClientTrait;
+use helix_beacon_client::{beacon_client::BeaconClient, BeaconClientTrait};
 use reqwest::Error;
 use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc::channel;
 
-use helix_common::api::{
+use helix_common::{api::{
     builder_api::BuilderGetValidatorsResponseEntry, proposer_api::ValidatorRegistrationInfo,
-};
+}, BeaconClientConfig};
+use url::Url;
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct BuilderGetValidatorsResponseEntryExternal {
@@ -119,9 +120,10 @@ async fn run() {
     ];
 
     let helix_register_endpoint = "http://localhost:4040/eth/v1/builder/validators";
-    let beacon_client = helix_beacon_client::beacon_client::BeaconClient::from_endpoint_str(
-        "http://localhost:5052",
-    );
+    let beacon_client = BeaconClient::from_config(BeaconClientConfig{
+        url: Url::parse("http://localhost:5052").unwrap(),
+        gossip_blobs_enabled: false,
+    });
 
     let (head_event_sender, mut head_event_receiver) =
         tokio::sync::broadcast::channel::<helix_beacon_client::types::HeadEventData>(100);

--- a/crates/api/src/proposer/api.rs
+++ b/crates/api/src/proposer/api.rs
@@ -32,7 +32,7 @@ use helix_common::{
     api::{
         builder_api::BuilderGetValidatorsResponseEntry,
         proposer_api::{GetPayloadResponse, ValidatorRegistrationInfo},
-    }, chain_info::{ChainInfo, Network}, signed_proposal::VersionedSignedProposal, try_execution_header_from_payload, validator_preferences, versioned_payload::PayloadAndBlobs, BidRequest, Filtering, GetHeaderTrace, GetPayloadTrace, RegisterValidatorsTrace, ValidatorPreferences
+    }, beacon_api::PublishBlobsRequest, chain_info::{ChainInfo, Network}, deneb::{BlobSidecars, BuildBlobSidecarError}, signed_proposal::VersionedSignedProposal, try_execution_header_from_payload, validator_preferences, versioned_payload::PayloadAndBlobs, BidRequest, Filtering, GetHeaderTrace, GetPayloadTrace, RegisterValidatorsTrace, ValidatorPreferences
 };
 use helix_database::DatabaseService;
 use helix_datastore::{error::AuctioneerError, Auctioneer};
@@ -169,6 +169,7 @@ where
             filtering: proposer_api.validator_preferences.filtering,
             trusted_builders: proposer_api.validator_preferences.trusted_builders.clone(),
             header_delay: proposer_api.validator_preferences.header_delay,
+            gossip_blobs: proposer_api.validator_preferences.gossip_blobs,
         };
 
 
@@ -202,6 +203,10 @@ where
 
             if let Some(header_delay) = preferences.header_delay {
                 validator_preferences.header_delay = header_delay;
+            }
+
+            if let Some(gossip_blobs) = preferences.gossip_blobs {
+                validator_preferences.gossip_blobs = gossip_blobs;
             }
         }
 
@@ -650,6 +655,19 @@ where
             };
         let payload = Arc::new(versioned_payload);
 
+        if self.validator_preferences.gossip_blobs || !matches!(self.chain_info.network, Network::Mainnet) {
+            info!(?request_id, "gossip blobs: about to gossip blobs");
+            let self_clone = self.clone();
+            let unblinded_payload_clone = unblinded_payload.clone();
+            let req_id = *request_id;
+            tokio::spawn(async move {
+                self_clone.gossip_blobs(unblinded_payload_clone, req_id).await;
+            });
+        } else {
+            info!(?request_id, "gossip blobs: bug")
+        }
+
+
         let is_trusted_proposer = self.is_trusted_proposer(&proposer_public_key).await?;
 
         // Publish and validate payload with multi-beacon-client
@@ -993,6 +1011,38 @@ where
                     );
                 }
             });
+        }
+    }
+
+        /// If there are blobs in the unblinded payload, this function will send them directly to the
+    /// beacon chain to be propagated async to the full block.
+    async fn gossip_blobs(
+        &self,
+        unblinded_payload: Arc<VersionedSignedProposal>,
+        request_id: Uuid,
+    ) {
+        let blob_sidecars = match BlobSidecars::try_from_unblinded_payload(unblinded_payload.clone()) {
+            Ok(blob_sidecars) => blob_sidecars,
+            Err(err) => {
+                match err {
+                    BuildBlobSidecarError::NoBlobsInPayload | BuildBlobSidecarError::PayloadVersionBeforeBlobs=> {}
+                    error => {
+                        error!(%request_id, ?error, "gossip blobs: failed to build blob sidecars for async gossiping");
+                    }
+                }
+                return;
+            }
+        };
+
+        info!(%request_id, "gossip blobs: successfully built blob sidecars for request. Gossiping async..");
+
+        // Send blob sidecars to beacon clients.
+        let publish_blob_request = PublishBlobsRequest {
+            blob_sidecars,
+            beacon_root: unblinded_payload.beacon_block().message().parent_root().clone(),
+        };
+        if let Err(error) = self.multi_beacon_client.publish_blobs(publish_blob_request).await {
+            error!(%request_id, ?error, "gossip blobs: failed to gossip blob sidecars");
         }
     }
 

--- a/crates/api/src/proposer/types.rs
+++ b/crates/api/src/proposer/types.rs
@@ -161,4 +161,6 @@ pub struct PreferencesHeader {
 
     /// Allows validators to express a preference for whether a delay should be applied to get headers or not.
     pub header_delay: Option<bool>,
+
+    pub gossip_blobs: Option<bool>,
 }

--- a/crates/api/src/service.rs
+++ b/crates/api/src/service.rs
@@ -59,7 +59,7 @@ impl ApiService {
 
         let mut beacon_clients = vec![];
         for cfg in &config.beacon_clients {
-            beacon_clients.push(Arc::new(BeaconClient::from_endpoint_str(&cfg.url)));
+            beacon_clients.push(Arc::new(BeaconClient::from_config(cfg.clone())));
         }
         let multi_beacon_client = Arc::new(MultiBeaconClient::<BeaconClient>::new(beacon_clients));
 
@@ -220,7 +220,7 @@ async fn init_broadcasters(config: &RelayConfig) -> Vec<Arc<BlockBroadcaster>> {
             }
             BroadcasterConfig::BeaconClient(cfg) => {
                 broadcasters.push(Arc::new(BlockBroadcaster::BeaconClient(
-                    BeaconClient::from_endpoint_str(&cfg.url),
+                    BeaconClient::from_config(cfg.clone()),
                 )));
             }
         }
@@ -234,6 +234,7 @@ mod test {
 
     use helix_common::{BeaconClientConfig, FiberConfig};
     use helix_utils::request_encoding::Encoding;
+    use url::Url;
 
     use super::*;
     use std::convert::TryFrom;
@@ -258,7 +259,8 @@ mod test {
                 encoding: Encoding::Json,
             }),
             BroadcasterConfig::BeaconClient(BeaconClientConfig {
-                url: "http://localhost:4040".to_string(),
+                url: Url::parse("http://localhost:4040").unwrap(),
+                gossip_blobs_enabled: false,
             }),
         ];
         let broadcasters = init_broadcasters(&config).await;

--- a/crates/beacon-client/src/beacon_client.rs
+++ b/crates/beacon-client/src/beacon_client.rs
@@ -10,8 +10,7 @@ use tracing::{debug, error, warn};
 use url::Url;
 
 use helix_common::{
-    bellatrix::SimpleSerialize, signed_proposal::VersionedSignedProposal, ProposerDuty,
-    ValidatorSummary,
+    beacon_api::PublishBlobsRequest, bellatrix::SimpleSerialize, signed_proposal::VersionedSignedProposal, BeaconClientConfig, ProposerDuty, ValidatorSummary
 };
 
 use crate::{
@@ -29,19 +28,18 @@ const BEACON_CLIENT_REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
 #[derive(Clone, Debug)]
 pub struct BeaconClient {
     pub http: reqwest::Client,
-    pub endpoint: Url,
+    pub config: BeaconClientConfig,
 }
 
 impl BeaconClient {
-    pub fn new(http: reqwest::Client, endpoint: Url) -> Self {
-        Self { http, endpoint }
+    pub fn new(http: reqwest::Client, config: BeaconClientConfig) -> Self {
+        Self { http, config }
     }
 
-    pub fn from_endpoint_str(endpoint: &str) -> Self {
-        let endpoint = Url::parse(endpoint).unwrap();
+    pub fn from_config(config: BeaconClientConfig) -> Self {
         let client =
             reqwest::ClientBuilder::new().timeout(BEACON_CLIENT_REQUEST_TIMEOUT).build().unwrap();
-        Self::new(client, endpoint)
+        Self::new(client, config)
     }
 
     pub async fn get<T: serde::Serialize + serde::de::DeserializeOwned>(
@@ -56,7 +54,7 @@ impl BeaconClient {
     }
 
     pub async fn http_get(&self, path: &str) -> Result<reqwest::Response, BeaconClientError> {
-        let target = self.endpoint.join(path)?;
+        let target = self.config.url.join(path)?;
         Ok(self.http.get(target).send().await?)
     }
 
@@ -80,7 +78,7 @@ impl BeaconClient {
         path: &str,
         argument: &T,
     ) -> Result<reqwest::Response, BeaconClientError> {
-        let target = self.endpoint.join(path)?;
+        let target = self.config.url.join(path)?;
         Ok(self.http.post(target).json(argument).send().await?)
     }
 
@@ -90,7 +88,7 @@ impl BeaconClient {
         topic: &str,
         chan: Sender<T>,
     ) -> Result<(), BeaconClientError> {
-        let url = format!("{}eth/v1/events?topics={}", self.endpoint, topic);
+        let url = format!("{}eth/v1/events?topics={}", self.config.url, topic);
 
         loop {
             let mut es = EventSource::get(&url);
@@ -193,7 +191,7 @@ impl BeaconClientTrait for BeaconClient {
         broadcast_validation: Option<BroadcastValidation>,
         fork: ethereum_consensus::Fork,
     ) -> Result<u16, BeaconClientError> {
-        let target = self.endpoint.join("eth/v2/beacon/blocks")?;
+        let target = self.config.url.join("eth/v2/beacon/blocks")?;
         let body_bytes = ssz::prelude::serialize(block.as_ref())?;
         let mut request = self
             .http
@@ -217,8 +215,34 @@ impl BeaconClientTrait for BeaconClient {
         }
     }
 
+    async fn publish_blobs(&self, blob_sidecars: PublishBlobsRequest) -> Result<u16, BeaconClientError> { 
+        if !self.config.gossip_blobs_enabled {
+            return Err(BeaconClientError::RequestNotSupported);
+        }
+
+        let target = self.config.url.join("eth/v2/beacon/blobs")?;
+        let body_bytes = serde_json::to_vec(&blob_sidecars)?;
+        let request = self
+            .http
+            .post(target)
+            .header(CONTENT_TYPE, "application/json")
+            .body(body_bytes);
+        let response = request.send().await?;
+
+        match response.status() {
+            reqwest::StatusCode::OK | reqwest::StatusCode::ACCEPTED => {
+                Ok(response.status().as_u16())
+            }
+            _ => {
+                let api_err = response.json::<ApiError>().await?;
+                Err(BeaconClientError::Api(api_err))
+            }
+        }
+    }
+
+
     fn get_uri(&self) -> String {
-        self.endpoint.to_string()
+        self.config.url.to_string()
     }
 }
 
@@ -237,7 +261,10 @@ mod beacon_client_tests {
             .with_body(r#"{"data":{"is_syncing":false,"is_optimistic":false,"head_slot":"7222736","sync_distance":"1"}}"#)
             .create();
 
-        let client = BeaconClient::from_endpoint_str(&server.url());
+        let client = BeaconClient::from_config(BeaconClientConfig{
+            url: Url::parse(&server.url()).unwrap(),
+            gossip_blobs_enabled: false,
+        });
         let result = client.sync_status().await;
 
         assert!(result.is_ok());
@@ -258,7 +285,10 @@ mod beacon_client_tests {
             .with_body(r#"{"execution_optimistic":false,"data":[{"index":"0","balance":"32000000000","status":"active_ongoing","validator":{"pubkey":"0x933ad9491b62059dd065b560d256d8957a8c402cc6e8d8ee7290ae11e8f7329267a8811c397529dac52ae1342ba58c95","withdrawal_credentials":"0x00f50428677c60f997aadeab24aabf7fceaef491c96a52b463ae91f95611cf71","effective_balance":"32000000000","slashed":false,"activation_eligibility_epoch":"0","activation_epoch":"0","exit_epoch":"18446744073709551615","withdrawable_epoch":"18446744073709551615"}}]}"#)
             .create();
 
-        let client = BeaconClient::from_endpoint_str(&server.url());
+        let client = BeaconClient::from_config(BeaconClientConfig{
+            url: Url::parse(&server.url()).unwrap(),
+            gossip_blobs_enabled: false,
+        });
         let result = client.get_state_validators(StateId::Genesis).await;
 
         assert!(result.is_ok());
@@ -277,7 +307,10 @@ mod beacon_client_tests {
             .with_body(r#"{"dependent_root":"0x44bff3186a234cf4fb2799c9a44dc089e33cd976a804081c652c47a8d66f11c2","execution_optimistic":false,"data":[{"pubkey":"0x926d6d7bcd4d6066d2c8a68fd2fd07f9f9eb0ac92adb3c0ddf57b63e65c078923a7cc67a17fc38cf7acb18f37795a343","validator_index":"556715","slot":"7223680"},{"pubkey":"0x8e8663c5da817c47c98099203c402e48992c4094a7e4c9b13e5ce89213b3c46a3c71613b5b3740a855c4c45493abf7ba","validator_index":"813363","slot":"7223681"},{"pubkey":"0xac3a37ae6c8047b4b467bd978590fe99825de55184f0688b4a275b92dfbe040c41b86eed25c21d43eb5a41be7e9e8e57","validator_index":"738684","slot":"7223682"},{"pubkey":"0xb82a5e04a517bab45fd53d8878eaf30b59ec201ded0b16109f186fdc0bd9b9f97110fda24d4d6f4dc9c82106f1b1471d","validator_index":"482430","slot":"7223683"},{"pubkey":"0x96127de24ea2b357cf382f1ef6c16d0aeb57d6346b80aaf6ad1db8263cf32261cb3c8edde53bb6fd1575e6e3d3c87cbc","validator_index":"232784","slot":"7223684"},{"pubkey":"0x8ca17cd0666681c3a41645cedfe709bb05480ed22bfab4849d7d7f923bf26ae5ff6b602866158c9dc49db53e2290019f","validator_index":"515504","slot":"7223685"},{"pubkey":"0xa4730c958451373e474423858fb200bba2f27a84f0e4557d1fbd146a61a74f13ff623b5ec7ffff802e86cc56a061b988","validator_index":"723480","slot":"7223686"},{"pubkey":"0x8114af3795548eb69bfc67c5f85b2fd4c38b23b711bcf7a5982bcf2a6fead389ecc5a1ecd9fd6b28f0cb5e6804750ee2","validator_index":"583875","slot":"7223687"},{"pubkey":"0xb8e11789ba6dad3806e71c88fba1756bb800e744139beaa3240979a66d6c3545deaed0be68a60e0467e653b199fb1891","validator_index":"796168","slot":"7223688"},{"pubkey":"0xa7efad97f92d8d760d9afcdbc68a7eef1efae1226c59ab83bd149fda0a0c94a0c8a49b1ba179377c3783bd47355cdb8c","validator_index":"91207","slot":"7223689"},{"pubkey":"0x90cbf6283a34e0c31f36cd3f720db50f96b29cd07bd0c7f092d387cd0537dcd852ffa7876623e48a5d16c96d9934b949","validator_index":"180815","slot":"7223690"},{"pubkey":"0x901c339534e94975cd30791ed23de5b133e3f36a78cd1792373c994a785bf0cdefa373de5657037816c036ef0e907fa2","validator_index":"86343","slot":"7223691"},{"pubkey":"0xac66ed0a9fde6d2b965144a4951dfb92e94a6a3a2c8165118d1e77e7353da91c473cfef5e220e1d9b24b56b062a857d4","validator_index":"121110","slot":"7223692"},{"pubkey":"0x8647bedce6e3e914fd1cdccc94cba797f075222831949fe463d1017c95579afb051bd53c1b19b0b61835c7d9096c1582","validator_index":"282963","slot":"7223693"},{"pubkey":"0xaf6643b796eaf2cdcbaa26b22a54005b795f758660dd57a99e378e73b83d49218658d6d34b30e7a08d5495cf9ac5803b","validator_index":"751090","slot":"7223694"},{"pubkey":"0xb7cc47302885b62e7e86364ffcfd261125c65cc951eb456e09497165de78d59571b29e993226807e4329ccebf48a4625","validator_index":"185357","slot":"7223695"},{"pubkey":"0x998c35d2a625d59f6d2992b031faa9fba55bab5bd684d3924fd27e9e608a1d32af8c594dc9adb96c6e0092ce6e597690","validator_index":"791244","slot":"7223696"},{"pubkey":"0x906c8721c51b912ceae9bc65db098db6b826d6300525f6b45fde4878952e34d6b375940d90caf0ec58799d663b565b43","validator_index":"833436","slot":"7223697"},{"pubkey":"0x80748bda405e68d2db44e13fa233d78a870545be2477daa19bbb512ffbc2dc8141dda43e56a56e4c8059c66216182569","validator_index":"166263","slot":"7223698"},{"pubkey":"0xb98fa5876db8d897c9978cbddceb7186589b544383a4439b9fd68db692c23329b61d4b6bc580f0ab7601f5e75e14f8ce","validator_index":"563603","slot":"7223699"},{"pubkey":"0xadb3ac4a0d4430ed9de8c99617537e21e39150ab31bb7ed76973439d5adbacfcf138fa8f06612e924c456a642c2b6a26","validator_index":"11615","slot":"7223700"},{"pubkey":"0x90c486d7a798917917d7f52d69cf4660af4d13a6fc7980c7c8b6cc657e351e6c4cfe6d3cbea5cacba53f3c267484b4a8","validator_index":"533916","slot":"7223701"},{"pubkey":"0xb3dfe5db378135b3554508cab6d8929db7e533cb25ad76bc7c40c168997098e2d1c559d069d1f9704180a35d3c83bb99","validator_index":"380521","slot":"7223702"},{"pubkey":"0x81f30511b207ad23d55e19bd6de1eadbf2b02a1c26f4abac841c7b486f77481926a9f0a956485e0911d7b94ded7d55c4","validator_index":"422071","slot":"7223703"},{"pubkey":"0x9380701cec4f3f192d464018ab8042a14399f4dc2740d7c93c7b8c661345c89311b130ec279236263d92fff59a98b9e7","validator_index":"152215","slot":"7223704"},{"pubkey":"0xb49ecc067d1d8f0ca7e38d354a01d64d213244b1e0f04ca0edfdac20869280568a7957ed9ae7afd551da95f4c00eada6","validator_index":"408071","slot":"7223705"},{"pubkey":"0xb5114b89c6371ea761ca269775f8fdf45bfa904ed5cfc534c1abaa4c37614c616ee90e65971df6e8e5f5cf85c12ded19","validator_index":"835667","slot":"7223706"},{"pubkey":"0xa438628252ae10121ca0765af539d9e03d75a578e8cd9eae384ef7290564a01d6f855e6fd43916929fea05b81327483d","validator_index":"238131","slot":"7223707"},{"pubkey":"0xb89a94670d852ec5431e51e0c2099d20f1267522923e2330f1b949d62818b4ddbf2eed65d60ecdbfa22c6a3b158889af","validator_index":"515979","slot":"7223708"},{"pubkey":"0xb5cb9c936b791b529592f715fb3c38b0ad4c14f1bf883a18a31e1f18e414304a445e52ffb9b4c80663fa2f943eb6716c","validator_index":"244183","slot":"7223709"},{"pubkey":"0xa4434c1c46c35726d5964e1d514b7b663ae67bb197cc7b343f219910e2a4a272752c4ccdf2de022d50a3f0b9cead611b","validator_index":"573925","slot":"7223710"},{"pubkey":"0xaf832097555d8b8d8c326a5cb9871bf5fd2366c1ea4ae3d595cd38eb32b8ea8d817bb8e504ec01b96481362121618e7f","validator_index":"62581","slot":"7223711"}]}"#)
             .create();
 
-        let client = BeaconClient::from_endpoint_str(&server.url());
+        let client = BeaconClient::from_config(BeaconClientConfig{
+            url: Url::parse(&server.url()).unwrap(),
+            gossip_blobs_enabled: false,
+        });
         let result = client.get_proposer_duties(225740).await;
 
         assert!(result.is_ok());
@@ -300,7 +333,10 @@ mod beacon_client_tests {
             .with_body(r#""#)
             .create();
 
-        let client = BeaconClient::from_endpoint_str(&server.url());
+        let client = BeaconClient::from_config(BeaconClientConfig{
+            url: Url::parse(&server.url()).unwrap(),
+            gossip_blobs_enabled: false,
+        });
 
         let test_block = VersionedSignedProposal::default();
         let result = client
@@ -383,6 +419,10 @@ mod beacon_client_tests {
     }
 
     fn get_test_client() -> BeaconClient {
-        BeaconClient::from_endpoint_str("http://localhost:5052")
+        let config = BeaconClientConfig {
+            url: Url::parse("http://localhost:5052").unwrap(),
+            gossip_blobs_enabled: true,
+        };
+        BeaconClient::from_config(config)
     }
 }

--- a/crates/beacon-client/src/error.rs
+++ b/crates/beacon-client/src/error.rs
@@ -48,6 +48,9 @@ pub enum BeaconClientError {
 
     #[error("Error initializing broadcaster: {0}")]
     BroadcasterInitError(String),
+
+    #[error("Request not supported")]
+    RequestNotSupported,
 }
 
 impl IntoResponse for BeaconClientError {

--- a/crates/beacon-client/src/mock_beacon_client.rs
+++ b/crates/beacon-client/src/mock_beacon_client.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use ethereum_consensus::{primitives::Root, ssz::prelude::*};
 use tokio::sync::broadcast::Sender;
 
-use helix_common::{ProposerDuty, ValidatorSummary};
+use helix_common::{beacon_api::PublishBlobsRequest, ProposerDuty, ValidatorSummary};
 
 use crate::{
     error::BeaconClientError,
@@ -99,6 +99,10 @@ impl BeaconClientTrait for MockBeaconClient {
         _broadcast_validation: Option<BroadcastValidation>,
         _fork: ethereum_consensus::Fork,
     ) -> Result<u16, BeaconClientError> {
+        Ok(self.publish_block_response_code)
+    }
+
+    async fn publish_blobs(&self, _blob_sidecars: PublishBlobsRequest) -> Result<u16, BeaconClientError> {
         Ok(self.publish_block_response_code)
     }
 }

--- a/crates/beacon-client/src/mock_multi_beacon_client.rs
+++ b/crates/beacon-client/src/mock_multi_beacon_client.rs
@@ -8,7 +8,7 @@ use ethereum_consensus::{
     phase0::Validator,
     primitives::{BlsPublicKey, Root},
 };
-use helix_common::{bellatrix::SimpleSerialize, ProposerDuty, ValidatorStatus, ValidatorSummary};
+use helix_common::{beacon_api::PublishBlobsRequest, bellatrix::SimpleSerialize, ProposerDuty, ValidatorStatus, ValidatorSummary};
 use tokio::sync::broadcast::Sender;
 
 use crate::{
@@ -104,5 +104,9 @@ impl MultiBeaconClientTrait for MockMultiBeaconClient {
         _fork: ethereum_consensus::Fork,
     ) -> Result<(), BeaconClientError> {
         Ok(())
+    }
+
+    async fn publish_blobs(&self, _blob_sidecars: PublishBlobsRequest) -> Result<u16, BeaconClientError> {
+        Ok(0)
     }
 }

--- a/crates/beacon-client/src/traits.rs
+++ b/crates/beacon-client/src/traits.rs
@@ -5,7 +5,7 @@ use ethereum_consensus::primitives::Root;
 use serde::{de::DeserializeOwned, Serialize};
 use tokio::sync::broadcast::Sender;
 
-use helix_common::{bellatrix::SimpleSerialize, ProposerDuty, ValidatorSummary};
+use helix_common::{beacon_api::PublishBlobsRequest, bellatrix::SimpleSerialize, ProposerDuty, ValidatorSummary};
 
 use crate::{
     error::BeaconClientError,
@@ -40,6 +40,7 @@ pub trait BeaconClientTrait: Send + Sync + Clone {
         broadcast_validation: Option<BroadcastValidation>,
         fork: ethereum_consensus::Fork,
     ) -> Result<u16, BeaconClientError>;
+    async fn publish_blobs(&self, blob_sidecars: PublishBlobsRequest) -> Result<u16, BeaconClientError>;
     fn get_uri(&self) -> String;
 }
 
@@ -65,4 +66,5 @@ pub trait MultiBeaconClientTrait: Send + Sync + Clone {
         broadcast_validation: Option<BroadcastValidation>,
         fork: ethereum_consensus::Fork,
     ) -> Result<(), BeaconClientError>;
+    async fn publish_blobs(&self, blob_sidecars: PublishBlobsRequest) -> Result<u16, BeaconClientError>;
 }

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -21,6 +21,9 @@ serde_yaml = "0.9.25"
 # Ethereum Types
 ethereum-consensus.workspace = true
 reth-primitives.workspace = true
+merkle_proof = { git = "https://github.com/sigp/lighthouse.git", tag = "v5.3.0" }
+ethereum-types = "0.14.1"
+ssz_types = "0.5.4"
 
 # DB
 deadpool-redis.workspace = true

--- a/crates/common/src/beacon_api.rs
+++ b/crates/common/src/beacon_api.rs
@@ -1,0 +1,22 @@
+use ethereum_consensus::primitives::Root;
+
+use crate::deneb::BlobSidecars;
+
+/// Struct used in the custom `publish_blobs` beacon chain api.
+/// Beacon chain expects this JSON serialised.
+#[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct PublishBlobsRequest {
+    pub blob_sidecars: BlobSidecars,
+    pub beacon_root: Root,
+}
+
+
+
+
+#[test]
+fn test_serde() {
+    let blobs = PublishBlobsRequest::default();
+    let json = serde_json::to_vec(&blobs).unwrap();
+
+    println!("{:?}", json);
+}

--- a/crates/common/src/eth/deneb.rs
+++ b/crates/common/src/eth/deneb.rs
@@ -1,21 +1,31 @@
+use std::sync::Arc;
+
 pub use ethereum_consensus::{builder::SignedValidatorRegistration, deneb::mainnet as spec};
 
 use ethereum_consensus::{
     deneb::{
-        mainnet::{MAX_BLOBS_PER_BLOCK, MAX_BLOB_COMMITMENTS_PER_BLOCK},
-        polynomial_commitments::{KzgCommitment, KzgProof},
+        self, mainnet::{BlobSidecar, MAX_BLOBS_PER_BLOCK, MAX_BLOB_COMMITMENTS_PER_BLOCK}, polynomial_commitments::{KzgCommitment, KzgProof}, BeaconBlockHeader, Bytes32, SignedBeaconBlockHeader
     },
     primitives::{BlsPublicKey, BlsSignature, Root, U256},
     serde::as_str,
     ssz::prelude::*,
     types::mainnet::SignedBeaconBlock,
 };
+use ethereum_types::H256;
+use merkle_proof::MerkleTreeError;
+use ssz_types::{typenum::U17, FixedVector};
+use thiserror::Error;
+
+use crate::signed_proposal::VersionedSignedProposal;
 
 pub type ExecutionPayload = spec::ExecutionPayload;
 pub type ExecutionPayloadHeader = spec::ExecutionPayloadHeader;
 pub type SignedBlindedBeaconBlock = spec::SignedBlindedBeaconBlock;
 pub type SignedBlindedBlobSidecar = spec::SignedBlindedBlobSidecar;
 pub type Blob = spec::Blob;
+
+/// Index of the `blob_kzg_commitments` leaf in the `BeaconBlockBody` tree post-deneb.
+pub const BLOB_KZG_COMMITMENTS_INDEX: usize = 11;
 
 #[derive(Debug, Default, Clone, SimpleSerialize, serde::Serialize, serde::Deserialize)]
 pub struct BuilderBid {
@@ -58,4 +68,173 @@ pub struct SignedBlockContents {
     pub signed_block: SignedBeaconBlock,
     pub kzg_proofs: List<KzgProof, MAX_BLOB_COMMITMENTS_PER_BLOCK>,
     pub blobs: List<Blob, MAX_BLOB_COMMITMENTS_PER_BLOCK>,
+}
+
+#[derive(Debug, Default, Clone, SimpleSerialize, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct BlobSidecars {
+    pub sidecars: List<BlobSidecar, MAX_BLOB_COMMITMENTS_PER_BLOCK>,
+}
+
+#[derive(Debug, Error)]
+pub enum BuildBlobSidecarError {
+    #[error("no blobs in payload")]
+    NoBlobsInPayload,
+    #[error("payload version before blobs")]
+    PayloadVersionBeforeBlobs,
+    #[error("missing kzg commitment")]
+    MissingKzgCommitment,
+    #[error("missing kzg proof")]
+    MissingKzgProof,
+    #[error("merkle tree error: {0:?}")]
+    MerkleTreeError(MerkleTreeError),
+    #[error("merkleization error: {0}")]
+    MerkleizationError(#[from] MerkleizationError),
+    #[error("failed to format inclusion proof")]
+    FailedToFormatInclusionProof,
+}
+
+impl BlobSidecars {
+    pub fn try_from_unblinded_payload(
+        unblinded_payload: Arc<VersionedSignedProposal>,
+    ) -> Result<Self, BuildBlobSidecarError> {
+        let payload = match unblinded_payload.as_ref() {
+            VersionedSignedProposal::Deneb(payload) => {
+                if payload.blobs.is_empty() {
+                    return Err(BuildBlobSidecarError::NoBlobsInPayload);
+                }
+                payload
+            }
+            _ => return Err(BuildBlobSidecarError::PayloadVersionBeforeBlobs),
+        };
+
+        let mut beacon_block = payload.signed_block.clone();
+        let signed_block = beacon_block.deneb_mut().unwrap();
+
+        let body_root = signed_block.message.body.hash_tree_root()?;
+
+        let mut blob_sidecars = Self { sidecars: List::default() };
+
+        for (index, blob) in payload.blobs.iter().enumerate() {
+            let kzg_proof = payload
+                .kzg_proofs
+                .get(index)
+                .ok_or(BuildBlobSidecarError::MissingKzgProof)?
+                .clone();
+
+            let sidecar =
+                new_blob_sidecar(index, blob.clone(), signed_block, body_root.clone(), kzg_proof)?;
+            blob_sidecars.sidecars.push(sidecar);
+        }
+
+        Ok(blob_sidecars)
+    }
+}
+
+/// Creates a new [BlobSidecar] from a beacon block and `blob` at `index`.
+pub fn new_blob_sidecar(
+    index: usize,
+    blob: Blob,
+    signed_block: &mut deneb::mainnet::SignedBeaconBlock,
+    body_root: Root,
+    kzg_proof: KzgProof,
+) -> Result<BlobSidecar, BuildBlobSidecarError> {
+    let kzg_commitments = &signed_block.message.body.blob_kzg_commitments;
+    let kzg_commitment =
+        kzg_commitments.get(index).ok_or(BuildBlobSidecarError::MissingKzgCommitment)?.clone();
+
+    let kzg_commitment_inclusion_proof = kzg_commitment_merkle_proof(signed_block, index)?;
+    let kzg_commitment_inclusion_proof: Vec<Bytes32> = kzg_commitment_inclusion_proof
+        .into_iter()
+        .map(|x| Bytes32::try_from(x.as_bytes()).unwrap())
+        .collect();
+    let kzg_commitment_inclusion_proof = kzg_commitment_inclusion_proof.try_into()
+        .map_err(|_| BuildBlobSidecarError::FailedToFormatInclusionProof)?;
+
+    let signed_block_header = SignedBeaconBlockHeader {
+        message: BeaconBlockHeader {
+            slot: signed_block.message.slot,
+            proposer_index: signed_block.message.proposer_index,
+            parent_root: signed_block.message.parent_root,
+            state_root: signed_block.message.state_root,
+            body_root,
+        },
+        signature: signed_block.signature.clone(),
+    };
+
+    Ok(BlobSidecar {
+        index,
+        blob,
+        kzg_commitment,
+        kzg_proof,
+        signed_block_header,
+        kzg_commitment_inclusion_proof,
+    })
+}
+
+/// Produces the proof of inclusion for a `KzgCommitment` in `self.blob_kzg_commitments`
+/// at `index`.
+///
+/// Taken from Lighthouse.
+fn kzg_commitment_merkle_proof(
+    signed_block: &mut deneb::mainnet::SignedBeaconBlock,
+    index: usize,
+) -> Result<FixedVector<H256, U17>, BuildBlobSidecarError> {
+    // We compute the branches by generating 2 merkle trees:
+    // 1. Merkle tree for the `blob_kzg_commitments` List object
+    // 2. Merkle tree for the `BeaconBlockBody` container
+    // We then merge the branches for both the trees all the way up to the root.
+
+    // Part1 (Branches for the subtree rooted at `blob_kzg_commitments`)
+    //
+    // Branches for `blob_kzg_commitments` without length mix-in
+    let mut leaves: Vec<H256> =
+        Vec::with_capacity(signed_block.message.body.blob_kzg_commitments.len());
+    for commitment in signed_block.message.body.blob_kzg_commitments.iter_mut() {
+        let root = commitment.hash_tree_root()?;
+        leaves.push(H256::from_slice(&*root));
+    }
+
+    let depth = MAX_BLOB_COMMITMENTS_PER_BLOCK.next_power_of_two().ilog2() as usize;
+
+    let tree = merkle_proof::MerkleTree::create(&leaves, depth);
+    let (_, mut proof) = tree
+        .generate_proof(index, depth)
+        .map_err(|err| BuildBlobSidecarError::MerkleTreeError(err))?;
+
+    // Add the branch corresponding to the length mix-in.
+    let length = signed_block.message.body.blob_kzg_commitments.len();
+    let mut length_bytes = [0; 32];
+
+    length_bytes
+        .get_mut(0..std::mem::size_of::<usize>())
+        .unwrap()
+        .copy_from_slice(&length.to_le_bytes());
+    let length_root = H256::from_slice(length_bytes.as_slice());
+    proof.push(length_root);
+
+    // Part 2
+    // Branches for `BeaconBlockBody` container
+    let leaves: [H256; 12] = [
+        H256::from_slice(&*signed_block.message.body.randao_reveal.hash_tree_root()?),
+        H256::from_slice(&*signed_block.message.body.eth1_data.hash_tree_root()?),
+        H256::from_slice(&*signed_block.message.body.graffiti.hash_tree_root()?),
+        H256::from_slice(&*signed_block.message.body.proposer_slashings.hash_tree_root()?),
+        H256::from_slice(&*signed_block.message.body.attester_slashings.hash_tree_root()?),
+        H256::from_slice(&*signed_block.message.body.attestations.hash_tree_root()?),
+        H256::from_slice(&*signed_block.message.body.deposits.hash_tree_root()?),
+        H256::from_slice(&*signed_block.message.body.voluntary_exits.hash_tree_root()?),
+        H256::from_slice(&*signed_block.message.body.sync_aggregate.hash_tree_root()?),
+        H256::from_slice(&*signed_block.message.body.execution_payload.hash_tree_root()?),
+        H256::from_slice(&*signed_block.message.body.bls_to_execution_changes.hash_tree_root()?),
+        H256::from_slice(&*signed_block.message.body.blob_kzg_commitments.hash_tree_root()?),
+    ];
+    let beacon_block_body_depth = leaves.len().next_power_of_two().ilog2() as usize;
+    let tree = merkle_proof::MerkleTree::create(&leaves, beacon_block_body_depth);
+    let (_, mut proof_body) = tree
+        .generate_proof(BLOB_KZG_COMMITMENTS_INDEX, beacon_block_body_depth)
+        .map_err(|err| BuildBlobSidecarError::MerkleTreeError(err))?;
+    // Join the proofs for the subtree and the main tree
+    proof.append(&mut proof_body);
+
+    Ok(proof.into())
 }

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -11,6 +11,8 @@ pub mod simulator;
 pub mod traces;
 pub mod validator;
 pub mod validator_preferences;
+pub mod beacon_api;
+
 
 pub use builder_info::*;
 pub use config::*;

--- a/crates/common/src/validator_preferences/mod.rs
+++ b/crates/common/src/validator_preferences/mod.rs
@@ -12,6 +12,9 @@ pub struct ValidatorPreferences {
     /// Allows validators to express a preference for whether a delay should be applied to get headers or not.
     #[serde(default = "default_header_delay")]
     pub header_delay: bool,
+
+    #[serde(default)]
+    pub gossip_blobs: bool,
 }
 
 fn default_filtering() -> Filtering {

--- a/crates/database/src/postgres/migrations/V21__add_gossip_blobs.sql
+++ b/crates/database/src/postgres/migrations/V21__add_gossip_blobs.sql
@@ -1,0 +1,2 @@
+ALTER TABLE validator_preferences
+ADD COLUMN "gossip_blobs" boolean DEFAULT false;

--- a/crates/database/src/postgres/postgres_db_row_parsing.rs
+++ b/crates/database/src/postgres/postgres_db_row_parsing.rs
@@ -183,6 +183,7 @@ impl FromRow for BuilderGetValidatorsResponseEntry {
                         },
                     ),
                     header_delay: row.get::<&str, bool>("header_delay"),
+                    gossip_blobs: row.get::<&str, bool>("gossip_blobs"),
                 },
             },
         })
@@ -251,6 +252,7 @@ impl FromRow for SignedValidatorRegistrationEntry {
                         },
                     ),
                     header_delay: row.get::<&str, bool>("header_delay"),
+                    gossip_blobs: row.get::<&str, bool>("gossip_blobs"),
                 },
             },
             inserted_at: parse_timestamptz_to_u64(

--- a/crates/database/src/postgres/postgres_db_service_tests.rs
+++ b/crates/database/src/postgres/postgres_db_service_tests.rs
@@ -108,6 +108,7 @@ mod tests {
                 filtering: Filtering::Global,
                 trusted_builders: Some(vec!["test".to_string(), "test2".to_string()]),
                 header_delay: true,
+                gossip_blobs: false,
             },
         }
     }

--- a/crates/utils/src/serde.rs
+++ b/crates/utils/src/serde.rs
@@ -1,3 +1,6 @@
+use reqwest::Url;
+use serde::{Deserialize, Deserializer, Serializer};
+
 pub mod as_u16 {
     use http::StatusCode;
     use serde::{de::Deserializer, Deserialize, Serializer};
@@ -36,4 +39,25 @@ pub mod axum_as_u16 {
         let value: u16 = Deserialize::deserialize(deserializer)?;
         StatusCode::from_u16(value).map_err(serde::de::Error::custom)
     }
+}
+
+/// Custom deserializer to convert a string to a url::Url
+pub fn deserialize_url<'de, D>(deserializer: D) -> Result<Url, D::Error>
+    where
+        D: Deserializer<'de>,
+{
+    let url_str: String = Deserialize::deserialize(deserializer)?;
+    Url::parse(&url_str).map_err(serde::de::Error::custom)
+}
+
+/// Custom serializer to convert a url::Url to a string
+pub fn serialize_url<S>(url: &Url, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    serializer.serialize_str(url.as_str())
+}
+
+pub const fn default_bool<const B: bool>() -> bool {
+    B
 }


### PR DESCRIPTION
By publishing blobs to the beacon node before the block is processed, it gives the blobs a head start to propagate around the network.