### PR TITLE
chore(script): make helix-relay container lookup more robust

### DIFF
--- a/scripts/devnet/restart_devnet.sh
+++ b/scripts/devnet/restart_devnet.sh
@@ -21,9 +21,15 @@ NETWORK_SUBNET=$(docker network inspect "kt-${ENCLAVE}" --format '{{range .IPAM.
 sudo ufw allow from "$NETWORK_SUBNET" to any port 4040
 sudo ufw allow from "$NETWORK_SUBNET" to any port 9060
 
-# Get proxy container IP
-PROXY_IP=$(docker inspect \
-  "$(docker ps --filter "name=helix-relay" --format '{{.ID}}' | head -1)" \
+# Get helix-relay proxy container IP
+PROXY_CONTAINER=$(docker ps --filter "name=helix-relay" --format '{{.ID}}' | head -n 1)
+
+if [ -z "$PROXY_CONTAINER" ]; then
+    echo "ERROR: helix-relay proxy container not found or not running" >&2
+    exit 1
+fi
+
+PROXY_IP=$(docker inspect "$PROXY_CONTAINER" \
   --format '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}')
 
 # Extract env vars from the service


### PR DESCRIPTION
Improve reliability of helix-relay container IP detection by splitting container lookup and inspect steps and adding an explicit error check when the container is not found
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/gattaca-com/helix/pull/429" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
