### PR TITLE
chore: copy traces

### DIFF
--- a/crates/api/src/builder/api.rs
+++ b/crates/api/src/builder/api.rs
@@ -510,10 +510,8 @@ where
         // Save submission to db.
         tokio::spawn(
             async move {
-                if let Err(err) = api
-                    .db
-                    .store_block_submission(payload, Arc::new(trace), optimistic_version as i16)
-                    .await
+                if let Err(err) =
+                    api.db.store_block_submission(payload, trace, optimistic_version as i16).await
                 {
                     error!(%err, "failed to store block submission")
                 }
@@ -721,7 +719,7 @@ where
         let db = api.db.clone();
         tokio::spawn(
             async move {
-                if let Err(err) = db.store_header_submission(payload, Arc::new(trace)).await {
+                if let Err(err) = db.store_header_submission(payload, trace).await {
                     error!(
                         %err,
                         "failed to store header submission",
@@ -929,7 +927,7 @@ where
             async move {
                 if let Err(err) = api
                     .db
-                    .store_block_submission(payload, Arc::new(trace), OptimisticVersion::V2 as i16)
+                    .store_block_submission(payload, trace, OptimisticVersion::V2 as i16)
                     .await
                 {
                     error!(%err, "failed to store block submission")
@@ -1125,9 +1123,8 @@ where
         // Save latency trace to db
         let db = self.db.clone();
         tokio::spawn(async move {
-            if let Err(err) = db
-                .save_gossiped_header_trace(req.bid_trace.block_hash.clone(), Arc::new(trace))
-                .await
+            if let Err(err) =
+                db.save_gossiped_header_trace(req.bid_trace.block_hash.clone(), trace).await
             {
                 error!(%err, "failed to store gossiped header trace")
             }
@@ -1205,7 +1202,7 @@ where
             if let Err(err) = db
                 .save_gossiped_payload_trace(
                     req.execution_payload.execution_payload.block_hash().clone(),
-                    Arc::new(trace),
+                    trace,
                 )
                 .await
             {

--- a/crates/api/src/builder/types.rs
+++ b/crates/api/src/builder/types.rs
@@ -9,10 +9,10 @@ use helix_common::{
 
 #[derive(Clone)]
 pub enum DbInfo {
-    NewSubmission(Arc<SignedBidSubmission>, Arc<SubmissionTrace>, OptimisticVersion),
-    NewHeaderSubmission(Arc<SignedHeaderSubmission>, Arc<HeaderSubmissionTrace>),
-    GossipedHeader { block_hash: ByteVector<32>, trace: Arc<GossipedHeaderTrace> },
-    GossipedPayload { block_hash: ByteVector<32>, trace: Arc<GossipedPayloadTrace> },
+    NewSubmission(Arc<SignedBidSubmission>, SubmissionTrace, OptimisticVersion),
+    NewHeaderSubmission(Arc<SignedHeaderSubmission>, HeaderSubmissionTrace),
+    GossipedHeader { block_hash: ByteVector<32>, trace: GossipedHeaderTrace },
+    GossipedPayload { block_hash: ByteVector<32>, trace: GossipedPayloadTrace },
     SimulationResult { block_hash: ByteVector<32>, block_sim_result: Result<(), BlockSimError> },
 }
 

--- a/crates/api/src/proposer/api.rs
+++ b/crates/api/src/proposer/api.rs
@@ -883,7 +883,7 @@ where
         let self_clone = self.clone();
         let unblinded_payload_clone = unblinded_payload.clone();
         let request_id_clone = *request_id;
-        let mut trace_clone = trace.clone();
+        let mut trace_clone = *trace;
         let payload_clone = payload.clone();
 
         tokio::spawn(async move {
@@ -916,7 +916,7 @@ where
                     payload_clone,
                     &signed_blinded_block,
                     &proposer_public_key,
-                    &trace_clone,
+                    trace_clone,
                     &request_id_clone,
                     user_agent,
                 )
@@ -1369,7 +1369,7 @@ where
         payload: Arc<PayloadAndBlobs>,
         signed_blinded_block: &SignedBlindedBeaconBlock,
         proposer_public_key: &BlsPublicKey,
-        trace: &GetPayloadTrace,
+        trace: GetPayloadTrace,
         request_id: &Uuid,
         user_agent: Option<String>,
     ) {
@@ -1394,7 +1394,6 @@ where
         };
 
         let db = self.db.clone();
-        let trace = trace.clone();
         let request_id = *request_id;
         tokio::spawn(async move {
             if let Err(err) =

--- a/crates/common/src/traces/builder_api_trace.rs
+++ b/crates/common/src/traces/builder_api_trace.rs
@@ -1,4 +1,6 @@
-#[derive(Clone, Default, Debug, serde::Serialize, serde::Deserialize)]
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
 pub struct SubmissionTrace {
     pub receive: u64,
     pub decode: u64,
@@ -10,7 +12,7 @@ pub struct SubmissionTrace {
     pub request_finish: u64,
 }
 
-#[derive(Clone, Default, Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
 pub struct HeaderSubmissionTrace {
     pub receive: u64,
     pub decode: u64,
@@ -21,14 +23,14 @@ pub struct HeaderSubmissionTrace {
     pub request_finish: u64,
 }
 
-#[derive(Clone, Default, Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
 pub struct GossipedPayloadTrace {
     pub receive: u64,
     pub pre_checks: u64,
     pub auctioneer_update: u64,
 }
 
-#[derive(Clone, Default, Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
 pub struct GossipedHeaderTrace {
     pub on_receive: u64,
     pub on_gossip_receive: u64,

--- a/crates/common/src/traces/constraint_api_trace.rs
+++ b/crates/common/src/traces/constraint_api_trace.rs
@@ -1,4 +1,6 @@
-#[derive(Clone, Default, Debug, serde::Serialize, serde::Deserialize)]
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
 pub struct ConstraintSubmissionTrace {
     pub receive: u64,
     pub decode: u64,

--- a/crates/common/src/traces/proposer_api.rs
+++ b/crates/common/src/traces/proposer_api.rs
@@ -1,17 +1,19 @@
-#[derive(Debug, Default)]
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, Default)]
 pub struct RegisterValidatorsTrace {
     pub receive: u64,
     pub registrations_complete: u64,
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Clone, Copy, Default)]
 pub struct GetHeaderTrace {
     pub receive: u64,
     pub validation_complete: u64,
     pub best_bid_fetched: u64,
 }
 
-#[derive(Debug, Default, serde::Serialize, serde::Deserialize, Clone)]
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
 pub struct GetPayloadTrace {
     pub receive: u64,
     pub proposer_index_validated: u64,

--- a/crates/database/src/mock_database_service.rs
+++ b/crates/database/src/mock_database_service.rs
@@ -150,7 +150,7 @@ impl DatabaseService for MockDatabaseService {
     async fn store_block_submission(
         &self,
         _submission: Arc<SignedBidSubmission>,
-        _trace: Arc<SubmissionTrace>,
+        _trace: SubmissionTrace,
         _optimistic_version: i16,
     ) -> Result<(), DatabaseError> {
         Ok(())
@@ -252,7 +252,7 @@ impl DatabaseService for MockDatabaseService {
     async fn store_header_submission(
         &self,
         _submission: Arc<SignedHeaderSubmission>,
-        _trace: Arc<HeaderSubmissionTrace>,
+        _trace: HeaderSubmissionTrace,
     ) -> Result<(), DatabaseError> {
         Ok(())
     }
@@ -260,7 +260,7 @@ impl DatabaseService for MockDatabaseService {
     async fn save_gossiped_header_trace(
         &self,
         _block_hash: ByteVector<32>,
-        _trace: Arc<GossipedHeaderTrace>,
+        _trace: GossipedHeaderTrace,
     ) -> Result<(), DatabaseError> {
         Ok(())
     }
@@ -268,7 +268,7 @@ impl DatabaseService for MockDatabaseService {
     async fn save_gossiped_payload_trace(
         &self,
         _block_hash: ByteVector<32>,
-        _trace: Arc<GossipedPayloadTrace>,
+        _trace: GossipedPayloadTrace,
     ) -> Result<(), DatabaseError> {
         Ok(())
     }

--- a/crates/database/src/postgres/postgres_db_service.rs
+++ b/crates/database/src/postgres/postgres_db_service.rs
@@ -1134,7 +1134,7 @@ impl DatabaseService for PostgresDatabaseService {
     async fn store_block_submission(
         &self,
         submission: Arc<SignedBidSubmission>,
-        trace: Arc<SubmissionTrace>,
+        trace: SubmissionTrace,
         optimistic_version: i16,
     ) -> Result<(), DatabaseError> {
         let mut record = DbMetricRecord::new("store_block_submission");
@@ -1717,7 +1717,7 @@ impl DatabaseService for PostgresDatabaseService {
     async fn store_header_submission(
         &self,
         submission: Arc<SignedHeaderSubmission>,
-        trace: Arc<HeaderSubmissionTrace>,
+        trace: HeaderSubmissionTrace,
     ) -> Result<(), DatabaseError> {
         let mut record = DbMetricRecord::new("store_header_submission");
 
@@ -1780,7 +1780,7 @@ impl DatabaseService for PostgresDatabaseService {
     async fn save_gossiped_header_trace(
         &self,
         block_hash: ByteVector<32>,
-        trace: Arc<GossipedHeaderTrace>,
+        trace: GossipedHeaderTrace,
     ) -> Result<(), DatabaseError> {
         let mut record = DbMetricRecord::new("save_gossiped_header_trace");
 
@@ -1810,7 +1810,7 @@ impl DatabaseService for PostgresDatabaseService {
     async fn save_gossiped_payload_trace(
         &self,
         block_hash: ByteVector<32>,
-        trace: Arc<GossipedPayloadTrace>,
+        trace: GossipedPayloadTrace,
     ) -> Result<(), DatabaseError> {
         let mut record = DbMetricRecord::new("save_gossiped_payload_trace");
 

--- a/crates/database/src/postgres/postgres_db_service_tests.rs
+++ b/crates/database/src/postgres/postgres_db_service_tests.rs
@@ -492,7 +492,7 @@ mod tests {
         };
 
         db_service
-            .store_block_submission(Arc::new(signed_bid_submission), Arc::new(submission_trace), 0)
+            .store_block_submission(Arc::new(signed_bid_submission), submission_trace, 0)
             .await?;
         Ok(())
     }
@@ -691,7 +691,7 @@ mod tests {
         db_service
             .store_header_submission(
                 Arc::new(signed_bid_submission),
-                Arc::new(HeaderSubmissionTrace::default()),
+                HeaderSubmissionTrace::default(),
             )
             .await?;
         Ok(())

--- a/crates/database/src/traits.rs
+++ b/crates/database/src/traits.rs
@@ -105,7 +105,7 @@ pub trait DatabaseService: Send + Sync + Clone {
     async fn store_block_submission(
         &self,
         submission: Arc<SignedBidSubmission>,
-        trace: Arc<SubmissionTrace>,
+        trace: SubmissionTrace,
         optimistic_version: i16,
     ) -> Result<(), DatabaseError>;
 
@@ -175,19 +175,19 @@ pub trait DatabaseService: Send + Sync + Clone {
     async fn store_header_submission(
         &self,
         submission: Arc<SignedHeaderSubmission>,
-        trace: Arc<HeaderSubmissionTrace>,
+        trace: HeaderSubmissionTrace,
     ) -> Result<(), DatabaseError>;
 
     async fn save_gossiped_header_trace(
         &self,
         block_hash: ByteVector<32>,
-        trace: Arc<GossipedHeaderTrace>,
+        trace: GossipedHeaderTrace,
     ) -> Result<(), DatabaseError>;
 
     async fn save_gossiped_payload_trace(
         &self,
         block_hash: ByteVector<32>,
-        trace: Arc<GossipedPayloadTrace>,
+        trace: GossipedPayloadTrace,
     ) -> Result<(), DatabaseError>;
 
     async fn get_trusted_proposers(&self) -> Result<Vec<ProposerInfo>, DatabaseError>;


### PR DESCRIPTION
traces are small structs of u64 so can be `Copy` and don't need to be `Arc`'d