### PR TITLE
chore: fix genesis timestamp for devnet

### DIFF
--- a/crates/api/src/builder/api.rs
+++ b/crates/api/src/builder/api.rs
@@ -2193,7 +2193,7 @@ fn sanity_check_block_submission(
     chain_info: &ChainInfo,
 ) -> Result<(), BuilderApiError> {
     let expected_timestamp =
-        chain_info.genesis_time_in_secs + (bid_trace.slot * chain_info.seconds_per_slot);
+        chain_info.genesis_time() + (bid_trace.slot * chain_info.seconds_per_slot);
     if payload.timestamp() != expected_timestamp {
         return Err(BuilderApiError::IncorrectTimestamp {
             got: payload.timestamp(),

--- a/crates/api/src/proposer/api.rs
+++ b/crates/api/src/proposer/api.rs
@@ -1030,8 +1030,8 @@ where
     /// Returns how many ms we are into the slot if ok.
     fn validate_bid_request_time(&self, bid_request: &BidRequest) -> Result<u64, ProposerApiError> {
         let curr_timestamp_ms = utcnow_ms() as i64;
-        let slot_start_timestamp = self.chain_info.genesis_time_in_secs +
-            (bid_request.slot * self.chain_info.seconds_per_slot);
+        let slot_start_timestamp =
+            self.chain_info.genesis_time() + (bid_request.slot * self.chain_info.seconds_per_slot);
         let ms_into_slot = curr_timestamp_ms.saturating_sub((slot_start_timestamp * 1000) as i64);
 
         if ms_into_slot > GET_HEADER_REQUEST_CUTOFF_MS {
@@ -1308,8 +1308,7 @@ where
     ) -> Result<PayloadAndBlobs, ProposerApiError> {
         const RETRY_DELAY: Duration = Duration::from_millis(20);
 
-        let slot_time =
-            self.chain_info.genesis_time_in_secs + (slot * self.chain_info.seconds_per_slot);
+        let slot_time = self.chain_info.genesis_time() + (slot * self.chain_info.seconds_per_slot);
         let slot_cutoff_millis = (slot_time * 1000) + GET_PAYLOAD_REQUEST_CUTOFF_MS as u64;
 
         let mut last_error: Option<ProposerApiError> = None;
@@ -1496,7 +1495,7 @@ fn calculate_slot_time_info(
     request_time: u64,
 ) -> (i64, Duration) {
     let slot_start_timestamp_in_secs =
-        chain_info.genesis_time_in_secs + (slot * chain_info.seconds_per_slot);
+        chain_info.genesis_time() + (slot * chain_info.seconds_per_slot);
     let ms_into_slot =
         (request_time / 1_000_000) as i64 - (slot_start_timestamp_in_secs * 1000) as i64;
     let duration_until_slot_start = chain_info.clock.duration_until_slot(slot);

--- a/crates/common/src/chain_info.rs
+++ b/crates/common/src/chain_info.rs
@@ -93,6 +93,16 @@ impl ChainInfo {
         }
     }
 
+    pub fn genesis_time(&self) -> u64 {
+        match self.network {
+            Network::Mainnet => self.genesis_time_in_secs,
+            Network::Sepolia => self.genesis_time_in_secs,
+            Network::Goerli => self.genesis_time_in_secs,
+            Network::Holesky => self.genesis_time_in_secs,
+            Network::Custom(_) => self.genesis_time_in_secs + self.context.genesis_delay,
+        }
+    }
+
     pub fn for_sepolia() -> Self {
         Self {
             network: Network::Sepolia,
@@ -142,11 +152,9 @@ impl ChainInfo {
     ) -> Result<Self, Error> {
         let context = Context::try_from_file(&config)?;
         let network = Network::Custom(config.clone());
-        let clock = from_system_time(
-            genesis_time_in_secs,
-            context.seconds_per_slot,
-            context.slots_per_epoch,
-        );
+        let genesis_time = context.min_genesis_time + context.genesis_delay;
+        let clock =
+            from_system_time(genesis_time, context.seconds_per_slot, context.slots_per_epoch);
         let seconds_per_slot = context.seconds_per_slot;
 
         Ok(Self {

--- a/crates/housekeeper/src/chain_event_updater.rs
+++ b/crates/housekeeper/src/chain_event_updater.rs
@@ -152,7 +152,7 @@ impl<D: DatabaseService> ChainEventUpdater<D> {
         // Validate this isn't a faulty head slot
 
         let slot_timestamp =
-            self.chain_info.genesis_time_in_secs + (slot * self.chain_info.seconds_per_slot);
+            self.chain_info.genesis_time() + (slot * self.chain_info.seconds_per_slot);
         if slot_timestamp > utcnow_sec() + MAX_DISTANCE_FOR_FUTURE_SLOT {
             warn!(head_slot = slot, "slot is too far in the future",);
             return


### PR DESCRIPTION
We are testing helix in the devnet(kurtosis devnet) which the genensis time is different from public network. The genesis delay needs to be considered otherwise the time is always wrong.

The pr is mainly to fix the problems by including genesis delay for other networks.