### PR TITLE
chore: remove redundant bot clone

### DIFF
--- a/crates/common/src/alerts.rs
+++ b/crates/common/src/alerts.rs
@@ -33,7 +33,6 @@ impl AlertManager {
         match self {
             AlertManager::Disabled => {}
             AlertManager::Telegram { bot, chat_ids } => {
-                let bot = bot.clone();
                 let msg = message.to_owned();
 
                 for chat_id in chat_ids {


### PR DESCRIPTION
Remove redundant bot.clone() in AlertManager::send — bot is already cloned per iteration, so the extra clone before the loop is unnecessary
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/gattaca-com/helix/pull/403" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
