### PR TITLE
chore: `rust-toolchain.toml`

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.72.0"
+profile = "default"


### PR DESCRIPTION
This PR introduces a `rust-toolchain.toml` file that specifies the version of the Rust compiler used which is currently missing from the codebase, leading to unexpected errors during build. By looking at the [`Dockerfile`](https://github.com/gattaca-com/helix/blob/main/Dockerfile#L1) it seems the used version is `1.72.0`.