### PR TITLE
use pubkey bytes in top bid

### DIFF
--- a/crates/common/src/api/builder_api.rs
+++ b/crates/common/src/api/builder_api.rs
@@ -1,7 +1,7 @@
 use alloy_consensus::TxEnvelope;
 use alloy_primitives::{Address, Bytes, B256, U256};
 use alloy_rlp::Decodable;
-use helix_types::{BlsPublicKey, SignedValidatorRegistration, Slot, TestRandom};
+use helix_types::{BlsPublicKey, BlsPublicKeyBytes, SignedValidatorRegistration, Slot};
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
 
@@ -35,14 +35,14 @@ impl From<BuilderGetValidatorsResponseEntry> for BuilderGetValidatorsResponse {
     }
 }
 
-#[derive(Clone, Debug, Encode, Decode, TestRandom)]
+#[derive(Clone, Debug, Encode, Decode)]
 pub struct TopBidUpdate {
     pub timestamp: u64,
     pub slot: u64,
     pub block_number: u64,
     pub block_hash: B256,
     pub parent_hash: B256,
-    pub builder_pubkey: BlsPublicKey,
+    pub builder_pubkey: BlsPublicKeyBytes,
     pub fee_recipient: Address,
     pub value: U256,
 }

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -10,6 +10,7 @@ version.workspace = true
 alloy-consensus.workspace = true
 alloy-eips.workspace = true
 alloy-primitives.workspace = true
+alloy-rpc-types.workspace = true
 ethereum_serde_utils.workspace = true
 ethereum_ssz.workspace = true
 ethereum_ssz_derive.workspace = true

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -32,10 +32,10 @@ pub type Domain = lh_types::Domain;
 
 // Signing
 pub type BlsPublicKey = lh_types::PublicKey;
+pub type BlsPublicKeyBytes = alloy_rpc_types::beacon::BlsPublicKey;
 pub type BlsSignature = lh_types::Signature;
 pub type BlsSecretKey = lh_types::SecretKey;
 pub type BlsKeypair = lh_types::Keypair;
-pub type PublicKeyBytes = lh_types::PublicKeyBytes;
 
 // Fields
 pub type Withdrawal = lh_types::withdrawal::Withdrawal;
@@ -139,8 +139,8 @@ pub fn maybe_upgrade_execution_payload(
     payload
 }
 
-pub fn mock_public_key_bytes() -> PublicKeyBytes {
-    PublicKeyBytes::empty()
+pub fn mock_public_key_bytes() -> lh_types::PublicKeyBytes {
+    lh_types::PublicKeyBytes::empty()
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Encode)]


### PR DESCRIPTION
the lighthouse bls pubkey implementation checks the bytes are valid, which can be slow and is unneeded when publishing the top bid updates