### PR TITLE
fix: switch `proposer_duties` table primary key to `slot_number`

### DIFF
--- a/crates/database/src/postgres/migrations/V21__proposer_duties_fix.sql
+++ b/crates/database/src/postgres/migrations/V21__proposer_duties_fix.sql
@@ -1,0 +1,2 @@
+ALTER TABLE proposer_duties DROP CONSTRAINT proposer_duties_pkey;
+ALTER TABLE proposer_duties ADD PRIMARY KEY (slot_number);

--- a/crates/database/src/postgres/postgres_db_service.rs
+++ b/crates/database/src/postgres/postgres_db_service.rs
@@ -614,7 +614,7 @@ impl DatabaseService for PostgresDatabaseService {
 
         // Join the values clauses and append them to the SQL statement
         sql.push_str(&values_clauses.join(", "));
-        sql.push_str(" ON CONFLICT (public_key) DO NOTHING");
+        sql.push_str(" ON CONFLICT (slot_number) DO NOTHING");
 
         // Execute the query
         transaction.execute(&sql, &params[..]).await?;


### PR DESCRIPTION
As title says this PR changes the `PRIMARY_KEY` of the `proposer_duties` table from `public_key` to `slot_number`, and updates the logic of `set_proposer_duties` method of the `PostgresDatabaseService` accordingly.

The reason this change is needed is that, even if rare, it might occur that a validator public key is chosen twice for the next proposer duties which leads to the second record not being written on the database table because there is a conflict with the primary key. This edge case happens quite often in a devnet which has a very small validator set size compared to Mainnet.

The downstream consequence of it is that when processing a new head event inside `process_head_event` in the `ChainEventUpdater` (see below)
https://github.com/gattaca-com/helix/blob/3533496355837a4bb96b330d7e6c49408228ed7e/crates/housekeeper/src/chain_event_updater.rs#L151-L175
some proposer duties are missing which might lead to `next_duty` to being `None`. The latter is then read inside the `submit_block`/`submit_header` functions throwing the error `BuilderApiError::ProposerDutyNotFound` incorrectly.