### PR TITLE
chore: use `chain_info.seconds_per_slot` instead of 12 seconds constant

### DIFF
--- a/crates/api/src/builder/api.rs
+++ b/crates/api/src/builder/api.rs
@@ -13,7 +13,7 @@ use axum::{
     Extension,
 };
 use ethereum_consensus::{
-    configs::mainnet::{CAPELLA_FORK_EPOCH, SECONDS_PER_SLOT},
+    configs::mainnet::CAPELLA_FORK_EPOCH,
     phase0::mainnet::SLOTS_PER_EPOCH,
     primitives::{BlsPublicKey, Bytes32, Hash32},
     ssz::{self, prelude::*},
@@ -1887,7 +1887,7 @@ fn sanity_check_block_submission(
     payload_attributes: &PayloadAttributesUpdate,
     chain_info: &ChainInfo,
 ) -> Result<(), BuilderApiError> {
-    let expected_timestamp = chain_info.genesis_time_in_secs + (bid_trace.slot * SECONDS_PER_SLOT);
+    let expected_timestamp = chain_info.genesis_time_in_secs + (bid_trace.slot * chain_info.seconds_per_slot);
     if payload.timestamp() != expected_timestamp {
         return Err(BuilderApiError::IncorrectTimestamp {
             got: payload.timestamp(),

--- a/crates/housekeeper/src/chain_event_updater.rs
+++ b/crates/housekeeper/src/chain_event_updater.rs
@@ -5,7 +5,7 @@ use std::{
 use std::collections::HashMap;
 
 use ethereum_consensus::{
-    configs::{goerli::CAPELLA_FORK_EPOCH, mainnet::SECONDS_PER_SLOT},
+    configs::goerli::CAPELLA_FORK_EPOCH,
     primitives::Bytes32,
 };
 use tokio::sync::{broadcast, mpsc};
@@ -132,7 +132,7 @@ impl<D: DatabaseService> ChainEventUpdater<D> {
         // Validate this isn't a faulty head slot
         if let Ok(current_timestamp) = SystemTime::now().duration_since(UNIX_EPOCH) {
             let slot_timestamp =
-                self.chain_info.genesis_time_in_secs + (event.slot * SECONDS_PER_SLOT);
+                self.chain_info.genesis_time_in_secs + (event.slot * self.chain_info.seconds_per_slot);
             if slot_timestamp > current_timestamp.as_secs() + MAX_DISTANCE_FOR_FUTURE_SLOT {
                 warn!(head_slot = event.slot, "head event slot is too far in the future",);
                 return;


### PR DESCRIPTION
This PR removes the remaining usage of the constant `SECONDS_PER_SLOT` where `chain_info.seconds_per_slot` should be used instead to allow correct submission of blocks and synchronization in testnets and devnets that might have a shorter slot time.