### PR TITLE
drop registration tasks on request timeout

### DIFF
--- a/crates/api/src/auctioneer/worker.rs
+++ b/crates/api/src/auctioneer/worker.rs
@@ -381,7 +381,7 @@ impl RegWorker {
         for i in range {
             if res_tx.is_closed() {
                 // validator dropped the request so no point in processing more
-                // a single check takes 1-5ms so it's ok to check this every time
+                // a single signature check takes 1-5ms so it's ok to check this every time
                 return false;
             }
 


### PR DESCRIPTION
when under load, requests may spend a lot of time in the queue and the client may cancel the request. In that case there's no point in progressing them and we can skip immediately 