### PR TITLE
Add API for builders to fetch builder info (isOptimistic and collateral) #186

### DIFF
--- a/crates/api/src/builder/get_builder_info.rs
+++ b/crates/api/src/builder/get_builder_info.rs
@@ -1,0 +1,46 @@
+use std::sync::Arc;
+
+use axum::{extract::Path, response::IntoResponse, Extension};
+use helix_database::DatabaseService;
+use helix_types::BlsPublicKeyBytes;
+use http::HeaderMap;
+use hyper::StatusCode;
+use tracing::debug;
+
+use super::{api::BuilderApi, error::BuilderApiError};
+use crate::{Api, HEADER_API_KEY};
+
+impl<A: Api> BuilderApi<A> {
+    /// Retrieves the builder info for a given builder public key.
+    ///
+    /// This function accepts a `pub_key` and:
+    /// 1. Validates the request is authenticated.
+    /// 2. Looks up the builder info in the database.
+    /// 3. Returns the builder info if found, otherwise 404.
+    ///
+    /// Returns a JSON response containing fields like `collateral` and `is_optimistic`.
+    #[tracing::instrument(skip_all, name = "get_builder_info", fields(pub_key = %pub_key))]
+    pub async fn get_builder_info(
+        Extension(api): Extension<Arc<BuilderApi<A>>>,
+        Path(pub_key): Path<BlsPublicKeyBytes>,
+        headers: HeaderMap,
+    ) -> Result<impl IntoResponse, BuilderApiError> {
+        debug!(pub_key = ?pub_key, "New request for builder info.");
+
+        let Some(api_key) = headers.get(HEADER_API_KEY) else {
+            return Err(BuilderApiError::InvalidApiKey);
+        };
+
+        if !api.auctioneer.validate_api_key(api_key, &pub_key) {
+            return Err(BuilderApiError::InvalidApiKey);
+        }
+
+        let builder_info =
+            api.db.get_builder_info(&pub_key).await.map_err(BuilderApiError::DatabaseError)?;
+
+        match builder_info {
+            Some(info) => Ok((StatusCode::OK, axum::Json(info)).into_response()),
+            None => Ok(StatusCode::NOT_FOUND.into_response()),
+        }
+    }
+}

--- a/crates/api/src/builder/mod.rs
+++ b/crates/api/src/builder/mod.rs
@@ -1,5 +1,6 @@
 pub mod api;
 pub mod error;
+pub mod get_builder_info;
 pub mod get_inclusion_list;
 pub mod hydration;
 pub mod simulator;

--- a/crates/api/src/router.rs
+++ b/crates/api/src/router.rs
@@ -61,6 +61,7 @@ pub fn build_router<A: Api>(
             Route::GetValidators => get(BuilderApi::<A>::get_validators),
             Route::SubmitBlock => post(BuilderApi::<A>::submit_block),
             Route::GetTopBid => get(BuilderApi::<A>::get_top_bid),
+            Route::GetBuilderInfo => get(BuilderApi::<A>::get_builder_info),
             Route::Status => get(proposer::status),
             Route::RegisterValidators => post(ProposerApi::<A>::register_validators),
             Route::GetHeader => get(ProposerApi::<A>::get_header),

--- a/crates/common/src/api/mod.rs
+++ b/crates/common/src/api/mod.rs
@@ -8,6 +8,7 @@ pub const PATH_GET_VALIDATORS: &str = "/validators";
 pub const PATH_SUBMIT_BLOCK: &str = "/blocks";
 pub const PATH_SUBMIT_HEADER: &str = "/headers";
 pub const PATH_GET_TOP_BID: &str = "/top_bid";
+pub const PATH_GET_BUILDER_INFO: &str = "/builder_info/{pub_key}";
 pub const PATH_GET_INCLUSION_LIST: &str = "/inclusion_list/{slot}/{parent_hash}/{pub_key}";
 
 pub const PATH_PROPOSER_API: &str = "/eth/v1/builder";

--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -287,6 +287,12 @@ pub struct BuilderConfig {
     pub builder_info: BuilderInfo,
 }
 
+impl BuilderConfig {
+    pub fn test_default() -> Self {
+        Self { pub_key: BlsPublicKeyBytes::random(), builder_info: BuilderInfo::default() }
+    }
+}
+
 #[derive(Serialize, Deserialize, Clone, Default)]
 pub enum NetworkConfig {
     #[default]
@@ -514,6 +520,7 @@ pub enum Route {
     GetValidators,
     SubmitBlock,
     GetTopBid,
+    GetBuilderInfo,
     Status,
     RegisterValidators,
     GetHeader,
@@ -534,6 +541,7 @@ impl Route {
             Route::GetValidators => format!("{PATH_BUILDER_API}{PATH_GET_VALIDATORS}"),
             Route::SubmitBlock => format!("{PATH_BUILDER_API}{PATH_SUBMIT_BLOCK}"),
             Route::GetTopBid => format!("{PATH_BUILDER_API}{PATH_GET_TOP_BID}"),
+            Route::GetBuilderInfo => format!("{PATH_BUILDER_API}{PATH_GET_BUILDER_INFO}"),
             Route::GetInclusionList => format!("{PATH_BUILDER_API}{PATH_GET_INCLUSION_LIST}"),
             Route::Status => format!("{PATH_PROPOSER_API}{PATH_STATUS}"),
             Route::RegisterValidators => format!("{PATH_PROPOSER_API}{PATH_REGISTER_VALIDATORS}"),

--- a/crates/database/src/mock_database_service.rs
+++ b/crates/database/src/mock_database_service.rs
@@ -12,9 +12,9 @@ use helix_common::{
         proposer_api::ValidatorRegistrationInfo,
     },
     bid_submission::{v2::header_submission::SignedHeaderSubmission, OptimisticVersion},
-    BuilderInfo, GetHeaderTrace, GetPayloadTrace, GossipedPayloadTrace, HeaderSubmissionTrace,
-    ProposerInfo, SignedValidatorRegistrationEntry, SubmissionTrace, ValidatorPreferences,
-    ValidatorSummary,
+    BuilderConfig, BuilderInfo, GetHeaderTrace, GetPayloadTrace, GossipedPayloadTrace,
+    HeaderSubmissionTrace, ProposerInfo, SignedValidatorRegistrationEntry, SubmissionTrace,
+    ValidatorPreferences, ValidatorSummary,
 };
 use helix_types::{
     BlsPublicKeyBytes, BlsSignatureBytes, PayloadAndBlobs, SignedBidSubmission,
@@ -189,6 +189,14 @@ impl DatabaseService for MockDatabaseService {
         _builders: &[BuilderInfoDocument],
     ) -> Result<(), DatabaseError> {
         Ok(())
+    }
+
+    async fn get_builder_info(
+        &self,
+        _builder_pub_key: &BlsPublicKeyBytes,
+    ) -> Result<Option<BuilderInfoDocument>, DatabaseError> {
+        let doc = BuilderConfig::test_default();
+        Ok(Some(doc))
     }
 
     async fn get_all_builder_infos(&self) -> Result<Vec<BuilderInfoDocument>, DatabaseError> {

--- a/crates/database/src/traits.rs
+++ b/crates/database/src/traits.rs
@@ -120,6 +120,11 @@ pub trait DatabaseService: Send + Sync + Clone {
 
     async fn get_all_builder_infos(&self) -> Result<Vec<BuilderInfoDocument>, DatabaseError>;
 
+    async fn get_builder_info(
+        &self,
+        builder_pub_key: &BlsPublicKeyBytes,
+    ) -> Result<Option<BuilderInfoDocument>, DatabaseError>;
+
     async fn check_builder_api_key(&self, api_key: &str) -> Result<bool, DatabaseError>;
 
     async fn db_demote_builder(


### PR DESCRIPTION
This PR implements a new API endpoint to allow authenticated builders to fetch their builder information, including fields such as isOptimistic and collateral. The endpoint is accessible only with valid authentication via an API key and returns the builder info when present or a 404 status otherwise.

Closes #186