### PR TITLE
simulator/block_merging: reject base blocks over blob limit; prevent u64 underflow in blob headroom

### DIFF
--- a/crates/simulator/src/block_merging/error.rs
+++ b/crates/simulator/src/block_merging/error.rs
@@ -49,6 +49,8 @@ pub(crate) enum BlockMergingApiError {
     RevenueAllocationReverted,
     #[error("reached blob limit")]
     BlobLimitReached,
+    #[error("base block exceeds blob limit: used {used_blob_count} blobs > max {max_blob_count}")]
+    BaseBlockBlobLimitExceeded { max_blob_count: u64, used_blob_count: u64 },
     #[error("validation: {0}")]
     Validation(#[from] ValidationApiError),
     #[error("could not find parent block: {_0}")]
@@ -64,7 +66,8 @@ impl From<BlockMergingApiError> for ErrorObject<'static> {
             BlockMergingApiError::InvalidProposerPayment |
             BlockMergingApiError::NoSafeForBuilder(_) |
             BlockMergingApiError::NotEnoughGasForPayment(_) |
-            BlockMergingApiError::InvalidSignatureInBaseBlock => {
+            BlockMergingApiError::InvalidSignatureInBaseBlock |
+            BlockMergingApiError::BaseBlockBlobLimitExceeded { .. } => {
                 invalid_params_rpc_err(error.to_string())
             }
 

--- a/crates/simulator/src/block_merging/mod.rs
+++ b/crates/simulator/src/block_merging/mod.rs
@@ -63,6 +63,32 @@ pub(crate) mod types;
 
 const DELEGATE_CALL: u8 = 1;
 
+// Remaining blob slots in the block.
+//
+// We must avoid unsigned underflow here: if `used_blob_count > max_blob_count`,
+// `max_blob_count - used_blob_count` would wrap in release builds (e.g. to `u64::MAX`),
+// effectively making blob-capacity checks think there is "infinite" capacity left.
+fn remaining_blob_slots(max_blob_count: u64, used_blob_count: u64) -> u64 {
+    max_blob_count.saturating_sub(used_blob_count)
+}
+
+fn count_blob_usage_in_transactions(transactions: &[SignedTx]) -> u64 {
+    transactions.iter().map(|tx| tx.blob_count().unwrap_or(0)).fold(0u64, u64::saturating_add)
+}
+
+fn ensure_base_block_blob_limit(
+    max_blob_count: u64,
+    used_blob_count: u64,
+) -> Result<(), BlockMergingApiError> {
+    if used_blob_count > max_blob_count {
+        return Err(BlockMergingApiError::BaseBlockBlobLimitExceeded {
+            max_blob_count,
+            used_blob_count,
+        });
+    }
+    Ok(())
+}
+
 impl BlockMergingApi {
     /// Core logic for appending additional transactions to a block.
     async fn _merge_block_v1(
@@ -221,6 +247,15 @@ impl BlockMergingApi {
         if payment_tx.value() != original_value || payment_tx.to() != Some(proposer_fee_recipient) {
             return Err(BlockMergingApiError::InvalidProposerPayment);
         }
+
+        // Pre-check blob usage to avoid executing invalid base blocks and to prevent
+        // arithmetic underflow in blob-capacity calculations.
+        let blob_params = evm_config
+            .chain_spec()
+            .blob_params_at_timestamp(header.timestamp)
+            .expect("we are past Cancun");
+        let base_blob_count = count_blob_usage_in_transactions(&transactions);
+        ensure_base_block_blob_limit(blob_params.max_blob_count, base_blob_count)?;
 
         // Reserve gas for the final revenue distribution transaction.
         // This amount is based on empirical measurements with some added buffer.
@@ -838,8 +873,10 @@ where
         }
 
         let available_gas = self.gas_limit - self.gas_used;
-        let available_blobs =
-            self.blob_params.max_blob_count - self.blob_versioned_hashes.len() as u64;
+        let available_blobs = remaining_blob_slots(
+            self.blob_params.max_blob_count,
+            self.blob_versioned_hashes.len() as u64,
+        );
 
         let evm_env = self.evm_env.clone();
         let state = self.get_state();
@@ -865,8 +902,10 @@ where
 
     fn append_transaction(&mut self, tx: RecoveredTx) -> Result<bool, BlockMergingApiError> {
         let mut is_success = false;
-        let blobs_available =
-            self.blob_params.max_blob_count - self.blob_versioned_hashes.len() as u64;
+        let blobs_available = remaining_blob_slots(
+            self.blob_params.max_blob_count,
+            self.blob_versioned_hashes.len() as u64,
+        );
         // NOTE: we check this because the block builder doesn't seem to do it
         if tx.blob_count().unwrap_or(0) > blobs_available {
             return Err(BlockMergingApiError::BlobLimitReached);
@@ -1265,5 +1304,27 @@ mod tests {
 
         let recovered = result.unwrap();
         assert_eq!(recovered.signer(), signer.address());
+    }
+    #[test]
+    fn test_remaining_blob_slots_saturates_on_underflow() {
+        assert_eq!(remaining_blob_slots(6, 7), 0);
+        assert_eq!(remaining_blob_slots(6, 6), 0);
+        assert_eq!(remaining_blob_slots(6, 5), 1);
+        assert_eq!(remaining_blob_slots(0, 1), 0);
+    }
+
+    #[test]
+    fn test_ensure_base_block_blob_limit_errors_when_exceeded() {
+        let err = ensure_base_block_blob_limit(6, 7).unwrap_err();
+        match err {
+            BlockMergingApiError::BaseBlockBlobLimitExceeded {
+                max_blob_count,
+                used_blob_count,
+            } => {
+                assert_eq!(max_blob_count, 6);
+                assert_eq!(used_blob_count, 7);
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
     }
 }


### PR DESCRIPTION
### Problem

`BlockBuilder` currently computes remaining blob capacity using unsigned subtraction in two places:

* `simulate_order`: `available_blobs = max_blob_count - blob_versioned_hashes.len() as u64`
* `append_transaction`: `blobs_available = max_blob_count - blob_versioned_hashes.len() as u64`

If `used_blob_count > max_blob_count`, this underflows and wraps in release builds (e.g., to a value near `u64::MAX`), which can make blob-capacity checks behave as if there is effectively unbounded headroom. ([GitHub][1])

### Change

1. **Fail fast on invalid base blocks (pre-execution):**
   Before executing the base block, count blob usage from the base block transaction list (`sum(tx.blob_count().unwrap_or(0))`) and compare it to the chain-spec blob limit at the block timestamp (`blob_params_at_timestamp(header.timestamp)`). If `used > max`, return `BaseBlockBlobLimitExceeded { max_blob_count, used_blob_count }` and map it to `invalid_params` (invalid request/base payload).

2. **Harden blob headroom arithmetic:**
   Replace the raw subtraction with a helper `remaining_blob_slots(max, used) = max.saturating_sub(used)` and use it in both `simulate_order` and `append_transaction`. This removes the wraparound failure mode even if invariants are violated.

3. **Tests:**

   * Unit test that `remaining_blob_slots` saturates on underflow.
   * Unit test that `ensure_base_block_blob_limit` returns `BaseBlockBlobLimitExceeded` when exceeded.

### Context

Mainnet blocks can saturate blob usage (e.g., block **#24505725** shows **21 blobs (100% utilisation)** and blob gas used equals blob gas limit). That makes correctness of blob budgeting checks materially relevant when blob usage is high. ([Ethereum (ETH) Blockchain Explorer][2])

[1]: https://raw.githubusercontent.com/gattaca-com/helix/develop/crates/simulator/src/block_merging/mod.rs "raw.githubusercontent.com"
[2]: https://etherscan.io/block/24505725 "
	Ethereum Blocks #24505725 | Etherscan
"
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/gattaca-com/helix/pull/400" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
