### PR TITLE
fix: return 400 for unknown validator registrations (#191)

### DIFF
--- a/crates/api/src/test_utils.rs
+++ b/crates/api/src/test_utils.rs
@@ -1,4 +1,7 @@
-use std::{sync::Arc, time::Duration};
+use std::{
+    sync::{atomic::AtomicBool, Arc},
+    time::Duration,
+};
 
 use axum::{
     error_handling::HandleErrorLayer,
@@ -25,6 +28,7 @@ use helix_common::{
 };
 use helix_database::mock_database_service::MockDatabaseService;
 use helix_housekeeper::CurrentSlotInfo;
+use moka::sync::Cache;
 use tokio::sync::{broadcast, mpsc::channel};
 use tower::{buffer::BufferLayer, limit::RateLimitLayer, timeout::TimeoutLayer, ServiceBuilder};
 use tower_http::limit::RequestBodyLimitLayer;
@@ -33,7 +37,8 @@ use crate::{
     builder::api::{BuilderApi, MAX_PAYLOAD_LENGTH},
     gossiper::grpc_gossiper::GrpcGossiperClientManager,
     proposer::{self, ProposerApi},
-    relay_data::DataApi,
+    relay_data::{BidsCache, DataApi, DeliveredPayloadsCache},
+    router::KnownValidatorsLoaded,
     Api,
 };
 
@@ -193,6 +198,7 @@ pub fn proposer_api_app() -> (Router, Arc<ProposerApi<MockApi>>, CurrentSlotInfo
             post(ProposerApi::<MockApi>::register_validators),
         )
         .layer(RequestBodyLimitLayer::new(MAX_PAYLOAD_LENGTH))
+        .layer(Extension(KnownValidatorsLoaded(Arc::new(AtomicBool::new(true)))))
         .layer(Extension(proposer_api_service.clone()));
 
     (router, proposer_api_service, current_slot_info, auctioneer)
@@ -204,6 +210,10 @@ pub fn data_api_app() -> (Router, Arc<DataApi<MockApi>>, Arc<MockDatabaseService
         Arc::new(ValidatorPreferences::default()),
         mock_database.clone(),
     ));
+
+    // Provide small caches required by the handlers
+    let bids_cache: BidsCache = Cache::builder().max_capacity(1024).build();
+    let delivered_cache: DeliveredPayloadsCache = Cache::builder().max_capacity(1024).build();
 
     let router = Router::new()
         .route(
@@ -218,7 +228,9 @@ pub fn data_api_app() -> (Router, Arc<DataApi<MockApi>>, Arc<MockDatabaseService
             &format!("{PATH_DATA_API}{PATH_VALIDATOR_REGISTRATION}"),
             get(DataApi::<MockApi>::validator_registration),
         )
-        .layer(Extension(proposer_api_service.clone()));
+        .layer(Extension(proposer_api_service.clone()))
+        .layer(Extension(delivered_cache))
+        .layer(Extension(bids_cache));
 
     (router, proposer_api_service, mock_database)
 }


### PR DESCRIPTION
- Proposer API now returns ProposerApiError::NoValidatorsCouldBeRegistered when a batch yields zero successful registrations, surfacing as HTTP 400.
- Added a unit test harness using the mock database’s new “treat all pubkeys as known” toggle and tidied the proposer test utilities accordingly.

Based on commit from [PR#260](https://github.com/gattaca-com/helix/pull/260)