### PR TITLE
skip sigverify for authenticated builders

### DIFF
--- a/crates/api/src/builder/api.rs
+++ b/crates/api/src/builder/api.rs
@@ -166,7 +166,7 @@ impl<A: Api> BuilderApi<A> {
     /// If this is the first time the hash has been seen it will insert the hash into the set.
     ///
     /// This function should not be called by functions that only process the payload.
-    pub(crate) async fn check_for_duplicate_block_hash(
+    pub(crate) fn check_for_duplicate_block_hash(
         &self,
         block_hash: &B256,
     ) -> Result<(), BuilderApiError> {
@@ -191,13 +191,19 @@ impl<A: Api> BuilderApi<A> {
         builder_info: &BuilderInfo,
         trace: &mut SubmissionTrace,
         payload_attributes: &PayloadAttributesUpdate,
+        skip_sigverify: bool,
     ) -> Result<bool, BuilderApiError> {
-        // Verify the payload signature
-        if let Err(err) = payload.verify_signature(&self.chain_info.context) {
-            warn!(%err, "failed to verify signature");
-            return Err(BuilderApiError::SignatureVerificationFailed);
+        if skip_sigverify {
+            trace!("skipping signature verification");
+        } else {
+            // Verify the payload signature
+            if let Err(err) = payload.verify_signature(&self.chain_info.context) {
+                warn!(%err, "failed to verify signature");
+                return Err(BuilderApiError::SignatureVerificationFailed);
+            }
+            trace!("verified signature");
         }
-        trace!("verified signature");
+        trace.skip_sigverify = skip_sigverify;
         trace.signature = utcnow_ns();
 
         let curr_best = self.shared_best_header.best_bid(payload.slot().as_u64());

--- a/crates/api/src/builder/submit_header.rs
+++ b/crates/api/src/builder/submit_header.rs
@@ -139,7 +139,7 @@ impl<A: Api> BuilderApi<A> {
         }
 
         // Handle duplicates.
-        if let Err(err) = api.check_for_duplicate_block_hash(block_hash).await {
+        if let Err(err) = api.check_for_duplicate_block_hash(block_hash) {
             match err {
                 BuilderApiError::DuplicateBlockHash { block_hash } => {
                     // We dont return the error here as we want to continue processing the request.

--- a/crates/api/src/builder/top_bid.rs
+++ b/crates/api/src/builder/top_bid.rs
@@ -14,7 +14,7 @@ use tokio::time::{self};
 use tracing::{debug, error};
 
 use super::api::BuilderApi;
-use crate::{builder::error::BuilderApiError, Api};
+use crate::{builder::error::BuilderApiError, Api, HEADER_API_KEY};
 
 impl<A: Api> BuilderApi<A> {
     #[tracing::instrument(skip_all)]
@@ -23,7 +23,7 @@ impl<A: Api> BuilderApi<A> {
         headers: HeaderMap,
         ws: WebSocketUpgrade,
     ) -> Result<impl IntoResponse, BuilderApiError> {
-        let Some(api_key) = headers.get("x-api-key") else {
+        let Some(api_key) = headers.get(HEADER_API_KEY) else {
             return Err(BuilderApiError::InvalidApiKey);
         };
 

--- a/crates/api/src/builder/v3/payload.rs
+++ b/crates/api/src/builder/v3/payload.rs
@@ -39,6 +39,7 @@ pub async fn fetch_builder_blocks<A: Api>(
                 block,
                 trace,
                 OptimisticVersion::V3,
+                false,
             )
             .await
             {

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -74,3 +74,4 @@ pub trait Api: Clone + Send + Sync + 'static {
 
 /// Timeout in milliseconds from when the call started
 pub const HEADER_TIMEOUT_MS: &str = "x-timeout-ms";
+pub const HEADER_API_KEY: &str = "x-api-key";

--- a/crates/common/src/traces/builder_api_trace.rs
+++ b/crates/common/src/traces/builder_api_trace.rs
@@ -15,6 +15,8 @@ pub struct SubmissionTrace {
     pub auctioneer_update: u64,
     pub request_finish: u64,
     pub metadata: Option<String>,
+
+    pub skip_sigverify: bool,
 }
 
 impl SubmissionTrace {
@@ -38,7 +40,9 @@ impl SubmissionTrace {
         SUB_TRACE_LATENCY.with_label_values(&["decode"]).observe(decode);
         SUB_TRACE_LATENCY.with_label_values(&["floor_bid_checks"]).observe(floor_bid_checks);
         SUB_TRACE_LATENCY.with_label_values(&["pre_checks"]).observe(pre_checks);
-        SUB_TRACE_LATENCY.with_label_values(&["signature"]).observe(signature);
+        if !self.skip_sigverify {
+            SUB_TRACE_LATENCY.with_label_values(&["signature"]).observe(signature);
+        }
         if optimistic_version.is_optimistic() {
             SUB_TRACE_LATENCY.with_label_values(&["sim_optimistic"]).observe(simulation);
         } else {


### PR DESCRIPTION
bls signatures are an expensive way to authenticate submission (which need to be re-signed by the relay anyways). We re-use the builder auth that we have for the top bid websocket to let builders skip this