### PR TITLE
Chore: Use enum for handling bid sorting

### DIFF
--- a/crates/common/src/api/data_api.rs
+++ b/crates/common/src/api/data_api.rs
@@ -4,6 +4,12 @@ use ethereum_consensus::{
 };
 use serde::{Deserialize, Serialize};
 
+#[derive(Debug, PartialEq, Eq, Deserialize, Serialize, Clone)]
+pub enum BidsOrderBy {
+    HighToLow,
+    LowToHigh,
+}
+
 #[derive(Debug, Deserialize, Serialize, Default, Clone)]
 pub struct BidFilters {
     pub slot: Option<u64>,
@@ -13,7 +19,7 @@ pub struct BidFilters {
     pub block_number: Option<u64>,
     pub proposer_pubkey: Option<BlsPublicKey>,
     pub builder_pubkey: Option<BlsPublicKey>,
-    pub order_by: Option<i8>,
+    pub order_by: Option<BidsOrderBy>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -40,8 +46,8 @@ impl From<ProposerPayloadDeliveredParams> for BidFilters {
             builder_pubkey: value.builder_pubkey,
             order_by: match value.order_by.as_ref() {
                 Some(s) => match s.as_str() {
-                    "value" => Some(1),
-                    "-value" => Some(-1),
+                    "value" => Some(BidsOrderBy::LowToHigh),
+                    "-value" => Some(BidsOrderBy::HighToLow),
                     _ => None,
                 },
                 None => None,

--- a/crates/database/src/postgres/postgres_db_filters.rs
+++ b/crates/database/src/postgres/postgres_db_filters.rs
@@ -1,4 +1,4 @@
-use helix_common::api::data_api::BidFilters;
+use helix_common::api::data_api::{BidFilters, BidsOrderBy};
 
 #[derive(Clone, Debug)]
 pub struct PgBidFilters(BidFilters);
@@ -40,8 +40,8 @@ impl PgBidFilters {
         self.0.block_hash.as_ref().map(|block_hash| block_hash.as_ref())
     }
 
-    pub fn order(&self) -> Option<i32> {
-        self.0.order_by.map(|order_by| order_by as i32)
+    pub fn order(&self) -> Option<&BidsOrderBy> {
+        self.0.order_by.as_ref()
     }
 
     pub fn limit(&self) -> Option<i64> {

--- a/crates/database/src/postgres/postgres_db_service.rs
+++ b/crates/database/src/postgres/postgres_db_service.rs
@@ -12,7 +12,8 @@ use ethereum_consensus::{altair::Hash32, primitives::BlsPublicKey, ssz::prelude:
 
 use helix_common::{
     api::{
-        builder_api::BuilderGetValidatorsResponseEntry, data_api::BidFilters,
+        builder_api::BuilderGetValidatorsResponseEntry,
+        data_api::{BidFilters, BidsOrderBy},
         proposer_api::ValidatorRegistrationInfo,
     },
     bid_submission::{
@@ -1585,7 +1586,9 @@ impl DatabaseService for PostgresDatabaseService {
 
         if let Some(order) = filters.order() {
             query.push_str(" ORDER BY block_submission.value ");
-            query.push_str(if order >= 0 { "ASC" } else { "DESC" });
+            if order == &BidsOrderBy::HighToLow {
+                query.push_str("DESC");
+            }
         } else {
             query.push_str(" ORDER BY block_submission.slot_number DESC");
         }


### PR DESCRIPTION
Used `BidsOrderBy` enum `Option<BidsOrderBy>` in place of `Option<i8>`.
Please follow this [issue](https://github.com/chainbound/bolt/issues/73) regarding my suggestion.

#### Bonus:
While running tests, noticed `#[ignore = "TODO: to fix"]`, could someone please clarify on this?
https://github.com/gattaca-com/helix/blob/f26f2577cbeeedb546997c924a244c0ecaa83df7/crates/database/src/postgres/postgres_db_service_tests.rs#L590-L592

Closes #73 