### PR TITLE
feat(config): add allowed builders from config file

### DIFF
--- a/crates/api/src/service.rs
+++ b/crates/api/src/service.rs
@@ -40,6 +40,7 @@ impl ApiService {
         let postgres_db = PostgresDatabaseService::from_relay_config(&config).unwrap();
         postgres_db.run_migrations().await;
         postgres_db.init_region(&config).await;
+        postgres_db.store_builders_info(&config.builders).await.expect("failed to store builders info from config");
         postgres_db.load_known_validators().await;
         postgres_db.start_registration_processor().await;
 

--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -1,6 +1,6 @@
-use crate::{api::*, ValidatorPreferences};
+use crate::{api::*, BuilderInfo, ValidatorPreferences};
 use clap::Parser;
-use ethereum_consensus::ssz::prelude::Node;
+use ethereum_consensus::{primitives::BlsPublicKey, ssz::prelude::Node};
 use helix_utils::{
     request_encoding::Encoding,
     serde::{default_bool, deserialize_url, serialize_url},
@@ -8,7 +8,6 @@ use helix_utils::{
 use reqwest::Url;
 use serde::{Deserialize, Serialize};
 use std::{collections::HashSet, fs::File};
-use ethereum_consensus::deneb::BlsPublicKey;
 
 #[derive(Serialize, Deserialize, Clone, Default)]
 pub struct RelayConfig {
@@ -21,6 +20,8 @@ pub struct RelayConfig {
     pub beacon_clients: Vec<BeaconClientConfig>,
     #[serde(default)]
     pub relays: Vec<RelayGossipConfig>,
+    #[serde(default)]
+    pub builders: Vec<BuilderConfig>,
     #[serde(default)]
     pub network_config: NetworkConfig,
     #[serde(default)]
@@ -102,6 +103,12 @@ pub struct BeaconClientConfig {
 #[derive(Serialize, Deserialize, Clone)]
 pub struct RelayGossipConfig {
     pub url: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct BuilderConfig {
+    pub pub_key: BlsPublicKey,
+    pub builder_info: BuilderInfo,
 }
 
 #[derive(Serialize, Deserialize, Clone, Default)]
@@ -303,7 +310,7 @@ fn test_config() {
         filtering: Filtering::Regional,
         trusted_builders: None,
         header_delay: true,
-        gossip_blobs: false
+        gossip_blobs: false,
     };
     config.router_config = RouterConfig {
         enabled_routes: vec![
@@ -319,7 +326,8 @@ fn test_config() {
             RouteInfo { route: Route::ProposerPayloadDelivered, rate_limit: None },
             RouteInfo { route: Route::RegisterValidators, rate_limit: None },
             RouteInfo { route: Route::Status, rate_limit: None },
-        ].to_vec(),
+        ]
+        .to_vec(),
     };
     println!("{}", serde_yaml::to_string(&config).unwrap());
 }

--- a/crates/database/src/mock_database_service.rs
+++ b/crates/database/src/mock_database_service.rs
@@ -156,7 +156,14 @@ impl DatabaseService for MockDatabaseService {
     async fn store_builder_info(
         &self,
         _builder_pub_key: &BlsPublicKey,
-        _builder_info: BuilderInfo,
+        _builder_info: &BuilderInfo,
+    ) -> Result<(), DatabaseError> {
+        Ok(())
+    }
+
+    async fn store_builders_info(
+        &self,
+        _builders: &Vec<BuilderInfoDocument>
     ) -> Result<(), DatabaseError> {
         Ok(())
     }

--- a/crates/database/src/postgres/postgres_db_service.rs
+++ b/crates/database/src/postgres/postgres_db_service.rs
@@ -1111,7 +1111,7 @@ impl DatabaseService for PostgresDatabaseService {
     async fn store_builder_info(
         &self,
         builder_pub_key: &BlsPublicKey,
-        builder_info: BuilderInfo,
+        builder_info: &BuilderInfo,
     ) -> Result<(), DatabaseError> {
         self.pool
             .get()
@@ -1133,6 +1133,19 @@ impl DatabaseService for PostgresDatabaseService {
                 ],
             )
             .await?;
+
+        Ok(())
+    }
+
+    async fn store_builders_info(
+        &self,
+        builders: &Vec<BuilderInfoDocument>,
+    ) -> Result<(), DatabaseError> {
+        // PERF: this is not the most performant approach but it is expected
+        // to add just a few builders only at startup
+        for builder in builders {
+            self.store_builder_info(&builder.pub_key, &builder.builder_info).await?;
+        }
 
         Ok(())
     }

--- a/crates/database/src/postgres/postgres_db_service_tests.rs
+++ b/crates/database/src/postgres/postgres_db_service_tests.rs
@@ -416,7 +416,7 @@ mod tests {
             builder_id: None,
         };
 
-        let result = db_service.store_builder_info(&public_key, builder_info).await;
+        let result = db_service.store_builder_info(&public_key, &builder_info).await;
         assert!(result.is_ok());
 
         let result = db_service.db_get_builder_info(&public_key).await;
@@ -440,7 +440,7 @@ mod tests {
             builder_id: None,
         };
 
-        let result = db_service.store_builder_info(&public_key, builder_info).await;
+        let result = db_service.store_builder_info(&public_key, &builder_info).await;
         assert!(result.is_ok());
 
         let result =

--- a/crates/database/src/traits.rs
+++ b/crates/database/src/traits.rs
@@ -109,7 +109,12 @@ pub trait DatabaseService: Send + Sync + Clone {
     async fn store_builder_info(
         &self,
         builder_pub_key: &BlsPublicKey,
-        builder_info: BuilderInfo,
+        builder_info: &BuilderInfo,
+    ) -> Result<(), DatabaseError>;
+
+    async fn store_builders_info(
+        &self,
+        builders: &Vec<BuilderInfoDocument>
     ) -> Result<(), DatabaseError>;
 
     async fn db_get_builder_info(

--- a/crates/database/src/types/documents.rs
+++ b/crates/database/src/types/documents.rs
@@ -12,7 +12,7 @@ use helix_common::{
     bid_submission::BidTrace,
     builder_info::BuilderInfo,
     simulator::BlockSimError,
-    SubmissionTrace,
+    BuilderConfig, SubmissionTrace,
 };
 
 #[derive(Serialize, Deserialize)]
@@ -78,11 +78,7 @@ impl DemotionDocument {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
-pub struct BuilderInfoDocument {
-    pub pub_key: BlsPublicKey,
-    pub builder_info: BuilderInfo,
-}
+pub type BuilderInfoDocument = BuilderConfig;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct BlockSimErrorDocument {


### PR DESCRIPTION
This PR enables adding allowed builders from the YAML configuration file using the `builders` field.

Currently adding new builders requires connecting to a the running postgres instance used by the relay and add new builders manually. While adding new builders happens rarely, when running the relay in a docker compose setup like a Kurtosis devnet this feature can be really helpful.