### PR TITLE
chain updater improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4094,6 +4094,7 @@ dependencies = [
  "ethereum_ssz",
  "eyre",
  "futures-util",
+ "helix-beacon",
  "helix-common",
  "helix-database",
  "helix-types",

--- a/crates/datastore/Cargo.toml
+++ b/crates/datastore/Cargo.toml
@@ -15,6 +15,7 @@ deadpool-redis.workspace = true
 ethereum_ssz.workspace = true
 eyre.workspace = true
 futures-util.workspace = true
+helix-beacon.workspace = true
 helix-common.workspace = true
 helix-database.workspace = true
 helix-types.workspace = true

--- a/crates/datastore/src/auctioneer/mock_auctioneer.rs
+++ b/crates/datastore/src/auctioneer/mock_auctioneer.rs
@@ -2,8 +2,11 @@ use std::sync::{atomic::AtomicBool, Arc, Mutex};
 
 use alloy_primitives::{bytes::Bytes, B256, U256};
 use async_trait::async_trait;
+use helix_beacon::types::PayloadAttributesEvent;
 use helix_common::{
-    api::builder_api::{InclusionListWithMetadata, TopBidUpdate},
+    api::builder_api::{
+        BuilderGetValidatorsResponseEntry, InclusionListWithMetadata, TopBidUpdate,
+    },
     bid_submission::v2::header_submission::SignedHeaderSubmission,
     pending_block::PendingBlock,
     signing::RelaySigningContext,
@@ -339,5 +342,44 @@ impl Auctioneer for MockAuctioneer {
         })
         .unwrap();
         rx
+    }
+
+    async fn publish_head_event(
+        &self,
+        _head_event: &helix_beacon::types::HeadEventData,
+    ) -> Result<(), AuctioneerError> {
+        Ok(())
+    }
+
+    fn get_head_event(&self) -> broadcast::Receiver<helix_beacon::types::HeadEventData> {
+        let (tx, rx) = broadcast::channel(1);
+        tx.send(helix_beacon::types::HeadEventData::default()).unwrap();
+        rx
+    }
+
+    async fn publish_payload_attributes(
+        &self,
+        _payload_attributes: &PayloadAttributesEvent,
+    ) -> Result<(), AuctioneerError> {
+        Ok(())
+    }
+
+    fn get_payload_attributes(&self) -> broadcast::Receiver<PayloadAttributesEvent> {
+        let (tx, rx) = broadcast::channel(1);
+        tx.send(PayloadAttributesEvent::default()).unwrap();
+        rx
+    }
+
+    async fn update_proposer_duties(
+        &self,
+        _duties: Vec<BuilderGetValidatorsResponseEntry>,
+    ) -> Result<(), AuctioneerError> {
+        Ok(())
+    }
+
+    async fn get_proposer_duties(
+        &self,
+    ) -> Result<Vec<BuilderGetValidatorsResponseEntry>, AuctioneerError> {
+        Ok(vec![])
     }
 }

--- a/crates/datastore/src/auctioneer/traits.rs
+++ b/crates/datastore/src/auctioneer/traits.rs
@@ -1,9 +1,13 @@
 use alloy_primitives::{bytes::Bytes, B256, U256};
 use async_trait::async_trait;
+use helix_beacon::types::{HeadEventData, PayloadAttributesEvent};
 use helix_common::{
-    api::builder_api::InclusionListWithMetadata,
-    bid_submission::v2::header_submission::SignedHeaderSubmission, builder_info::BuilderInfo,
-    pending_block::PendingBlock, signing::RelaySigningContext, ProposerInfo,
+    api::builder_api::{BuilderGetValidatorsResponseEntry, InclusionListWithMetadata},
+    bid_submission::v2::header_submission::SignedHeaderSubmission,
+    builder_info::BuilderInfo,
+    pending_block::PendingBlock,
+    signing::RelaySigningContext,
+    ProposerInfo,
 };
 use helix_database::BuilderInfoDocument;
 use helix_types::{
@@ -222,4 +226,24 @@ pub trait Auctioneer: Send + Sync + Clone {
     ) -> Result<(), AuctioneerError>;
 
     fn get_inclusion_list(&self) -> broadcast::Receiver<InclusionListWithKey>;
+
+    async fn publish_head_event(&self, head_event: &HeadEventData) -> Result<(), AuctioneerError>;
+
+    fn get_head_event(&self) -> broadcast::Receiver<HeadEventData>;
+
+    async fn publish_payload_attributes(
+        &self,
+        payload_attributes_event: &PayloadAttributesEvent,
+    ) -> Result<(), AuctioneerError>;
+
+    fn get_payload_attributes(&self) -> broadcast::Receiver<PayloadAttributesEvent>;
+
+    async fn update_proposer_duties(
+        &self,
+        duties: Vec<BuilderGetValidatorsResponseEntry>,
+    ) -> Result<(), AuctioneerError>;
+
+    async fn get_proposer_duties(
+        &self,
+    ) -> Result<Vec<BuilderGetValidatorsResponseEntry>, AuctioneerError>;
 }

--- a/crates/housekeeper/src/housekeeper.rs
+++ b/crates/housekeeper/src/housekeeper.rs
@@ -476,6 +476,8 @@ impl<DB: DatabaseService, A: Auctioneer> Housekeeper<DB, A> {
             "storing proposer duties"
         );
 
+        self.auctioneer.update_proposer_duties(formatted_proposer_duties.clone()).await?;
+
         self.db.set_proposer_duties(formatted_proposer_duties).await?;
 
         Ok(())

--- a/crates/housekeeper/src/lib.rs
+++ b/crates/housekeeper/src/lib.rs
@@ -43,7 +43,7 @@ pub async fn start_housekeeper(
     housekeeper.start(head_event_receiver.resubscribe()).await?;
 
     let curr_slot_info = CurrentSlotInfo::new();
-    let chain_updater = ChainEventUpdater::new(db, auctioneer, chain_info, curr_slot_info.clone());
+    let chain_updater = ChainEventUpdater::new(auctioneer, chain_info, curr_slot_info.clone());
     tokio::spawn(chain_updater.start(head_event_receiver, payload_attribute_receiver));
 
     Ok(curr_slot_info)

--- a/crates/website/src/website_service.rs
+++ b/crates/website/src/website_service.rs
@@ -72,12 +72,8 @@ impl WebsiteService {
             current_slot_info: current_slot_info.clone(),
         });
 
-        let chain_updater = ChainEventUpdater::new(
-            db.clone(),
-            Arc::new(MockAuctioneer::new()),
-            chain_info,
-            current_slot_info,
-        );
+        let chain_updater =
+            ChainEventUpdater::new(Arc::new(MockAuctioneer::new()), chain_info, current_slot_info);
         info!("ChainEventUpdater initialized");
 
         let (head_event_tx, head_event_rx) = broadcast::channel(100);


### PR DESCRIPTION
Header and payload attrs event now syncd via redis to ensure if one node in the cluster receives the event they all will.

Removes unnecessary db dependancy from chain even updater as it was just duplicating work done in the housekeeper already. Instead housekeeper caches that work in redis.