### PR TITLE
fix: prevent DB deadlock on bid save

### DIFF
--- a/crates/relay/src/api/relay_data/api.rs
+++ b/crates/relay/src/api/relay_data/api.rs
@@ -92,8 +92,10 @@ impl DataApi {
             .await
         {
             Ok(result) => {
+                let mut seen = std::collections::HashSet::with_capacity(result.len());
                 let response = result
                     .into_iter()
+                    .filter(|b| seen.insert(b.bid_trace.block_hash))
                     .map(|b| b.into())
                     .collect::<Vec<DeliveredPayloadsResponse>>();
 
@@ -140,8 +142,12 @@ impl DataApi {
         match data_api.db.get_bids(&(&params).into(), data_api.validator_preferences.clone()).await
         {
             Ok(result) => {
-                let response =
-                    result.into_iter().map(|b| b.into()).collect::<Vec<ReceivedBlocksResponse>>();
+                let mut seen = std::collections::HashSet::with_capacity(result.len());
+                let response = result
+                    .into_iter()
+                    .filter(|b| seen.insert(b.bid_trace.block_hash))
+                    .map(|b| b.into())
+                    .collect::<Vec<ReceivedBlocksResponse>>();
 
                 cache.insert(params, response.clone());
 

--- a/crates/relay/src/database/postgres/migrations/V35__flatten.sql
+++ b/crates/relay/src/database/postgres/migrations/V35__flatten.sql
@@ -1,0 +1,11 @@
+ALTER TABLE block_submission DROP CONSTRAINT IF EXISTS block_submission_pkey;
+
+ALTER TABLE block_submission 
+ADD COLUMN IF NOT EXISTS region_id smallint,
+ADD COLUMN IF NOT EXISTS optimistic_version smallint,
+ADD COLUMN IF NOT EXISTS metadata character varying;
+
+ALTER TABLE get_header
+ADD COLUMN IF NOT EXISTS receive bigint,
+ADD COLUMN IF NOT EXISTS validation_complete bigint,
+ADD COLUMN IF NOT EXISTS best_bid_fetched bigint;


### PR DESCRIPTION
Remove ON CONFLICT, which requires a lock and can cause data loss if a deadlock occurs. Add a retry mechanism to further reduce the chance of errors leading to lost data.

Remove the uniqueness constraint from block submissions to speed up inserts and reduce lock contention. This removes built-in deduplication, but we already perform a dedupe when a bid is received. Some duplicates can still slip through, so add an additional dedupe step in the data API before returning results to the user.

Remove get_header_trace and submission_trace.
get_header times can be flattened into the get_header table, and submission_trace is obsolete since its recorded times have been zero for a while.