### PR TITLE
feat: change API for inclusion list node to not include metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4132,6 +4132,7 @@ dependencies = [
  "httpmock",
  "parking_lot",
  "reqwest 0.11.27",
+ "serde",
  "serde_json",
  "thiserror 1.0.69",
  "tokio",

--- a/crates/api/src/builder/api.rs
+++ b/crates/api/src/builder/api.rs
@@ -296,7 +296,7 @@ impl<A: Api> BuilderApi<A> {
         debug!(timestamp_before_validation = utcnow_ns());
 
         let current_slot_coord = get_slot_coordinate(
-            payload.slot().as_u64() as i32,
+            payload.slot().as_u64(),
             payload.proposer_public_key(),
             payload.parent_hash(),
         );

--- a/crates/api/src/builder/inclusion_list.rs
+++ b/crates/api/src/builder/inclusion_list.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use axum::{extract::Path, response::IntoResponse, Extension};
-use helix_common::utils::get_slot_coordinate;
+use helix_common::{api::builder_api::InclusionList, utils::get_slot_coordinate};
 use helix_datastore::types::keys::inclusion_list_key;
 use hyper::StatusCode;
 use tracing::debug;
@@ -32,7 +32,8 @@ impl<A: Api> BuilderApi<A> {
         let requested_key = inclusion_list_key(&requested_slot_coordinate);
 
         if current_list.key == requested_key {
-            Ok((StatusCode::OK, axum::Json(current_list.inclusion_list.clone())).into_response())
+            let response_payload = InclusionList::from(&current_list.inclusion_list);
+            Ok((StatusCode::OK, axum::Json(response_payload)).into_response())
         } else {
             debug!(requested_slot = %slot, pub_key = %pub_key, parent_hash = %parent_hash,
                 "Requested inclusion list for a slot in the past. Current slot: {}",

--- a/crates/api/src/builder/inclusion_list.rs
+++ b/crates/api/src/builder/inclusion_list.rs
@@ -4,7 +4,7 @@ use axum::{extract::Path, response::IntoResponse, Extension};
 use helix_common::utils::get_slot_coordinate;
 use helix_datastore::types::keys::inclusion_list_key;
 use hyper::StatusCode;
-use tracing::info;
+use tracing::debug;
 
 use super::{api::BuilderApi, error::BuilderApiError, InclusionListPathParams};
 use crate::Api;
@@ -15,19 +15,17 @@ impl<A: Api> BuilderApi<A> {
         Extension(api): Extension<Arc<BuilderApi<A>>>,
         Path(InclusionListPathParams { slot, parent_hash, pub_key }): Path<InclusionListPathParams>,
     ) -> Result<impl IntoResponse, BuilderApiError> {
-        info!(requested_slot = %slot, pub_key = %pub_key, parent_hash = %parent_hash,
-            "Request for inclusion list."
+        debug!(requested_slot = %slot, pub_key = %pub_key, parent_hash = %parent_hash,
+            "New request for inclusion list."
         );
 
         let current_list = api.current_inclusion_list.read();
 
         let Some(current_list) = current_list.as_ref() else {
-            info!(requested_slot = %slot, pub_key = %pub_key, parent_hash = %parent_hash,
+            debug!(requested_slot = %slot, pub_key = %pub_key, parent_hash = %parent_hash,
                 "Builder has requested an inclusion list but none has been found in redis."
             );
-            return Ok(
-                (StatusCode::NOT_FOUND, "No inclusion lists have been generated").into_response()
-            );
+            return Ok(StatusCode::NOT_FOUND.into_response());
         };
 
         let requested_slot_coordinate = get_slot_coordinate(slot as i32, &pub_key, &parent_hash);
@@ -36,15 +34,12 @@ impl<A: Api> BuilderApi<A> {
         if current_list.key == requested_key {
             Ok((StatusCode::OK, axum::Json(current_list.inclusion_list.clone())).into_response())
         } else {
-            info!(requested_slot = %slot, pub_key = %pub_key, parent_hash = %parent_hash,
+            debug!(requested_slot = %slot, pub_key = %pub_key, parent_hash = %parent_hash,
                 "Requested inclusion list for a slot in the past. Current slot: {}",
                 api.curr_slot_info.head_slot()
             );
-            let response = format!(
-                "Requested inclusion list for slot in the past. Current (slot, parent_hash, pubkey): {}, Requested (slot, parent_hash, pubkey): {}",
-                current_list.key, requested_slot_coordinate
-            );
-            Ok((StatusCode::NOT_FOUND, response).into_response())
+
+            Ok(StatusCode::NOT_FOUND.into_response())
         }
     }
 }

--- a/crates/api/src/builder/inclusion_list.rs
+++ b/crates/api/src/builder/inclusion_list.rs
@@ -28,7 +28,7 @@ impl<A: Api> BuilderApi<A> {
             return Ok(StatusCode::NOT_FOUND.into_response());
         };
 
-        let requested_slot_coordinate = get_slot_coordinate(slot as i32, &pub_key, &parent_hash);
+        let requested_slot_coordinate = get_slot_coordinate(slot, &pub_key, &parent_hash);
         let requested_key = inclusion_list_key(&requested_slot_coordinate);
 
         if current_list.key == requested_key {

--- a/crates/api/src/builder/simulator/mod.rs
+++ b/crates/api/src/builder/simulator/mod.rs
@@ -13,7 +13,8 @@ use std::sync::Arc;
 
 use alloy_primitives::B256;
 use helix_common::{
-    api::builder_api::InclusionList, bid_submission::BidSubmission, ValidatorPreferences,
+    api::builder_api::InclusionListWithMetadata, bid_submission::BidSubmission,
+    ValidatorPreferences,
 };
 use helix_types::{
     BidTrace, BlobsBundle, BlsSignature, ExecutionPayload, ExecutionRequests, SignedBidSubmission,
@@ -30,7 +31,7 @@ pub struct BlockSimRequest {
     pub blobs_bundle: Option<BlobsBundle>,
     pub execution_requests: Option<ExecutionRequests>,
     pub parent_beacon_block_root: Option<B256>,
-    pub inclusion_list: Option<InclusionList>,
+    pub inclusion_list: Option<InclusionListWithMetadata>,
 }
 
 impl BlockSimRequest {
@@ -39,7 +40,7 @@ impl BlockSimRequest {
         block: Arc<SignedBidSubmission>,
         proposer_preferences: ValidatorPreferences,
         parent_beacon_block_root: Option<B256>,
-        inclusion_list: Option<InclusionList>,
+        inclusion_list: Option<InclusionListWithMetadata>,
     ) -> Self {
         Self {
             registered_gas_limit,

--- a/crates/common/src/api/builder_api.rs
+++ b/crates/common/src/api/builder_api.rs
@@ -70,7 +70,7 @@ impl TryFrom<InclusionList> for InclusionListWithMetadata {
         for encoded_tx in inclusion_list.txs {
             let decoded_tx = TxEnvelope::decode(&mut encoded_tx.iter().as_slice())?;
             let tx_with_md = InclusionListTxWithMetadata {
-                hash: decoded_tx.hash().clone(),
+                hash: *decoded_tx.hash(),
                 nonce: decoded_tx.nonce(),
                 sender: decoded_tx.recover_signer()?,
                 gas_priority_fee: decoded_tx

--- a/crates/common/src/api/builder_api.rs
+++ b/crates/common/src/api/builder_api.rs
@@ -50,12 +50,6 @@ pub struct InclusionList {
     pub txs: Vec<InclusionListTx>,
 }
 
-impl InclusionList {
-    pub const fn empty() -> Self {
-        Self { txs: vec![] }
-    }
-}
-
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct InclusionListTx {
     pub hash: B256,

--- a/crates/common/src/api/builder_api.rs
+++ b/crates/common/src/api/builder_api.rs
@@ -68,7 +68,7 @@ impl TryFrom<InclusionList> for InclusionListWithMetadata {
         let mut txs = Vec::with_capacity(inclusion_list.txs.len());
 
         for encoded_tx in inclusion_list.txs {
-            let decoded_tx = TxEnvelope::decode(&mut encoded_tx.iter().as_slice())?;
+            let decoded_tx = TxEnvelope::decode(&mut &encoded_tx[..])?;
             let tx_with_md = InclusionListTxWithMetadata {
                 hash: *decoded_tx.hash(),
                 nonce: decoded_tx.nonce(),

--- a/crates/common/src/api/builder_api.rs
+++ b/crates/common/src/api/builder_api.rs
@@ -68,7 +68,7 @@ impl TryFrom<InclusionList> for InclusionListWithMetadata {
         let mut txs = Vec::with_capacity(inclusion_list.txs.len());
 
         for encoded_tx in inclusion_list.txs {
-            let decoded_tx = TxEnvelope::decode(&mut &encoded_tx[..])?;
+            let decoded_tx = TxEnvelope::decode(&mut encoded_tx.as_ref())?;
             let tx_with_md = InclusionListTxWithMetadata {
                 hash: *decoded_tx.hash(),
                 nonce: decoded_tx.nonce(),

--- a/crates/common/src/api/builder_api.rs
+++ b/crates/common/src/api/builder_api.rs
@@ -1,4 +1,6 @@
-use alloy_primitives::{bytes::Bytes, Address, B256, U256};
+use alloy_consensus::{Transaction, TxEnvelope};
+use alloy_primitives::{Address, Bytes, SignatureError, B256, U256};
+use alloy_rlp::Decodable;
 use helix_types::{BlsPublicKey, SignedValidatorRegistration, Slot, TestRandom};
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
@@ -45,17 +47,92 @@ pub struct TopBidUpdate {
     pub value: U256,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct InclusionList {
-    pub txs: Vec<InclusionListTx>,
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct InclusionListTx {
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub struct InclusionListTxWithMetadata {
     pub hash: B256,
     pub nonce: u64,
     pub sender: Address,
-    pub gas_priority_fee: u64,
+    pub gas_priority_fee: u128,
     pub bytes: Bytes,
-    pub wait_time: u32,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct InclusionListWithMetadata {
+    pub txs: Vec<InclusionListTxWithMetadata>,
+}
+
+impl TryFrom<InclusionList> for InclusionListWithMetadata {
+    type Error = InclusionListError;
+
+    fn try_from(inclusion_list: InclusionList) -> Result<Self, Self::Error> {
+        let mut txs = Vec::with_capacity(inclusion_list.txs.len());
+
+        for encoded_tx in inclusion_list.txs {
+            let decoded_tx = TxEnvelope::decode(&mut encoded_tx.iter().as_slice())?;
+            let tx_with_md = InclusionListTxWithMetadata {
+                hash: decoded_tx.hash().clone(),
+                nonce: decoded_tx.nonce(),
+                sender: decoded_tx.recover_signer()?,
+                gas_priority_fee: decoded_tx
+                    .max_priority_fee_per_gas()
+                    .ok_or(InclusionListError::MissingPriorityFee)?,
+                bytes: encoded_tx,
+            };
+
+            txs.push(tx_with_md);
+        }
+
+        Ok(Self { txs })
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum InclusionListError {
+    #[error("Failed to decode transaction: {0}")]
+    TransactionDecode(#[from] alloy_rlp::Error),
+    #[error("Failed to recover signer: {0}")]
+    TransactionError(#[from] SignatureError),
+    #[error("Transaction missing max priority fee")]
+    MissingPriorityFee,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct InclusionList {
+    pub txs: Vec<Bytes>,
+}
+
+impl From<&InclusionListWithMetadata> for InclusionList {
+    fn from(value: &InclusionListWithMetadata) -> Self {
+        InclusionList { txs: value.txs.iter().map(|tx| tx.bytes.clone()).collect() }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{Address, Bytes, B256};
+
+    use super::{InclusionList, InclusionListWithMetadata};
+    use crate::api::builder_api::InclusionListTxWithMetadata;
+
+    #[test]
+    fn derive_rlp_bytes_to_inclusion_list_with_metadata() {
+        let il: InclusionList = InclusionList { txs: vec![
+                "0x02f87582426801850221646a70850221646a7082520894acabf6c2d38973a5f2ebab6b5e85623db1005a4e880ddf2f839aa3d97080c080a0088ae2635655e314949dae343ac296c3fb6ac56802e1024639f9603c61e253669f2bf33fe18ce70520abc6a662794c1ef5bb310248b7b7c4acc6be93e7885d62".parse::<Bytes>().unwrap(),
+                "0x02f8b5824268820130850239465d16850239465d1682728a9494373a4919b3240d86ea41593d5eba789fef384880b844095ea7b30000000000000000000000005fbe74a283f7954f10aa04c2edf55578811aeb03000000000000000000000000000000000000000000000000000009184e72a000c080a0a6d0c20df1f0582c0dbf62a125fc1874868106d845c3916d666441973fb29ff0a04f4ce8879bd85510c82246de9a58a5a705dc672b6d89cc8183544f2db8649ea9".parse::<Bytes>().unwrap(),
+                "0x02f8b48242688193850232306c41850232306c4182739294685ce6742351ae9b618f383883d6d1e0c5a31b4b80b844095ea7b30000000000000000000000005fbe74a283f7954f10aa04c2edf55578811aeb030000000000000000000000000000000000000000000000000de0b6b3a7640000c001a0bda9b5171b2e0d3ceceebfa4de504485bd6a8fd5041251fcd2d4aed24a65ab4ca0369e2d4bcc7ef790e64195578005c8a6c3313dd0b0bc105856d0202a4e230de9".parse::<Bytes>().unwrap(),
+            ] };
+        let il_len = il.txs.len();
+        let il_w_md = InclusionListWithMetadata::try_from(il).unwrap();
+
+        assert_eq!(il_len, il_w_md.txs.len());
+        assert_eq!(il_w_md.txs[0], InclusionListTxWithMetadata {
+            hash: "0x80e000dd49cd0c518e8e426cf00daeebbae81ee79e0bb669601a329d1cafa6c2"
+                .parse::<B256>()
+                .unwrap(),
+            nonce: 1,
+            sender: "0x384b9b5024f0f40b9f595284b14746e1b271e181".parse::<Address>().unwrap(),
+            gas_priority_fee: 9150163568,
+            bytes: "0x02f87582426801850221646a70850221646a7082520894acabf6c2d38973a5f2ebab6b5e85623db1005a4e880ddf2f839aa3d97080c080a0088ae2635655e314949dae343ac296c3fb6ac56802e1024639f9603c61e253669f2bf33fe18ce70520abc6a662794c1ef5bb310248b7b7c4acc6be93e7885d62".parse::<Bytes>().unwrap()
+        });
+    }
 }

--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -461,19 +461,11 @@ fn test_config() {
 
 #[derive(Clone, Deserialize, Serialize)]
 pub struct InclusionListConfig {
-    pub node: Url,
-    pub max_size_bytes: usize,
-    pub wait_time_tx_score_weight: u32,
-    pub priority_fee_tx_score_weight: u32,
+    pub node_url: Url,
 }
 
 impl Default for InclusionListConfig {
     fn default() -> Self {
-        Self {
-            node: Url::from_str("http://please-set-node-url-in-confg.invalid").unwrap(),
-            max_size_bytes: 8192,
-            wait_time_tx_score_weight: 1,
-            priority_fee_tx_score_weight: 1,
-        }
+        Self { node_url: Url::from_str("http://please-set-node-url-in-confg.invalid").unwrap() }
     }
 }

--- a/crates/common/src/utils.rs
+++ b/crates/common/src/utils.rs
@@ -163,7 +163,7 @@ pub fn utcnow_ns() -> u64 {
 
 #[inline(always)]
 pub fn get_slot_coordinate(
-    slot: i32,
+    slot: u64,
     proposer_pub_key: &BlsPublicKey,
     parent_hash: &B256,
 ) -> String {

--- a/crates/database/src/mock_database_service.rs
+++ b/crates/database/src/mock_database_service.rs
@@ -299,7 +299,7 @@ impl DatabaseService for MockDatabaseService {
     async fn save_inclusion_list(
         &self,
         _: &InclusionListWithMetadata,
-        _: i32,
+        _: u64,
     ) -> Result<(), Vec<DatabaseError>> {
         Ok(())
     }

--- a/crates/database/src/mock_database_service.rs
+++ b/crates/database/src/mock_database_service.rs
@@ -7,7 +7,7 @@ use alloy_primitives::{Address, B256, U256};
 use async_trait::async_trait;
 use helix_common::{
     api::{
-        builder_api::{BuilderGetValidatorsResponseEntry, InclusionList},
+        builder_api::{BuilderGetValidatorsResponseEntry, InclusionListWithMetadata},
         data_api::BidFilters,
         proposer_api::ValidatorRegistrationInfo,
     },
@@ -298,7 +298,7 @@ impl DatabaseService for MockDatabaseService {
 
     async fn save_inclusion_list(
         &self,
-        _: &InclusionList,
+        _: &InclusionListWithMetadata,
         _: i32,
     ) -> Result<(), Vec<DatabaseError>> {
         Ok(())

--- a/crates/database/src/postgres/migrations/V32__inclusion_lists.sql
+++ b/crates/database/src/postgres/migrations/V32__inclusion_lists.sql
@@ -10,6 +10,5 @@ CREATE TABLE "inclusion_list_txs" (
     "nonce" integer NOT NULL,
     "gas_priority_fee" integer NOT NULL,
     "sender" bytea NOT NULL,
-    "wait_time" BIGINT NOT NULL,
     "slot_included" integer NOT NULL
 );

--- a/crates/database/src/postgres/migrations/V32__inclusion_lists.sql
+++ b/crates/database/src/postgres/migrations/V32__inclusion_lists.sql
@@ -7,8 +7,8 @@ ADD COLUMN "disable_inclusion_lists" boolean NOT NULL DEFAULT false;
 CREATE TABLE "inclusion_list_txs" (
     "tx_hash" bytea NOT NULL PRIMARY KEY,
     "bytes" bytea NOT NULL,
-    "nonce" integer NOT NULL,
-    "gas_priority_fee" integer NOT NULL,
+    "nonce" bigint NOT NULL,
+    "gas_priority_fee" bigint NOT NULL,
     "sender" bytea NOT NULL,
-    "slot_included" integer NOT NULL
+    "slot_included" bigint NOT NULL
 );

--- a/crates/database/src/postgres/postgres_db_service.rs
+++ b/crates/database/src/postgres/postgres_db_service.rs
@@ -1796,7 +1796,7 @@ impl DatabaseService for PostgresDatabaseService {
     async fn save_inclusion_list(
         &self,
         inclusion_list: &InclusionListWithMetadata,
-        slot_number: i32,
+        slot_number: u64,
     ) -> Result<(), Vec<DatabaseError>> {
         let mut record = DbMetricRecord::new("save_inclusion_list");
         let client = self.pool.get().await.map_err(|err| vec![err.into()])?;
@@ -1816,10 +1816,10 @@ impl DatabaseService for PostgresDatabaseService {
                 &[
                     &(tx.hash.as_slice()),
                     &(tx.bytes.iter().as_slice()),
-                    &(tx.nonce as i32),
-                    &(tx.gas_priority_fee as i32),
+                    &(tx.nonce as i64),
+                    &(tx.gas_priority_fee as i64),
                     &(tx.sender.as_slice()),
-                    &(slot_number),
+                    &(slot_number as i64),
                 ],
             ).await;
 

--- a/crates/database/src/postgres/postgres_db_service.rs
+++ b/crates/database/src/postgres/postgres_db_service.rs
@@ -6,7 +6,7 @@ use dashmap::{DashMap, DashSet};
 use deadpool_postgres::{Config, GenericClient, ManagerConfig, Pool, RecyclingMethod};
 use helix_common::{
     api::{
-        builder_api::{BuilderGetValidatorsResponseEntry, InclusionList},
+        builder_api::{BuilderGetValidatorsResponseEntry, InclusionListWithMetadata},
         data_api::BidFilters,
         proposer_api::ValidatorRegistrationInfo,
     },
@@ -1795,25 +1795,22 @@ impl DatabaseService for PostgresDatabaseService {
 
     async fn save_inclusion_list(
         &self,
-        inclusion_list: &InclusionList,
+        inclusion_list: &InclusionListWithMetadata,
         slot_number: i32,
     ) -> Result<(), Vec<DatabaseError>> {
         let mut record = DbMetricRecord::new("save_inclusion_list");
-
         let client = self.pool.get().await.map_err(|err| vec![err.into()])?;
-
         let mut errors = vec![];
 
         for tx in &inclusion_list.txs {
             let result = client.execute(
                 "
                     INSERT INTO
-                        inclusion_list_txs (tx_hash, bytes, nonce, gas_priority_fee, sender, wait_time, slot_included)
+                        inclusion_list_txs (tx_hash, bytes, nonce, gas_priority_fee, sender, slot_included)
                     VALUES
-                        ($1, $2, $3, $4, $5, $6, $7)
+                        ($1, $2, $3, $4, $5, $6)
                     ON CONFLICT (tx_hash)
                     DO UPDATE SET
-                        wait_time = EXCLUDED.wait_time,
                         slot_included = EXCLUDED.slot_included
                 ",
                 &[
@@ -1822,7 +1819,6 @@ impl DatabaseService for PostgresDatabaseService {
                     &(tx.nonce as i32),
                     &(tx.gas_priority_fee as i32),
                     &(tx.sender.as_slice()),
-                    &(tx.wait_time as i64),
                     &(slot_number),
                 ],
             ).await;

--- a/crates/database/src/postgres/postgres_db_service_tests.rs
+++ b/crates/database/src/postgres/postgres_db_service_tests.rs
@@ -574,6 +574,7 @@ mod tests {
             .store_header_submission(
                 Arc::new(signed_bid_submission),
                 HeaderSubmissionTrace::default(),
+                None,
             )
             .await?;
         Ok(())

--- a/crates/database/src/traits.rs
+++ b/crates/database/src/traits.rs
@@ -4,7 +4,7 @@ use alloy_primitives::B256;
 use async_trait::async_trait;
 use helix_common::{
     api::{
-        builder_api::{BuilderGetValidatorsResponseEntry, InclusionList},
+        builder_api::{BuilderGetValidatorsResponseEntry, InclusionListWithMetadata},
         data_api::BidFilters,
         proposer_api::ValidatorRegistrationInfo,
     },
@@ -184,7 +184,7 @@ pub trait DatabaseService: Send + Sync + Clone {
 
     async fn save_inclusion_list(
         &self,
-        inclusion_list: &InclusionList,
+        inclusion_list: &InclusionListWithMetadata,
         slot_number: i32,
     ) -> Result<(), Vec<DatabaseError>>;
 }

--- a/crates/database/src/traits.rs
+++ b/crates/database/src/traits.rs
@@ -185,6 +185,6 @@ pub trait DatabaseService: Send + Sync + Clone {
     async fn save_inclusion_list(
         &self,
         inclusion_list: &InclusionListWithMetadata,
-        slot_number: i32,
+        slot_number: u64,
     ) -> Result<(), Vec<DatabaseError>>;
 }

--- a/crates/datastore/src/auctioneer/mock_auctioneer.rs
+++ b/crates/datastore/src/auctioneer/mock_auctioneer.rs
@@ -3,7 +3,7 @@ use std::sync::{atomic::AtomicBool, Arc, Mutex};
 use alloy_primitives::{bytes::Bytes, B256, U256};
 use async_trait::async_trait;
 use helix_common::{
-    api::builder_api::{InclusionList, TopBidUpdate},
+    api::builder_api::{InclusionListWithMetadata, TopBidUpdate},
     bid_submission::v2::header_submission::SignedHeaderSubmission,
     pending_block::PendingBlock,
     signing::RelaySigningContext,
@@ -325,7 +325,7 @@ impl Auctioneer for MockAuctioneer {
 
     async fn update_current_inclusion_list(
         &self,
-        _: InclusionList,
+        _: InclusionListWithMetadata,
         _: String,
     ) -> Result<(), AuctioneerError> {
         Ok(())
@@ -335,7 +335,7 @@ impl Auctioneer for MockAuctioneer {
         let (tx, rx) = broadcast::channel(1);
         tx.send(InclusionListWithKey {
             key: "".into(),
-            inclusion_list: InclusionList { txs: vec![] },
+            inclusion_list: InclusionListWithMetadata { txs: vec![] },
         })
         .unwrap();
         rx

--- a/crates/datastore/src/auctioneer/mock_auctioneer.rs
+++ b/crates/datastore/src/auctioneer/mock_auctioneer.rs
@@ -333,8 +333,11 @@ impl Auctioneer for MockAuctioneer {
 
     fn get_inclusion_list(&self) -> broadcast::Receiver<InclusionListWithKey> {
         let (tx, rx) = broadcast::channel(1);
-        tx.send(InclusionListWithKey { key: "".into(), inclusion_list: InclusionList::empty() })
-            .unwrap();
+        tx.send(InclusionListWithKey {
+            key: "".into(),
+            inclusion_list: InclusionList { txs: vec![] },
+        })
+        .unwrap();
         rx
     }
 }

--- a/crates/datastore/src/auctioneer/traits.rs
+++ b/crates/datastore/src/auctioneer/traits.rs
@@ -1,7 +1,7 @@
 use alloy_primitives::{bytes::Bytes, B256, U256};
 use async_trait::async_trait;
 use helix_common::{
-    api::builder_api::InclusionList, bid_submission::v2::header_submission::SignedHeaderSubmission,
+    api::builder_api::InclusionListWithMetadata, bid_submission::v2::header_submission::SignedHeaderSubmission,
     builder_info::BuilderInfo, pending_block::PendingBlock, signing::RelaySigningContext,
     ProposerInfo,
 };
@@ -217,7 +217,7 @@ pub trait Auctioneer: Send + Sync + Clone {
 
     async fn update_current_inclusion_list(
         &self,
-        inclusion_list: InclusionList,
+        inclusion_list: InclusionListWithMetadata,
         slot_coordinate: String,
     ) -> Result<(), AuctioneerError>;
 

--- a/crates/datastore/src/auctioneer/traits.rs
+++ b/crates/datastore/src/auctioneer/traits.rs
@@ -1,9 +1,9 @@
 use alloy_primitives::{bytes::Bytes, B256, U256};
 use async_trait::async_trait;
 use helix_common::{
-    api::builder_api::InclusionListWithMetadata, bid_submission::v2::header_submission::SignedHeaderSubmission,
-    builder_info::BuilderInfo, pending_block::PendingBlock, signing::RelaySigningContext,
-    ProposerInfo,
+    api::builder_api::InclusionListWithMetadata,
+    bid_submission::v2::header_submission::SignedHeaderSubmission, builder_info::BuilderInfo,
+    pending_block::PendingBlock, signing::RelaySigningContext, ProposerInfo,
 };
 use helix_database::BuilderInfoDocument;
 use helix_types::{

--- a/crates/datastore/src/redis/redis_cache.rs
+++ b/crates/datastore/src/redis/redis_cache.rs
@@ -7,7 +7,7 @@ use async_trait::async_trait;
 use deadpool_redis::{Config, Connection, CreatePoolError, Pool, Runtime};
 use futures_util::StreamExt;
 use helix_common::{
-    api::builder_api::{InclusionList, TopBidUpdate},
+    api::builder_api::{InclusionListWithMetadata, TopBidUpdate},
     bid_submission::{v2::header_submission::SignedHeaderSubmission, BidSubmission},
     bid_submission_to_builder_bid, header_submission_to_builder_bid,
     metrics::{RedisMetricRecord, TopBidMetrics},
@@ -1416,7 +1416,7 @@ impl Auctioneer for RedisCache {
 
     async fn update_current_inclusion_list(
         &self,
-        inclusion_list: InclusionList,
+        inclusion_list: InclusionListWithMetadata,
         slot_coordinate: String,
     ) -> Result<(), AuctioneerError> {
         let mut record = RedisMetricRecord::new("update_current_inclusion_list");
@@ -1440,7 +1440,7 @@ impl Auctioneer for RedisCache {
 #[derive(Clone, Debug)]
 pub struct InclusionListWithKey {
     pub key: String,
-    pub inclusion_list: InclusionList,
+    pub inclusion_list: InclusionListWithMetadata,
 }
 
 fn get_top_bid(bid_values: &HashMap<String, U256>) -> Option<(String, U256)> {

--- a/crates/housekeeper/Cargo.toml
+++ b/crates/housekeeper/Cargo.toml
@@ -20,6 +20,7 @@ helix-types.workspace = true
 httpmock.workspace = true
 parking_lot.workspace = true
 reqwest.workspace = true
+serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 tokio.workspace = true

--- a/crates/housekeeper/src/chain_event_updater.rs
+++ b/crates/housekeeper/src/chain_event_updater.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, sync::Arc, time::Duration};
 use alloy_primitives::B256;
 use helix_beacon::types::{HeadEventData, PayloadAttributes, PayloadAttributesEvent};
 use helix_common::{
-    api::builder_api::BuilderGetValidatorsResponseEntry,
+    api::builder_api::{BuilderGetValidatorsResponseEntry, InclusionListWithMetadata},
     chain_info::ChainInfo,
     utils::{get_slot_coordinate, utcnow_sec},
     RelayConfig,
@@ -265,21 +265,28 @@ impl<D: DatabaseService + 'static, A: Auctioneer + 'static> ChainEventUpdater<D,
         pub_key: &BlsPublicKey,
         parent_hash: &B256,
     ) {
-        let inclusion_list_opt = tokio::select! {
+        let inclusion_list = tokio::select! {
             inclusion_list = self.inclusion_list_fetcher.fetch_inclusion_list_with_retry(self.head_slot) => {
-                Some(inclusion_list)
+                inclusion_list
             }
             _ = tokio::time::sleep(self.time_to_missing_inclusion_list_cutoff()) => {
                 warn!(head_slot = self.head_slot,
                     "No inclusion list for this slot. We have reached the {}s cutoff and have not been able to source one.",
                     MISSING_INCLUSION_LIST_CUTOFF.as_secs()
                 );
-                None
+                return;
             }
         };
 
-        let Some(inclusion_list) = inclusion_list_opt else {
-            return;
+        let inclusion_list = match InclusionListWithMetadata::try_from(inclusion_list) {
+            Ok(list) => list,
+            Err(err) => {
+                warn!(
+                    head_slot = self.head_slot,
+                    "Could not decode inclusion list RLP bytes. Error:{}", err
+                );
+                return;
+            }
         };
 
         let slot: i32 = self.head_slot.try_into().unwrap();

--- a/crates/housekeeper/src/chain_event_updater.rs
+++ b/crates/housekeeper/src/chain_event_updater.rs
@@ -289,7 +289,7 @@ impl<D: DatabaseService + 'static, A: Auctioneer + 'static> ChainEventUpdater<D,
             }
         };
 
-        let slot: i32 = self.head_slot.try_into().unwrap();
+        let slot = self.head_slot;
         let slot_coordinate = get_slot_coordinate(slot, pub_key, parent_hash);
 
         let db = self.database.clone();

--- a/crates/housekeeper/src/inclusion_list_fetcher.rs
+++ b/crates/housekeeper/src/inclusion_list_fetcher.rs
@@ -1,7 +1,10 @@
 use std::time::Duration;
 
+use alloy_primitives::Bytes;
 use helix_common::{api::builder_api::InclusionList, InclusionListConfig};
 use reqwest::{Client, ClientBuilder, StatusCode, Url};
+use serde::Deserialize;
+use serde_json::json;
 use thiserror::Error;
 use tracing::{info, warn};
 
@@ -43,12 +46,20 @@ impl InclusionListFetcher {
 
     async fn fetch_inclusion_list(
         &self,
-        node_url: Url,
+        inclusion_list_node_url: Url,
     ) -> Result<InclusionList, InclusionListError> {
-        let response = self.http.get(node_url).send().await?;
+        let request_payload = json!({
+            "jsonrpc": "2.0",
+            "id": "1",
+            "method": "relay_inclusionList",
+            "params": []
+        });
+
+        let response =
+            self.http.post(inclusion_list_node_url).json(&request_payload).send().await?;
 
         let inclusion_list = match response.status() {
-            StatusCode::OK => response.json().await?,
+            StatusCode::OK => response.json::<InclusionListResponse>().await?.into(),
             status => Err(InclusionListError::Http(format!(
                 "Invalid status in response from inclusion list node. Expected 200 but got {}. Headers: {:?}. Response: {:?}",
                 status, response.headers(), response
@@ -71,11 +82,21 @@ enum InclusionListError {
     Deserialization(#[from] serde_json::Error),
 }
 
+/// Response from node generating the inclusion list, excluding all unused jsonrpc params
+#[derive(Deserialize)]
+struct InclusionListResponse {
+    result: Vec<Bytes>,
+}
+
+impl From<InclusionListResponse> for InclusionList {
+    fn from(value: InclusionListResponse) -> Self {
+        Self { txs: value.result }
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use alloy_primitives::{bytes::Bytes, Address, B256};
-    use helix_common::api::builder_api::InclusionListTx;
-    use httpmock::prelude::*;
+    use httpmock::{Method::POST, MockServer};
     use serde_json::json;
 
     use super::*;
@@ -91,35 +112,28 @@ mod tests {
         let config = create_test_config(url.clone());
         let fetcher = InclusionListFetcher::new(config);
 
-        let expected_inclusion_list = InclusionList {
-            txs: vec![InclusionListTx {
-                hash: B256::default(),
-                nonce: 1,
-                sender: Address::default(),
-                gas_priority_fee: 100,
-                bytes: Bytes::default(),
-                wait_time: 0,
-            }],
-        };
+        let expected_inclusion_list =
+            InclusionList { txs: vec![
+                "0x02f87582426801850221646a70850221646a7082520894acabf6c2d38973a5f2ebab6b5e85623db1005a4e880ddf2f839aa3d97080c080a0088ae2635655e314949dae343ac296c3fb6ac56802e1024639f9603c61e253669f2bf33fe18ce70520abc6a662794c1ef5bb310248b7b7c4acc6be93e7885d62".into(),
+                "0x02f8b5824268820130850239465d16850239465d1682728a9494373a4919b3240d86ea41593d5eba789fef384880b844095ea7b30000000000000000000000005fbe74a283f7954f10aa04c2edf55578811aeb03000000000000000000000000000000000000000000000000000009184e72a000c080a0a6d0c20df1f0582c0dbf62a125fc1874868106d845c3916d666441973fb29ff0a04f4ce8879bd85510c82246de9a58a5a705dc672b6d89cc8183544f2db8649ea9".into(),
+                "0x02f8b48242688193850232306c41850232306c4182739294685ce6742351ae9b618f383883d6d1e0c5a31b4b80b844095ea7b30000000000000000000000005fbe74a283f7954f10aa04c2edf55578811aeb030000000000000000000000000000000000000000000000000de0b6b3a7640000c001a0bda9b5171b2e0d3ceceebfa4de504485bd6a8fd5041251fcd2d4aed24a65ab4ca0369e2d4bcc7ef790e64195578005c8a6c3313dd0b0bc105856d0202a4e230de9".into(),
+            ] };
 
         let mock = server.mock(|when, then| {
-            when.method(GET).path("/");
+            when.method(POST).path("/");
             then.status(200).json_body(json!({
-                "txs": [{
-                    "hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
-                    "nonce": 1,
-                    "sender": "0x0000000000000000000000000000000000000000",
-                    "gas_priority_fee": 100,
-                    "bytes": "0x",
-                    "wait_time": 0
-                }]
+                "jsonrpc":"2.0",
+                "id":1,
+                "result":[
+                    "0x02f87582426801850221646a70850221646a7082520894acabf6c2d38973a5f2ebab6b5e85623db1005a4e880ddf2f839aa3d97080c080a0088ae2635655e314949dae343ac296c3fb6ac56802e1024639f9603c61e253669f2bf33fe18ce70520abc6a662794c1ef5bb310248b7b7c4acc6be93e7885d62",
+                    "0x02f8b5824268820130850239465d16850239465d1682728a9494373a4919b3240d86ea41593d5eba789fef384880b844095ea7b30000000000000000000000005fbe74a283f7954f10aa04c2edf55578811aeb03000000000000000000000000000000000000000000000000000009184e72a000c080a0a6d0c20df1f0582c0dbf62a125fc1874868106d845c3916d666441973fb29ff0a04f4ce8879bd85510c82246de9a58a5a705dc672b6d89cc8183544f2db8649ea9",
+                    "0x02f8b48242688193850232306c41850232306c4182739294685ce6742351ae9b618f383883d6d1e0c5a31b4b80b844095ea7b30000000000000000000000005fbe74a283f7954f10aa04c2edf55578811aeb030000000000000000000000000000000000000000000000000de0b6b3a7640000c001a0bda9b5171b2e0d3ceceebfa4de504485bd6a8fd5041251fcd2d4aed24a65ab4ca0369e2d4bcc7ef790e64195578005c8a6c3313dd0b0bc105856d0202a4e230de9",
+                ]
             }));
         });
 
         let result = fetcher.fetch_inclusion_list(url).await.unwrap();
         assert_eq!(result.txs.len(), expected_inclusion_list.txs.len());
-        assert_eq!(result.txs[0].nonce, expected_inclusion_list.txs[0].nonce);
-        assert_eq!(result.txs[0].gas_priority_fee, expected_inclusion_list.txs[0].gas_priority_fee);
         mock.assert();
     }
 }


### PR DESCRIPTION
Changing the API we used to fetch inclusion lists to strip out the extra metadata we had there before. Now we just decode the RLP bytes (cheap), extract the metadata we want to store as debug info in postgres, & send on to the simulator for validation.