### PR TITLE
chore: make panic hook discord alert non-blocking

### DIFF
--- a/crates/common/src/utils.rs
+++ b/crates/common/src/utils.rs
@@ -160,12 +160,20 @@ pub fn alert_discord(message: &str) {
 
     let content = HashMap::from([("content", msg)]);
 
-    if let Err(err) =
-        reqwest::blocking::Client::new().post(webhook_url.clone()).json(&content).send()
-    {
-        error!("failed to send discord alert: {err}");
-        eprintln!("failed to send discord alert: {err}");
-    }
+    let webhook_url = webhook_url.clone();
+    let content = content.clone();
+
+    std::thread::spawn(move || {
+        let res = reqwest::blocking::Client::new()
+            .post(webhook_url)
+            .json(&content)
+            .timeout(std::time::Duration::from_secs(3))
+            .send();
+
+        if let Err(err) = res {
+            eprintln!("failed to send discord alert: {err}");
+        }
+    });
 }
 
 pub fn save_to_file(path: PathBuf, json: String) {

--- a/crates/common/src/utils.rs
+++ b/crates/common/src/utils.rs
@@ -171,6 +171,7 @@ pub fn alert_discord(message: &str) {
             .send();
 
         if let Err(err) = res {
+            error!("failed to send discord alert: {err}");
             eprintln!("failed to send discord alert: {err}");
         }
     });


### PR DESCRIPTION
Make Discord alert in panic hook non-blocking. Move blocking reqwest call into a separate thread and add timeout
to avoid potential hangs during shutdown.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/gattaca-com/helix/pull/404" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
