### PR TITLE
chore: bump rust to 1.85

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ resolver = "2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/gattaca-com/helix"
-rust-version = "1.82.0"
+rust-version = "1.85.0"
 version = "0.0.1"
 
 [workspace.dependencies]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM lukemathwalker/cargo-chef:latest-rust-1.82 AS chef
+FROM lukemathwalker/cargo-chef:latest-rust-1.85 AS chef
 WORKDIR /app
 
 FROM chef AS planner

--- a/crates/api/src/builder/api.rs
+++ b/crates/api/src/builder/api.rs
@@ -462,17 +462,11 @@ pub async fn decode_payload(
     let headers = req.headers().clone();
 
     // Get content encoding and content type
-    let is_gzip = req
-        .headers()
-        .get("Content-Encoding")
-        .and_then(|val| val.to_str().ok())
-        .map_or(false, |v| v == "gzip");
+    let is_gzip =
+        req.headers().get("Content-Encoding").and_then(|val| val.to_str().ok()) == Some("gzip");
 
-    let is_ssz = req
-        .headers()
-        .get("Content-Type")
-        .and_then(|val| val.to_str().ok())
-        .map_or(false, |v| v == "application/octet-stream");
+    let is_ssz = req.headers().get("Content-Type").and_then(|val| val.to_str().ok()) ==
+        Some("application/octet-stream");
 
     // Read the body
     let body = req.into_body();

--- a/crates/api/src/builder/simulator/rpc_simulator.rs
+++ b/crates/api/src/builder/simulator/rpc_simulator.rs
@@ -210,9 +210,7 @@ impl<DB: DatabaseService + 'static> BlockSimulator for RpcSimulator<DB> {
 async fn process_db_additions<DB: DatabaseService + 'static>(db: Arc<DB>, db_info: DbInfo) {
     match db_info {
         DbInfo::NewSubmission(submission, trace, version) => {
-            if let Err(err) =
-                db.store_block_submission(submission, Arc::new(trace), version as i16).await
-            {
+            if let Err(err) = db.store_block_submission(submission, trace, version as i16).await {
                 error!(%err, "failed to store block submission")
             }
         }

--- a/crates/api/src/builder/submit_block.rs
+++ b/crates/api/src/builder/submit_block.rs
@@ -229,11 +229,7 @@ where
                     async move {
                         if let Err(err) = api
                             .db
-                            .store_block_submission(
-                                payload,
-                                Arc::new(trace),
-                                optimistic_version as i16,
-                            )
+                            .store_block_submission(payload, trace, optimistic_version as i16)
                             .await
                         {
                             error!(%err, "failed to store block submission")
@@ -288,10 +284,8 @@ where
             file!(),
             line!(),
             async move {
-                if let Err(err) = api
-                    .db
-                    .store_block_submission(payload, Arc::new(trace), optimistic_version as i16)
-                    .await
+                if let Err(err) =
+                    api.db.store_block_submission(payload, trace, optimistic_version as i16).await
                 {
                     error!(%err, "failed to store block submission")
                 }

--- a/crates/api/src/builder/submit_block_v2.rs
+++ b/crates/api/src/builder/submit_block_v2.rs
@@ -249,10 +249,8 @@ where
             file!(),
             line!(),
             async move {
-                if let Err(err) = api
-                    .db
-                    .store_block_submission(payload, Arc::new(trace), optimistic_version as i16)
-                    .await
+                if let Err(err) =
+                    api.db.store_block_submission(payload, trace, optimistic_version as i16).await
                 {
                     error!(%err, "failed to store block submission")
                 }

--- a/crates/api/src/builder/submit_header.rs
+++ b/crates/api/src/builder/submit_header.rs
@@ -136,11 +136,10 @@ where
         );
 
         // Verify that we have a validator connected for this slot
-        if next_duty.is_none() {
+        let Some(next_duty) = next_duty else {
             warn!(?block_hash, "could not find slot duty");
             return Err(BuilderApiError::ProposerDutyNotFound);
-        }
-        let next_duty = next_duty.unwrap();
+        };
 
         // Fetch the next payload attributes and validate basic information
         let payload_attributes =
@@ -402,11 +401,8 @@ pub async fn decode_header_submission(
         })
         .unwrap_or(false);
 
-    let is_ssz = req
-        .headers()
-        .get("Content-Type")
-        .and_then(|val| val.to_str().ok())
-        .map_or(false, |v| v == "application/octet-stream");
+    let is_ssz = req.headers().get("Content-Type").and_then(|val| val.to_str().ok()) ==
+        Some("application/octet-stream");
 
     // Read the body
     let body = req.into_body();

--- a/crates/beacon/src/multi_beacon_client.rs
+++ b/crates/beacon/src/multi_beacon_client.rs
@@ -86,7 +86,7 @@ impl MultiBeaconClient {
             match join_result {
                 Ok(sync_status_result) => match sync_status_result {
                     Ok(sync_status) => {
-                        if best_sync_status.as_ref().map_or(true, |current_best| {
+                        if best_sync_status.as_ref().is_none_or(|current_best| {
                             current_best.head_slot < sync_status.head_slot
                         }) {
                             best_sync_status = Some(sync_status);

--- a/crates/common/src/metrics.rs
+++ b/crates/common/src/metrics.rs
@@ -398,7 +398,7 @@ impl<'a> DbMetricRecord<'a> {
     }
 }
 
-impl<'a> Drop for DbMetricRecord<'a> {
+impl Drop for DbMetricRecord<'_> {
     fn drop(&mut self) {
         if !self.has_recorded {
             self.record_failure();
@@ -465,7 +465,7 @@ impl<'a> RedisMetricRecord<'a> {
     }
 }
 
-impl<'a> Drop for RedisMetricRecord<'a> {
+impl Drop for RedisMetricRecord<'_> {
     fn drop(&mut self) {
         if !self.has_recorded {
             self.record_failure();

--- a/crates/database/src/mock_database_service.rs
+++ b/crates/database/src/mock_database_service.rs
@@ -165,7 +165,7 @@ impl DatabaseService for MockDatabaseService {
     async fn store_block_submission(
         &self,
         _submission: Arc<SignedBidSubmission>,
-        _trace: Arc<SubmissionTrace>,
+        _trace: SubmissionTrace,
         _optimistic_version: i16,
     ) -> Result<(), DatabaseError> {
         Ok(())

--- a/crates/database/src/postgres/postgres_db_service.rs
+++ b/crates/database/src/postgres/postgres_db_service.rs
@@ -1157,7 +1157,7 @@ impl DatabaseService for PostgresDatabaseService {
     async fn store_block_submission(
         &self,
         submission: Arc<SignedBidSubmission>,
-        trace: Arc<SubmissionTrace>,
+        trace: SubmissionTrace,
         optimistic_version: i16,
     ) -> Result<(), DatabaseError> {
         let mut record = DbMetricRecord::new("store_block_submission");

--- a/crates/database/src/postgres/postgres_db_service_tests.rs
+++ b/crates/database/src/postgres/postgres_db_service_tests.rs
@@ -456,11 +456,7 @@ mod tests {
         let submission_trace = SubmissionTrace { receive: utcnow_ns(), ..Default::default() };
 
         db_service
-            .store_block_submission(
-                Arc::new(signed_bid_submission.into()),
-                Arc::new(submission_trace),
-                0,
-            )
+            .store_block_submission(Arc::new(signed_bid_submission.into()), submission_trace, 0)
             .await?;
         Ok(())
     }

--- a/crates/database/src/postgres/postgres_db_u256_parsing.rs
+++ b/crates/database/src/postgres/postgres_db_u256_parsing.rs
@@ -28,8 +28,7 @@ const NBASE: u64 = 10000;
 /// E.g. some tests have shown that 1000_000_000_000_000_000_000_000_000 is stored as
 /// [0, 1, 0, 6, 0, 0, 0, 0, 3, 232]
 /// sign and dscale are still not used
-
-impl<'a> FromSql<'a> for PostgresNumeric {
+impl FromSql<'_> for PostgresNumeric {
     fn from_sql(
         _: &tokio_postgres::types::Type,
         raw: &[u8],

--- a/crates/database/src/traits.rs
+++ b/crates/database/src/traits.rs
@@ -100,7 +100,7 @@ pub trait DatabaseService: Send + Sync + Clone {
     async fn store_block_submission(
         &self,
         submission: Arc<SignedBidSubmission>,
-        trace: Arc<SubmissionTrace>,
+        trace: SubmissionTrace,
         optimistic_version: i16,
     ) -> Result<(), DatabaseError>;
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.82.0"
+channel = "1.85.0"
 profile = "default"


### PR DESCRIPTION
smaller cleanup and bump rust to 1.85 (needed for bincode) , fix new clippy warnings