### PR TITLE
fix(logs): show also console logs with `RUST_LOG`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ reth-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "5dd5555c
 
 # Logging
 tracing = "0.1.37"
-tracing-subscriber = "0.3.17"
+tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 tracing-appender = "0.2.2"
 
 # Testing and Mocking

--- a/crates/cmd/src/main.rs
+++ b/crates/cmd/src/main.rs
@@ -15,7 +15,11 @@ async fn run() {
 
     match &config.logging {
         LoggingConfig::Console => {
-            tracing_subscriber::fmt().init();
+            let filter_layer = tracing_subscriber::EnvFilter::from_default_env();
+
+            tracing_subscriber::fmt()
+                .with_env_filter(filter_layer)
+                .init();
         }
         LoggingConfig::File { dir_path, file_name } => {
             let file_appender = tracing_appender::rolling::daily(dir_path, file_name);


### PR DESCRIPTION
Currently only logging to a file supports the `RUST_LOG` environment variable as a filter layer. This PR fixes it and ensure the `env-filter` feature is added to `tracing-subscriber`.