### PR TITLE
removes locks on header and block submission

### DIFF
--- a/crates/database/src/postgres/postgres_db_service.rs
+++ b/crates/database/src/postgres/postgres_db_service.rs
@@ -1074,8 +1074,7 @@ impl DatabaseService for PostgresDatabaseService {
                 VALUES
                     ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
                 ON CONFLICT (block_hash)
-                DO UPDATE SET
-                    first_seen = LEAST(block_submission.first_seen, excluded.first_seen)
+                DO NOTHING
                 ",
             &[
                 &(submission.block_number() as i32),
@@ -1703,8 +1702,7 @@ impl DatabaseService for PostgresDatabaseService {
                 VALUES
                     ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
                 ON CONFLICT (block_hash)
-                DO UPDATE SET
-                    first_seen = LEAST(header_submission.first_seen, excluded.first_seen)
+                DO NOTHING
                 ",
             &[
                 &(submission.execution_payload_header().block_number() as i32),


### PR DESCRIPTION
currently lock rows to udpdate the first seen
if we can accept a slightly less accurate first seen then we can avoid the need for a locks on the row.