### PR TITLE
Align config defaults w/ and w/o validator_preferences section

### DIFF
--- a/crates/common/src/validator_preferences/mod.rs
+++ b/crates/common/src/validator_preferences/mod.rs
@@ -1,6 +1,6 @@
 use crate::default_bool;
 
-#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ValidatorPreferences {
     /// Apply filtering to the beacon block submissions.
     #[serde(default = "default_filtering")]
@@ -21,6 +21,18 @@ pub struct ValidatorPreferences {
 
     #[serde(default)]
     pub disable_inclusion_lists: bool,
+}
+
+impl Default for ValidatorPreferences {
+    fn default() -> Self {
+        Self {
+            filtering: default_filtering(),
+            trusted_builders: None,
+            header_delay: true,
+            delay_ms: None,
+            disable_inclusion_lists: false,
+        }
+    }
 }
 
 const fn default_filtering() -> Filtering {


### PR DESCRIPTION
There's a slight difference in behavior in config file loading between the cases where the validator_preferences section exists but is empty vs validator_preferences section not present at all.

When the section is present, it gets parsed using serde-specified defaults, such as header_delay's `#[serde(default = "default_bool::<true>")]`.

When the section is completely absent, ValidatorPreferences gets initialized using `#[derive(Default)]`, in which header_delay defaults to false.

This change defines a custom default() function such that the default values align in both cases.