### PR TITLE
add sorter queue metric

### DIFF
--- a/crates/api/src/builder/submit_block.rs
+++ b/crates/api/src/builder/submit_block.rs
@@ -203,6 +203,7 @@ impl<A: Api> BuilderApi<A> {
             &trace,
             optimistic_version,
             is_cancellations_enabled,
+            utcnow_ns(),
         )) {
             error!(?err, "failed to send submission to sorter");
             return Err(BuilderApiError::InternalError);

--- a/crates/api/src/builder/submit_header.rs
+++ b/crates/api/src/builder/submit_header.rs
@@ -219,6 +219,7 @@ impl<A: Api> BuilderApi<A> {
             &payload,
             trace.receive,
             is_cancellations_enabled,
+            utcnow_ns(),
         )) {
             error!(?err, "failed to send submission to sorter");
             return Err(BuilderApiError::InternalError);

--- a/crates/common/src/metrics.rs
+++ b/crates/common/src/metrics.rs
@@ -306,6 +306,14 @@ lazy_static! {
     )
     .unwrap();
 
+    pub static ref BID_SORTER_QUEUE_LATENCY_US: Histogram = register_histogram_with_registry!(
+        "bid_sorter_queue_latency_us",
+        "Latency of bid sorter queue in us",
+        vec![1., 5., 10., 25., 50., 100., 500., 1_000., 5_000., 10_000., 50_000., 100_000., 1_000_000.],
+        &RELAY_METRICS_REGISTRY
+    )
+    .unwrap();
+
     //////////////// TIMING GAMES ////////////////
 
     static ref GET_HEADER_TIMEOUT: HistogramVec = register_histogram_vec_with_registry!(


### PR DESCRIPTION
we're seeing some discrepancy between the submission trace steps and bid sorter recv latency. Adding a new metric to track how long bids spend in the queue waiting to be processed