### PR TITLE
dcache / use flux ingestion time for metrics

### DIFF
--- a/crates/relay/src/api/builder/submit_block.rs
+++ b/crates/relay/src/api/builder/submit_block.rs
@@ -4,7 +4,10 @@ use axum::{
     Extension,
     response::{IntoResponse, Response},
 };
-use flux::{spine::SpineProducers, timing::Nanos};
+use flux::{
+    spine::SpineProducers,
+    timing::{IngestionTime, Nanos},
+};
 use flux_utils::ArrayStr;
 use helix_common::{
     self, RequestTimings, SubmissionTrace, api_provider::ApiProvider,
@@ -56,14 +59,16 @@ impl<A: Api> BuilderApi<A> {
         let future_ix = api.future_results.push(FutureBidSubmissionResult::new());
 
         match api.submissions.write(body.len(), |buf| buf.copy_from_slice(&body)) {
-            Ok(dref) => api.producer.produce(NewBidSubmission {
-                dref,
-                header,
-                submission_ref: SubmissionRef::Http(future_ix),
-                trace,
-                expected_pubkey: None,
-                sent_at: Nanos::now(),
-            }),
+            Ok(dref) => api.producer.produce_with_ingestion(
+                NewBidSubmission {
+                    dref,
+                    header,
+                    submission_ref: SubmissionRef::Http(future_ix),
+                    trace,
+                    expected_pubkey: None,
+                },
+                IngestionTime::now(),
+            ),
             Err(e) => {
                 tracing::error!("failed to write bid submission into dcache: {e}");
                 return StatusCode::INTERNAL_SERVER_ERROR.into_response()

--- a/crates/relay/src/bid_decoder/tile.rs
+++ b/crates/relay/src/bid_decoder/tile.rs
@@ -1,7 +1,11 @@
 use std::sync::Arc;
 
 use alloy_primitives::B256;
-use flux::{spine::SpineProducers, tile::Tile, timing::Nanos};
+use flux::{
+    spine::SpineProducers,
+    tile::Tile,
+    timing::{InternalMessage, Nanos},
+};
 use flux_utils::{DCache, SharedVector};
 use helix_common::{
     RelayConfig, SubmissionTrace, chain_info::ChainInfo, local_cache::LocalCache,
@@ -44,26 +48,30 @@ pub struct DecoderTile {
 
 impl Tile<HelixSpine> for DecoderTile {
     fn loop_body(&mut self, adapter: &mut flux::spine::SpineAdapter<HelixSpine>) {
-        adapter.consume(|new_bid: NewBidSubmission, producers| {
-            match self.submissions.map(new_bid.dref, |payload| {
-                Self::handle_block_submission(
-                    &self.cache,
-                    &self.chain_info,
-                    &self.config,
-                    &new_bid.submission_ref,
-                    &new_bid.header,
-                    payload,
-                    &mut self.buffer,
-                    new_bid.trace,
-                    new_bid.sent_at,
-                    new_bid.expected_pubkey.as_ref(),
-                )
-            }) {
+        adapter.consume_internal_message(
+            |new_bid: &mut InternalMessage<NewBidSubmission>, producers| match self.submissions.map(
+                new_bid.dref,
+                |payload| {
+                    let sent_at = new_bid.tracking_timestamp().publish_t();
+                    Self::handle_block_submission(
+                        &self.cache,
+                        &self.chain_info,
+                        &self.config,
+                        &new_bid.submission_ref,
+                        &new_bid.header,
+                        payload,
+                        &mut self.buffer,
+                        new_bid.trace,
+                        sent_at,
+                        new_bid.expected_pubkey.as_ref(),
+                    )
+                },
+            ) {
                 Ok(Ok((submission, span))) => {
                     let ix = self.decoded.push(SubmissionDataWithSpan {
                         submission_data: submission,
                         span,
-                        sent_at: new_bid.sent_at,
+                        sent_at: new_bid.tracking_timestamp().publish_t(),
                     });
                     producers.produce(DecodedSubmission { ix });
                 }
@@ -84,8 +92,8 @@ impl Tile<HelixSpine> for DecoderTile {
                         Err(BuilderApiError::InternalError),
                     );
                 }
-            }
-        });
+            },
+        );
     }
 }
 

--- a/crates/relay/src/spine/messages.rs
+++ b/crates/relay/src/spine/messages.rs
@@ -1,4 +1,3 @@
-use flux::timing::Nanos;
 use flux_utils::{ArrayStr, DCacheRef};
 use helix_common::SubmissionTrace;
 use helix_tcp_types::Status;
@@ -17,9 +16,6 @@ pub struct NewBidSubmission {
     pub header: InternalBidSubmissionHeader,
     pub trace: SubmissionTrace,
     pub expected_pubkey: Option<BlsPublicKeyBytes>,
-    // TODO @nina - this is because http path uses StandaloneProducer
-    // which is currently unable to update it's ingestion timestamp
-    pub sent_at: Nanos,
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/crates/relay/src/tcp_bid_recv/mod.rs
+++ b/crates/relay/src/tcp_bid_recv/mod.rs
@@ -132,7 +132,6 @@ impl Tile<HelixSpine> for BidSubmissionTcpListener {
                             submission_ref,
                             trace,
                             expected_pubkey: Some(*expected_pubkey),
-                            sent_at: Nanos::now(),
                         }),
                         Err(e) => {
                             tracing::error!("{e} failed to write the bid submission into dcache");


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/gattaca-com/helix/pull/417" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
