### PR TITLE
cleanup signed root

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1565,7 +1565,7 @@ dependencies = [
 [[package]]
 name = "bls"
 version = "0.2.0"
-source = "git+https://github.com/ltitanb/lighthouse?rev=8cb40ed6adf6c22096f000e4a01c125b9b0a1ef6#8cb40ed6adf6c22096f000e4a01c125b9b0a1ef6"
+source = "git+https://github.com/ltitanb/lighthouse?rev=304b026ea0b5da12507e1410e8dae2b28f9db812#304b026ea0b5da12507e1410e8dae2b28f9db812"
 dependencies = [
  "alloy-primitives 0.8.25",
  "arbitrary",
@@ -1942,7 +1942,7 @@ dependencies = [
 [[package]]
 name = "compare_fields"
 version = "0.2.0"
-source = "git+https://github.com/ltitanb/lighthouse?rev=8cb40ed6adf6c22096f000e4a01c125b9b0a1ef6#8cb40ed6adf6c22096f000e4a01c125b9b0a1ef6"
+source = "git+https://github.com/ltitanb/lighthouse?rev=304b026ea0b5da12507e1410e8dae2b28f9db812#304b026ea0b5da12507e1410e8dae2b28f9db812"
 dependencies = [
  "itertools 0.10.5",
 ]
@@ -1950,7 +1950,7 @@ dependencies = [
 [[package]]
 name = "compare_fields_derive"
 version = "0.2.0"
-source = "git+https://github.com/ltitanb/lighthouse?rev=8cb40ed6adf6c22096f000e4a01c125b9b0a1ef6#8cb40ed6adf6c22096f000e4a01c125b9b0a1ef6"
+source = "git+https://github.com/ltitanb/lighthouse?rev=304b026ea0b5da12507e1410e8dae2b28f9db812#304b026ea0b5da12507e1410e8dae2b28f9db812"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -2873,7 +2873,7 @@ dependencies = [
 [[package]]
 name = "eth2"
 version = "0.1.0"
-source = "git+https://github.com/ltitanb/lighthouse?rev=8cb40ed6adf6c22096f000e4a01c125b9b0a1ef6#8cb40ed6adf6c22096f000e4a01c125b9b0a1ef6"
+source = "git+https://github.com/ltitanb/lighthouse?rev=304b026ea0b5da12507e1410e8dae2b28f9db812#304b026ea0b5da12507e1410e8dae2b28f9db812"
 dependencies = [
  "derivative",
  "either",
@@ -2905,7 +2905,7 @@ dependencies = [
 [[package]]
 name = "eth2_interop_keypairs"
 version = "0.2.0"
-source = "git+https://github.com/ltitanb/lighthouse?rev=8cb40ed6adf6c22096f000e4a01c125b9b0a1ef6#8cb40ed6adf6c22096f000e4a01c125b9b0a1ef6"
+source = "git+https://github.com/ltitanb/lighthouse?rev=304b026ea0b5da12507e1410e8dae2b28f9db812#304b026ea0b5da12507e1410e8dae2b28f9db812"
 dependencies = [
  "bls",
  "ethereum_hashing",
@@ -2918,7 +2918,7 @@ dependencies = [
 [[package]]
 name = "eth2_key_derivation"
 version = "0.1.0"
-source = "git+https://github.com/ltitanb/lighthouse?rev=8cb40ed6adf6c22096f000e4a01c125b9b0a1ef6#8cb40ed6adf6c22096f000e4a01c125b9b0a1ef6"
+source = "git+https://github.com/ltitanb/lighthouse?rev=304b026ea0b5da12507e1410e8dae2b28f9db812#304b026ea0b5da12507e1410e8dae2b28f9db812"
 dependencies = [
  "bls",
  "num-bigint-dig",
@@ -2930,7 +2930,7 @@ dependencies = [
 [[package]]
 name = "eth2_keystore"
 version = "0.1.0"
-source = "git+https://github.com/ltitanb/lighthouse?rev=8cb40ed6adf6c22096f000e4a01c125b9b0a1ef6#8cb40ed6adf6c22096f000e4a01c125b9b0a1ef6"
+source = "git+https://github.com/ltitanb/lighthouse?rev=304b026ea0b5da12507e1410e8dae2b28f9db812#304b026ea0b5da12507e1410e8dae2b28f9db812"
 dependencies = [
  "aes 0.7.5",
  "bls",
@@ -3466,7 +3466,7 @@ dependencies = [
 [[package]]
 name = "filesystem"
 version = "0.1.0"
-source = "git+https://github.com/ltitanb/lighthouse?rev=8cb40ed6adf6c22096f000e4a01c125b9b0a1ef6#8cb40ed6adf6c22096f000e4a01c125b9b0a1ef6"
+source = "git+https://github.com/ltitanb/lighthouse?rev=304b026ea0b5da12507e1410e8dae2b28f9db812#304b026ea0b5da12507e1410e8dae2b28f9db812"
 dependencies = [
  "winapi",
  "windows-acl",
@@ -3487,7 +3487,7 @@ dependencies = [
 [[package]]
 name = "fixed_bytes"
 version = "0.1.0"
-source = "git+https://github.com/ltitanb/lighthouse?rev=8cb40ed6adf6c22096f000e4a01c125b9b0a1ef6#8cb40ed6adf6c22096f000e4a01c125b9b0a1ef6"
+source = "git+https://github.com/ltitanb/lighthouse?rev=304b026ea0b5da12507e1410e8dae2b28f9db812#304b026ea0b5da12507e1410e8dae2b28f9db812"
 dependencies = [
  "alloy-primitives 0.8.25",
  "safe_arith",
@@ -4739,7 +4739,7 @@ dependencies = [
 [[package]]
 name = "int_to_bytes"
 version = "0.2.0"
-source = "git+https://github.com/ltitanb/lighthouse?rev=8cb40ed6adf6c22096f000e4a01c125b9b0a1ef6#8cb40ed6adf6c22096f000e4a01c125b9b0a1ef6"
+source = "git+https://github.com/ltitanb/lighthouse?rev=304b026ea0b5da12507e1410e8dae2b28f9db812#304b026ea0b5da12507e1410e8dae2b28f9db812"
 dependencies = [
  "bytes",
 ]
@@ -4907,7 +4907,7 @@ dependencies = [
 [[package]]
 name = "kzg"
 version = "0.1.0"
-source = "git+https://github.com/ltitanb/lighthouse?rev=8cb40ed6adf6c22096f000e4a01c125b9b0a1ef6#8cb40ed6adf6c22096f000e4a01c125b9b0a1ef6"
+source = "git+https://github.com/ltitanb/lighthouse?rev=304b026ea0b5da12507e1410e8dae2b28f9db812#304b026ea0b5da12507e1410e8dae2b28f9db812"
 dependencies = [
  "arbitrary",
  "c-kzg",
@@ -5150,7 +5150,7 @@ dependencies = [
 [[package]]
 name = "merkle_proof"
 version = "0.2.0"
-source = "git+https://github.com/ltitanb/lighthouse?rev=8cb40ed6adf6c22096f000e4a01c125b9b0a1ef6#8cb40ed6adf6c22096f000e4a01c125b9b0a1ef6"
+source = "git+https://github.com/ltitanb/lighthouse?rev=304b026ea0b5da12507e1410e8dae2b28f9db812#304b026ea0b5da12507e1410e8dae2b28f9db812"
 dependencies = [
  "alloy-primitives 0.8.25",
  "ethereum_hashing",
@@ -5184,7 +5184,7 @@ dependencies = [
 [[package]]
 name = "metrics"
 version = "0.2.0"
-source = "git+https://github.com/ltitanb/lighthouse?rev=8cb40ed6adf6c22096f000e4a01c125b9b0a1ef6#8cb40ed6adf6c22096f000e4a01c125b9b0a1ef6"
+source = "git+https://github.com/ltitanb/lighthouse?rev=304b026ea0b5da12507e1410e8dae2b28f9db812#304b026ea0b5da12507e1410e8dae2b28f9db812"
 dependencies = [
  "prometheus",
 ]
@@ -6040,7 +6040,7 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 [[package]]
 name = "pretty_reqwest_error"
 version = "0.1.0"
-source = "git+https://github.com/ltitanb/lighthouse?rev=8cb40ed6adf6c22096f000e4a01c125b9b0a1ef6#8cb40ed6adf6c22096f000e4a01c125b9b0a1ef6"
+source = "git+https://github.com/ltitanb/lighthouse?rev=304b026ea0b5da12507e1410e8dae2b28f9db812#304b026ea0b5da12507e1410e8dae2b28f9db812"
 dependencies = [
  "reqwest 0.11.27",
  "sensitive_url",
@@ -6246,7 +6246,7 @@ dependencies = [
 [[package]]
 name = "proto_array"
 version = "0.2.0"
-source = "git+https://github.com/ltitanb/lighthouse?rev=8cb40ed6adf6c22096f000e4a01c125b9b0a1ef6#8cb40ed6adf6c22096f000e4a01c125b9b0a1ef6"
+source = "git+https://github.com/ltitanb/lighthouse?rev=304b026ea0b5da12507e1410e8dae2b28f9db812#304b026ea0b5da12507e1410e8dae2b28f9db812"
 dependencies = [
  "ethereum_ssz",
  "ethereum_ssz_derive",
@@ -6995,7 +6995,7 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 [[package]]
 name = "safe_arith"
 version = "0.1.0"
-source = "git+https://github.com/ltitanb/lighthouse?rev=8cb40ed6adf6c22096f000e4a01c125b9b0a1ef6#8cb40ed6adf6c22096f000e4a01c125b9b0a1ef6"
+source = "git+https://github.com/ltitanb/lighthouse?rev=304b026ea0b5da12507e1410e8dae2b28f9db812#304b026ea0b5da12507e1410e8dae2b28f9db812"
 
 [[package]]
 name = "salsa20"
@@ -7210,7 +7210,7 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 [[package]]
 name = "sensitive_url"
 version = "0.1.0"
-source = "git+https://github.com/ltitanb/lighthouse?rev=8cb40ed6adf6c22096f000e4a01c125b9b0a1ef6#8cb40ed6adf6c22096f000e4a01c125b9b0a1ef6"
+source = "git+https://github.com/ltitanb/lighthouse?rev=304b026ea0b5da12507e1410e8dae2b28f9db812#304b026ea0b5da12507e1410e8dae2b28f9db812"
 dependencies = [
  "serde",
  "url",
@@ -7549,7 +7549,7 @@ dependencies = [
 [[package]]
 name = "slashing_protection"
 version = "0.1.0"
-source = "git+https://github.com/ltitanb/lighthouse?rev=8cb40ed6adf6c22096f000e4a01c125b9b0a1ef6#8cb40ed6adf6c22096f000e4a01c125b9b0a1ef6"
+source = "git+https://github.com/ltitanb/lighthouse?rev=304b026ea0b5da12507e1410e8dae2b28f9db812#304b026ea0b5da12507e1410e8dae2b28f9db812"
 dependencies = [
  "arbitrary",
  "ethereum_serde_utils",
@@ -7567,7 +7567,7 @@ dependencies = [
 [[package]]
 name = "slot_clock"
 version = "0.2.0"
-source = "git+https://github.com/ltitanb/lighthouse?rev=8cb40ed6adf6c22096f000e4a01c125b9b0a1ef6#8cb40ed6adf6c22096f000e4a01c125b9b0a1ef6"
+source = "git+https://github.com/ltitanb/lighthouse?rev=304b026ea0b5da12507e1410e8dae2b28f9db812#304b026ea0b5da12507e1410e8dae2b28f9db812"
 dependencies = [
  "metrics",
  "parking_lot",
@@ -7832,7 +7832,7 @@ dependencies = [
 [[package]]
 name = "swap_or_not_shuffle"
 version = "0.2.0"
-source = "git+https://github.com/ltitanb/lighthouse?rev=8cb40ed6adf6c22096f000e4a01c125b9b0a1ef6#8cb40ed6adf6c22096f000e4a01c125b9b0a1ef6"
+source = "git+https://github.com/ltitanb/lighthouse?rev=304b026ea0b5da12507e1410e8dae2b28f9db812#304b026ea0b5da12507e1410e8dae2b28f9db812"
 dependencies = [
  "alloy-primitives 0.8.25",
  "ethereum_hashing",
@@ -7971,7 +7971,7 @@ dependencies = [
 [[package]]
 name = "test_random_derive"
 version = "0.2.0"
-source = "git+https://github.com/ltitanb/lighthouse?rev=8cb40ed6adf6c22096f000e4a01c125b9b0a1ef6#8cb40ed6adf6c22096f000e4a01c125b9b0a1ef6"
+source = "git+https://github.com/ltitanb/lighthouse?rev=304b026ea0b5da12507e1410e8dae2b28f9db812#304b026ea0b5da12507e1410e8dae2b28f9db812"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -8640,7 +8640,7 @@ checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 [[package]]
 name = "types"
 version = "0.2.1"
-source = "git+https://github.com/ltitanb/lighthouse?rev=8cb40ed6adf6c22096f000e4a01c125b9b0a1ef6#8cb40ed6adf6c22096f000e4a01c125b9b0a1ef6"
+source = "git+https://github.com/ltitanb/lighthouse?rev=304b026ea0b5da12507e1410e8dae2b28f9db812#304b026ea0b5da12507e1410e8dae2b28f9db812"
 dependencies = [
  "alloy-primitives 0.8.25",
  "alloy-rlp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,12 +59,12 @@ http = "1.0.0"
 httpmock = "0.7.0"
 hyper = "1.1.0"
 lazy_static = "1.5.0"
-lh-bls = { package = "bls", git = "https://github.com/ltitanb/lighthouse", rev = "8cb40ed6adf6c22096f000e4a01c125b9b0a1ef6" }
-lh-eth2 = { package = "eth2", git = "https://github.com/ltitanb/lighthouse", rev = "8cb40ed6adf6c22096f000e4a01c125b9b0a1ef6" }
-lh-kzg = { package = "kzg", git = "https://github.com/ltitanb/lighthouse", rev = "8cb40ed6adf6c22096f000e4a01c125b9b0a1ef6" }
-lh-slot-clock = { package = "slot_clock", git = "https://github.com/ltitanb/lighthouse", rev = "8cb40ed6adf6c22096f000e4a01c125b9b0a1ef6" }
-lh-test-random = { package = "test_random_derive", git = "https://github.com/ltitanb/lighthouse", rev = "8cb40ed6adf6c22096f000e4a01c125b9b0a1ef6" }
-lh-types = { package = "types", git = "https://github.com/ltitanb/lighthouse", rev = "8cb40ed6adf6c22096f000e4a01c125b9b0a1ef6" }
+lh-bls = { package = "bls", git = "https://github.com/ltitanb/lighthouse", rev = "304b026ea0b5da12507e1410e8dae2b28f9db812" }
+lh-eth2 = { package = "eth2", git = "https://github.com/ltitanb/lighthouse", rev = "304b026ea0b5da12507e1410e8dae2b28f9db812" }
+lh-kzg = { package = "kzg", git = "https://github.com/ltitanb/lighthouse", rev = "304b026ea0b5da12507e1410e8dae2b28f9db812" }
+lh-slot-clock = { package = "slot_clock", git = "https://github.com/ltitanb/lighthouse", rev = "304b026ea0b5da12507e1410e8dae2b28f9db812" }
+lh-test-random = { package = "test_random_derive", git = "https://github.com/ltitanb/lighthouse", rev = "304b026ea0b5da12507e1410e8dae2b28f9db812" }
+lh-types = { package = "types", git = "https://github.com/ltitanb/lighthouse", rev = "304b026ea0b5da12507e1410e8dae2b28f9db812" }
 mockito = "1.1.1"
 moka = "0.9"
 num-format = "0.4.4"

--- a/crates/common/src/bid_submission/v2/header_submission.rs
+++ b/crates/common/src/bid_submission/v2/header_submission.rs
@@ -6,13 +6,10 @@ use helix_types::{
     TestRandom,
 };
 use ssz_derive::{Decode, Encode};
-use tree_hash_derive::TreeHash;
 
 use crate::bid_submission::{BidSubmission, BidTrace, BidValidationError};
 
-#[derive(
-    Debug, Clone, serde::Serialize, serde::Deserialize, Encode, Decode, TreeHash, TestRandom,
-)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Encode, Decode, TestRandom)]
 pub struct HeaderSubmissionDeneb {
     pub bid_trace: BidTrace,
     pub execution_payload_header: ExecutionPayloadHeaderDeneb,
@@ -21,9 +18,7 @@ pub struct HeaderSubmissionDeneb {
 
 pub type SignedHeaderSubmissionDeneb = SignedMessage<HeaderSubmissionDeneb>;
 
-#[derive(
-    Debug, Clone, serde::Serialize, serde::Deserialize, Encode, Decode, TreeHash, TestRandom,
-)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Encode, Decode, TestRandom)]
 pub struct HeaderSubmissionElectra {
     pub bid_trace: BidTrace,
     pub execution_payload_header: ExecutionPayloadHeaderElectra,

--- a/crates/common/src/bid_submission/v3/header_submission_v3.rs
+++ b/crates/common/src/bid_submission/v3/header_submission_v3.rs
@@ -123,6 +123,8 @@ pub struct GetPayloadV3 {
     pub relay_pubkey: BlsPublicKey,
 }
 
+impl helix_types::SignedRoot for GetPayloadV3 {}
+
 /// Builder block payload response.
 #[derive(Debug, serde::Deserialize, serde::Serialize, Encode, Decode)]
 pub struct SignedGetPayloadV3 {

--- a/crates/database/src/postgres/postgres_db_service_tests.rs
+++ b/crates/database/src/postgres/postgres_db_service_tests.rs
@@ -376,7 +376,7 @@ mod tests {
         assert!(result.is_ok());
 
         let result =
-            db_service.db_demote_builder(&public_key, &Default::default(), "".to_string()).await;
+            db_service.db_demote_builder(0, &public_key, &Default::default(), "".to_string()).await;
         assert!(result.is_ok());
     }
 

--- a/crates/types/src/bid_submission.rs
+++ b/crates/types/src/bid_submission.rs
@@ -41,6 +41,8 @@ pub struct BidTrace {
     pub value: U256,
 }
 
+impl SignedRoot for BidTrace {}
+
 impl BidTrace {
     pub fn slot(&self) -> Slot {
         Slot::from(self.slot)

--- a/crates/types/src/validator.rs
+++ b/crates/types/src/validator.rs
@@ -24,6 +24,8 @@ pub struct ValidatorRegistrationData {
     pub pubkey: PublicKey,
 }
 
+impl SignedRoot for ValidatorRegistrationData {}
+
 impl SignedValidatorRegistrationData {
     pub fn verify_signature(&self, spec: &ChainSpec) -> bool {
         let domain = spec.get_builder_domain();
@@ -36,9 +38,7 @@ impl SignedValidatorRegistrationData {
 /// Information about a `BeaconChain` validator.
 ///
 /// Spec v0.12.1
-#[derive(
-    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom,
-)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Encode, Decode, TestRandom)]
 pub struct Validator {
     pub pubkey: PublicKey,
     pub withdrawal_credentials: B256,


### PR DESCRIPTION
Follow same approach as LH and only implement `SignedRoot` for types we actually have to sign.
ref https://github.com/sigp/lighthouse/pull/7367