### PR TITLE
feat: builder demotion alert with repromote button

### DIFF
--- a/crates/common/src/alerts.rs
+++ b/crates/common/src/alerts.rs
@@ -1,17 +1,44 @@
+use std::sync::Arc;
+
+use alloy_primitives::B256;
+use dashmap::DashMap;
+use helix_types::BlsPublicKeyBytes;
 use teloxide::{
     Bot,
     payloads::SendMessageSetters,
     prelude::Requester,
-    types::{ChatId, ParseMode},
+    types::{ChatId, InlineKeyboardButton, InlineKeyboardMarkup, ParseMode},
 };
 use tracing::error;
+use uuid::Uuid;
 
 use crate::RelayConfig;
+
+#[derive(Clone, Default)]
+pub struct PromotionTokenCache(Arc<DashMap<String, BlsPublicKeyBytes>>);
+
+impl PromotionTokenCache {
+    pub fn insert(&self, pubkey: BlsPublicKeyBytes) -> String {
+        let token = Uuid::new_v4().to_string();
+        self.0.insert(token.clone(), pubkey);
+        token
+    }
+
+    // Consumes token (one-shot — can't reuse)
+    pub fn consume(&self, token: &str) -> Option<BlsPublicKeyBytes> {
+        self.0.remove(token).map(|(_, pubkey)| pubkey)
+    }
+}
 
 #[derive(Clone)]
 pub enum AlertManager {
     Disabled,
-    Telegram { bot: Bot, chat_ids: Vec<ChatId> },
+    Telegram {
+        bot: Bot,
+        chat_ids: Vec<ChatId>,
+        promotion_tokens: PromotionTokenCache,
+        relay_url: String,
+    },
 }
 
 impl AlertManager {
@@ -23,6 +50,8 @@ impl AlertManager {
                 AlertManager::Telegram {
                     bot: Bot::new(&alerts.telegram_bot_token),
                     chat_ids: alerts.chat_ids.clone(),
+                    promotion_tokens: PromotionTokenCache::default(),
+                    relay_url: alerts.relay_url.clone(),
                 }
             }
             _ => AlertManager::Disabled,
@@ -32,7 +61,7 @@ impl AlertManager {
     pub fn send(&self, message: &str) {
         match self {
             AlertManager::Disabled => {}
-            AlertManager::Telegram { bot, chat_ids } => {
+            AlertManager::Telegram { bot, chat_ids, .. } => {
                 let msg = message.to_owned();
 
                 for chat_id in chat_ids {
@@ -51,4 +80,76 @@ impl AlertManager {
             }
         }
     }
+
+    pub fn send_demotion(&self, message: &str, token: &str) {
+        let AlertManager::Telegram { bot, chat_ids, relay_url, .. } = self else { return };
+
+        let url = format!("{relay_url}/relay/v2/data/promote?token={token}");
+
+        for chat_id in chat_ids {
+            let bot = bot.clone();
+            let chat_id = *chat_id;
+            let msg = message.to_owned();
+            let url = url.clone();
+
+            tokio::spawn(async move {
+                let keyboard = InlineKeyboardMarkup::new(vec![vec![InlineKeyboardButton::url(
+                    "🔁 Repromote",
+                    url.parse().expect("valid url"),
+                )]]);
+                if let Err(e) = bot
+                    .send_message(chat_id, msg)
+                    .parse_mode(ParseMode::MarkdownV2)
+                    .reply_markup(keyboard)
+                    .await
+                {
+                    error!("demotion alert send error: {e}");
+                }
+            });
+        }
+    }
+
+    pub fn generate_token(&self, pubkey: BlsPublicKeyBytes) -> String {
+        match self {
+            AlertManager::Telegram { promotion_tokens, .. } => promotion_tokens.insert(pubkey),
+            AlertManager::Disabled => String::new(),
+        }
+    }
+
+    pub fn consume_promotion_token(&self, token: &str) -> Option<BlsPublicKeyBytes> {
+        match self {
+            AlertManager::Telegram { promotion_tokens, .. } => promotion_tokens.consume(token),
+            AlertManager::Disabled => None,
+        }
+    }
+}
+
+pub fn format_demotion_alert(
+    slot: u64,
+    network: &str,
+    region: &str,
+    builder_pubkey: &BlsPublicKeyBytes,
+    builder_id: &str,
+    block_hash: &B256,
+    reason: &str,
+) -> String {
+    format!(
+        "⚠️ *Builder Demoted*\n\
+            \n\
+            *Link:* https://beaconcha\\.in/slot/{slot}\n\
+            *Slot:* `{slot}`\n\
+            *Network:* `{network}`\n\
+            *Region:* `{region}`\n\
+            *Builder Pubkey:* `{builder_pubkey}`\n\
+            *Builder ID:* `{builder_id}`\n\
+            *Block Hash:* `{block_hash}`\n\
+            *Reason:* `{reason}`\n",
+        slot = slot,
+        network = network,
+        region = region,
+        builder_pubkey = builder_pubkey,
+        builder_id = builder_id,
+        block_hash = block_hash,
+        reason = reason,
+    )
 }

--- a/crates/common/src/api/mod.rs
+++ b/crates/common/src/api/mod.rs
@@ -28,3 +28,5 @@ pub const PATH_BUILDER_BIDS_RECEIVED: &str = "/bidtraces/builder_blocks_received
 pub const PATH_VALIDATOR_REGISTRATION: &str = "/validator_registration";
 
 pub const PATH_RELAY_NETWORK: &str = "/relay/v1/network";
+
+pub const PATH_PROMOTE_BUILDER: &str = "/promote";

--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -259,6 +259,7 @@ pub const fn default_u64<const D: u64>() -> u64 {
 pub struct AlertsConfig {
     pub telegram_bot_token: String,
     pub chat_ids: Vec<ChatId>,
+    pub relay_url: String,
 }
 
 #[derive(Serialize, Deserialize, Clone, Default)]
@@ -429,6 +430,7 @@ impl RouterConfig {
             Route::SubmitBlock,
             Route::GetTopBid,
             Route::GetInclusionList,
+            Route::PromoteBuilder,
         ]);
 
         self.replace_condensed_with_real(Route::ProposerApi, &[
@@ -556,6 +558,7 @@ pub enum Route {
     RelayNetwork,
     DataAdjustments,
     MergedBlocks,
+    PromoteBuilder,
 }
 
 impl Route {
@@ -586,6 +589,7 @@ impl Route {
             Route::ValidatorRegistration => format!("{PATH_DATA_API}{PATH_VALIDATOR_REGISTRATION}"),
             Route::DataAdjustments => format!("{PATH_DATA_API}{PATH_DATA_ADJUSTMENTS}"),
             Route::MergedBlocks => format!("{PATH_DATA_API}{PATH_MERGED_BLOCKS}"),
+            Route::PromoteBuilder => format!("{PATH_DATA_API_V2}{PATH_PROMOTE_BUILDER}"),
             Route::All => panic!("All is not a real route"),
             Route::BuilderApi => panic!("BuilderApi is not a real route"),
             Route::ProposerApi => panic!("ProposerApi is not a real route"),

--- a/crates/common/src/http/client.rs
+++ b/crates/common/src/http/client.rs
@@ -67,7 +67,11 @@ impl HttpClient {
     ) -> Result<PendingResponse, HttpClientError> {
         let (transport, mio) = self.connect(url)?;
         let handshake = Box::pin(http1::handshake::<_, Full<Bytes>>(transport));
-        Ok(PendingResponse::new(State::Handshaking { handshake, req }, mio, Events::with_capacity(8)))
+        Ok(PendingResponse::new(
+            State::Handshaking { handshake, req },
+            mio,
+            Events::with_capacity(8),
+        ))
     }
 
     pub fn get(&self, url: &Url) -> Result<PendingResponse, HttpClientError> {

--- a/crates/common/src/http/pending_response.rs
+++ b/crates/common/src/http/pending_response.rs
@@ -13,7 +13,10 @@ use hyper::{
 };
 use mio::{Events, Poll as MioPoll};
 
-use crate::http::{error::HttpClientError, transport::{BoxFuture, HyperConn, Transport}};
+use crate::http::{
+    error::HttpClientError,
+    transport::{BoxFuture, HyperConn, Transport},
+};
 
 pub enum State {
     Handshaking {
@@ -83,7 +86,7 @@ impl Future for PendingResponse {
                             return Poll::Pending;
                         }
                         Poll::Ready(Err(e)) => {
-                            return Poll::Ready(Err(HttpClientError::HyperError(e)))
+                            return Poll::Ready(Err(HttpClientError::HyperError(e)));
                         }
                         Poll::Ready(Ok(response)) => {
                             let status = response.status().as_u16();
@@ -102,10 +105,10 @@ impl Future for PendingResponse {
                             return Poll::Pending;
                         }
                         Poll::Ready(Err(e)) => {
-                            return Poll::Ready(Err(HttpClientError::HyperError(e)))
+                            return Poll::Ready(Err(HttpClientError::HyperError(e)));
                         }
                         Poll::Ready(Ok(collected)) => {
-                            return Poll::Ready(Ok((status, collected.to_bytes())))
+                            return Poll::Ready(Ok((status, collected.to_bytes())));
                         }
                     }
                 }
@@ -141,9 +144,9 @@ impl PendingResponse {
             Poll::Ready(Err(e)) => Poll::Ready(Err(e)),
             Poll::Ready(Ok((status, bytes))) => {
                 if !(200..300).contains(&status) {
-                    return Poll::Ready(Err(HttpClientError::RequestFailed(
-                        format!("HTTP {status}"),
-                    )));
+                    return Poll::Ready(Err(HttpClientError::RequestFailed(format!(
+                        "HTTP {status}"
+                    ))));
                 }
                 Poll::Ready(
                     serde_json::from_slice(&bytes)

--- a/crates/common/src/local_cache.rs
+++ b/crates/common/src/local_cache.rs
@@ -174,7 +174,21 @@ impl LocalCache {
         }
 
         builder_info.is_optimistic = false;
-        builder_info.is_optimistic_for_regional_filtering = false;
+
+        true
+    }
+
+    /// Returns whether builder was non-optimistic before the promotion
+    pub fn promote_builder(&self, builder_pub_key: &BlsPublicKeyBytes) -> bool {
+        let Some(mut builder_info) = self.builder_info_cache.get_mut(builder_pub_key) else {
+            return false;
+        };
+
+        if builder_info.is_optimistic {
+            return false;
+        }
+
+        builder_info.is_optimistic = true;
 
         true
     }

--- a/crates/database/src/handle.rs
+++ b/crates/database/src/handle.rs
@@ -7,6 +7,7 @@ use alloy_primitives::{Address, B256, U256};
 use helix_common::{
     DataAdjustmentsEntry, GetHeaderTrace, GetPayloadTrace, GossipedPayloadTrace, SubmissionTrace,
     ValidatorSummary,
+    alerts::{AlertManager, format_demotion_alert},
     api::{
         builder_api::{BuilderGetValidatorsResponseEntry, InclusionListWithMetadata},
         proposer_api::GetHeaderParams,
@@ -91,12 +92,16 @@ impl DbHandle {
         block_hash: B256,
         reason: String,
         failsafe_triggered: Arc<AtomicBool>,
+        alert_manager: &Arc<AlertManager>,
+        network: &str,
+        region: &str,
+        builder_id: &str,
     ) {
         if let Err(err) = self.sender.try_send(DbRequest::DbDemoteBuilder {
             slot,
             builder_pub_key,
             block_hash,
-            reason,
+            reason: reason.clone(),
             failsafe_triggered: failsafe_triggered.clone(),
         }) {
             error!(%err, "failed to send DbDemoteBuilder request triggering failsafe: stopping all optimistic submissions");
@@ -105,6 +110,24 @@ impl DbHandle {
                 "{} {} {} failed to demote builder in database! Pausing all optmistic submissions",
                 builder_pub_key, err, block_hash
             ));
+
+            let token = alert_manager.generate_token(builder_pub_key);
+            let message = format_demotion_alert(
+                slot,
+                network,
+                region,
+                &builder_pub_key,
+                builder_id,
+                &block_hash,
+                &reason,
+            );
+            alert_manager.send_demotion(&message, &token);
+        }
+    }
+
+    pub fn db_promote_builder(&self, builder_pub_key: BlsPublicKeyBytes) {
+        if let Err(err) = self.sender.try_send(DbRequest::DbPromoteBuilder { builder_pub_key }) {
+            error!(%err, "failed to send DbPromoteBuilder request");
         }
     }
 

--- a/crates/database/src/postgres/postgres_db_service.rs
+++ b/crates/database/src/postgres/postgres_db_service.rs
@@ -67,6 +67,9 @@ pub enum DbRequest {
         reason: String,
         failsafe_triggered: Arc<AtomicBool>,
     },
+    DbPromoteBuilder {
+        builder_pub_key: BlsPublicKeyBytes,
+    },
     SaveGetHeaderCall {
         params: GetHeaderParams,
         best_block_hash: B256,
@@ -588,6 +591,11 @@ impl PostgresDatabaseService {
                         "{} {} {} failed to demote builder in database! Pausing all optmistic submissions",
                         builder_pub_key, err, block_hash
                     ));
+                }
+            }
+            DbRequest::DbPromoteBuilder { builder_pub_key } => {
+                if let Err(err) = self.db_promote_builder(&builder_pub_key).await {
+                    error!(%err, "error promoting builder in database");
                 }
             }
             DbRequest::SaveGetHeaderCall {
@@ -1857,6 +1865,22 @@ impl PostgresDatabaseService {
         transaction.commit().await?;
 
         record.record_success();
+        Ok(())
+    }
+
+    #[instrument(skip_all)]
+    pub async fn db_promote_builder(
+        &self,
+        builder_pub_key: &BlsPublicKeyBytes,
+    ) -> Result<(), DatabaseError> {
+        let client = self.high_priority_pool.get().await?;
+
+        client
+            .execute("UPDATE builder_info SET is_optimistic = TRUE WHERE public_key = $1", &[
+                &(builder_pub_key.as_slice()),
+            ])
+            .await?;
+
         Ok(())
     }
 

--- a/crates/relay/src/api/builder/api.rs
+++ b/crates/relay/src/api/builder/api.rs
@@ -5,7 +5,7 @@ use bytes::Bytes;
 use crossbeam_channel::Sender;
 use flux::spine::StandaloneDCacheProducer;
 use flux_utils::SharedVector;
-use helix_common::{CurrentSlotInfo, RelayConfig, local_cache::LocalCache};
+use helix_common::{CurrentSlotInfo, RelayConfig, alerts::AlertManager, local_cache::LocalCache};
 use helix_database::handle::DbHandle;
 
 use crate::{
@@ -21,6 +21,7 @@ pub struct BuilderApi<A: Api> {
     pub relay_config: Arc<RelayConfig>,
     pub auctioneer_handle: AuctioneerHandle,
     pub api_provider: Arc<A::ApiProvider>,
+    pub alert_manager: Arc<AlertManager>,
     pub producer: StandaloneDCacheProducer<NewBidSubmission>,
     pub future_results: Arc<SharedVector<FutureBidSubmissionResult>>,
     pub submission_payloads: Arc<SharedVector<Bytes>>,
@@ -35,6 +36,7 @@ impl<A: Api> BuilderApi<A> {
         curr_slot_info: CurrentSlotInfo,
         auctioneer_handle: AuctioneerHandle,
         api_provider: Arc<A::ApiProvider>,
+        alert_manager: Arc<AlertManager>,
         producer: StandaloneDCacheProducer<NewBidSubmission>,
         future_results: Arc<SharedVector<FutureBidSubmissionResult>>,
         submission_payloads: Arc<SharedVector<Bytes>>,
@@ -47,6 +49,7 @@ impl<A: Api> BuilderApi<A> {
             curr_slot_info,
             auctioneer_handle,
             api_provider,
+            alert_manager,
             producer,
             future_results,
             submission_payloads,

--- a/crates/relay/src/api/builder/mod.rs
+++ b/crates/relay/src/api/builder/mod.rs
@@ -11,5 +11,7 @@ mod top_bid;
 pub use top_bid::TopBidTile;
 pub use types::*;
 
+pub mod promote;
+
 // #[cfg(test)]
 // mod tests;

--- a/crates/relay/src/api/builder/promote.rs
+++ b/crates/relay/src/api/builder/promote.rs
@@ -1,0 +1,48 @@
+use std::sync::Arc;
+
+use axum::{Extension, extract::Query, response::IntoResponse};
+use http::StatusCode;
+use serde::Deserialize;
+use tracing::warn;
+
+use super::api::BuilderApi;
+use crate::Api;
+
+#[derive(Debug, Deserialize)]
+pub struct PromoteBuilderParams {
+    pub token: String,
+}
+
+impl<A: Api> BuilderApi<A> {
+    #[tracing::instrument(skip_all, fields(builder_pubkey = tracing::field::Empty))]
+    pub async fn promote_builder(
+        Extension(api): Extension<Arc<BuilderApi<A>>>,
+        Query(params): Query<PromoteBuilderParams>,
+    ) -> impl IntoResponse {
+        let Some(builder_pubkey) = api.alert_manager.consume_promotion_token(&params.token) else {
+            warn!("invalid or expired promotion token received");
+            return (StatusCode::UNAUTHORIZED, "invalid or expired promotion token").into_response();
+        };
+
+        tracing::Span::current().record("builder_pubkey", tracing::field::display(builder_pubkey));
+
+        let promoted = api.local_cache.promote_builder(&builder_pubkey);
+
+        if !promoted {
+            warn!(
+                %builder_pubkey,
+                "builder already optimistic or not found"
+            );
+
+            return (StatusCode::BAD_REQUEST, "builder already optimistic or not found")
+                .into_response();
+        }
+
+        api.db.db_promote_builder(builder_pubkey);
+
+        api.alert_manager
+            .send(&format!("✅ *Optimistic promotion successful*\n*Builder:* `{builder_pubkey}`"));
+
+        (StatusCode::OK, "builder promotion successful").into_response()
+    }
+}

--- a/crates/relay/src/api/proposer/mod.rs
+++ b/crates/relay/src/api/proposer/mod.rs
@@ -35,7 +35,7 @@ pub struct ProposerApi<A: Api> {
     pub chain_info: Arc<ChainInfo>,
     pub validator_preferences: Arc<ValidatorPreferences>,
     pub relay_config: RelayConfig,
-    pub alert_manager: AlertManager,
+    pub alert_manager: Arc<AlertManager>,
     pub auctioneer_handle: AuctioneerHandle,
     pub reg_handle: RegWorkerHandle,
 }
@@ -54,6 +54,7 @@ impl<A: Api> ProposerApi<A> {
         curr_slot_info: CurrentSlotInfo,
         auctioneer_handle: AuctioneerHandle,
         reg_handle: RegWorkerHandle,
+        alert_manager: Arc<AlertManager>,
     ) -> Self {
         Self {
             local_cache,
@@ -66,7 +67,7 @@ impl<A: Api> ProposerApi<A> {
             validator_preferences,
             relay_config: relay_config.clone(),
             curr_slot_info,
-            alert_manager: AlertManager::from_relay_config(&relay_config),
+            alert_manager,
             auctioneer_handle,
             reg_handle,
         }

--- a/crates/relay/src/api/router.rs
+++ b/crates/relay/src/api/router.rs
@@ -64,6 +64,7 @@ pub fn build_router<A: Api>(
             Route::GetValidators => get(BuilderApi::<A>::get_validators),
             Route::SubmitBlock => post(BuilderApi::<A>::submit_block),
             Route::GetTopBid => get(BuilderApi::<A>::get_top_bid),
+            Route::PromoteBuilder => get(BuilderApi::<A>::promote_builder),
             Route::Status => get(proposer::status),
             Route::RegisterValidators => post(ProposerApi::<A>::register_validators),
             Route::GetHeader => get(ProposerApi::<A>::get_header),

--- a/crates/relay/src/api/service.rs
+++ b/crates/relay/src/api/service.rs
@@ -9,8 +9,8 @@ use crossbeam_channel::Sender;
 use flux::spine::StandaloneDCacheProducer;
 use flux_utils::SharedVector;
 use helix_common::{
-    CurrentSlotInfo, RelayConfig, beacon::MultiBeaconClient, chain_info::ChainInfo,
-    local_cache::LocalCache, signing::RelaySigningContext,
+    CurrentSlotInfo, RelayConfig, alerts::AlertManager, beacon::MultiBeaconClient,
+    chain_info::ChainInfo, local_cache::LocalCache, signing::RelaySigningContext,
 };
 use helix_data_api::{
     BidsCache, BidsCacheV2, DataApi, DeliveredPayloadsCache, DeliveredPayloadsCacheV2,
@@ -51,6 +51,7 @@ pub fn start_api_service<A: Api>(
     future_results: Arc<SharedVector<FutureBidSubmissionResult>>,
     http_submissions: Arc<SharedVector<Bytes>>,
     web_socket_connections: Sender<RawWebSocket>,
+    alert_manager: Arc<AlertManager>,
 ) {
     tokio::spawn(run_api_service::<A>(
         config.clone(),
@@ -71,6 +72,7 @@ pub fn start_api_service<A: Api>(
         future_results,
         http_submissions,
         web_socket_connections,
+        alert_manager,
     ));
 }
 
@@ -93,6 +95,7 @@ pub async fn run_api_service<A: Api>(
     future_results: Arc<SharedVector<FutureBidSubmissionResult>>,
     http_submissions: Arc<SharedVector<Bytes>>,
     web_socket_connections: Sender<RawWebSocket>,
+    alert_manager: Arc<AlertManager>,
 ) {
     let gossiper = Arc::new(
         GrpcGossiperClientManager::new(config.relays.iter().map(|cfg| cfg.url.clone()).collect())
@@ -111,6 +114,7 @@ pub async fn run_api_service<A: Api>(
         current_slot_info.clone(),
         auctioneer_handle.clone(),
         api_provider.clone(),
+        alert_manager.clone(),
         bid_producer,
         future_results,
         http_submissions,
@@ -133,6 +137,7 @@ pub async fn run_api_service<A: Api>(
         current_slot_info,
         auctioneer_handle,
         registrations_handle,
+        alert_manager,
     ));
 
     tokio::spawn(process_gossip_messages(

--- a/crates/relay/src/auctioneer/context.rs
+++ b/crates/relay/src/auctioneer/context.rs
@@ -12,6 +12,7 @@ use flux::spine::{SpineProducer, SpineProducers};
 use flux_utils::SharedVector;
 use helix_common::{
     BuilderInfo, RelayConfig,
+    alerts::AlertManager,
     chain_info::ChainInfo,
     local_cache::LocalCache,
     metrics::{CACHE_SIZE, SimulatorMetrics},
@@ -67,6 +68,7 @@ pub struct Context<B: BidAdjustor> {
     pub sim_inbound: Arc<SharedVector<SimRequest>>,
     pub accept_optimistic: Arc<AtomicBool>,
     pub failsafe_triggered: Arc<AtomicBool>,
+    pub alert_manager: Arc<AlertManager>,
 }
 
 const EXPECTED_PAYLOADS_PER_SLOT: usize = 5000;
@@ -88,6 +90,7 @@ impl<B: BidAdjustor> Context<B> {
         decoded: Arc<SharedVector<SubmissionDataWithSpan>>,
         future_results: Arc<SharedVector<FutureBidSubmissionResult>>,
         auctioneer_handle: AuctioneerHandle,
+        alert_manager: Arc<AlertManager>,
     ) -> Self {
         let unknown_builder_info = BuilderInfo {
             collateral: U256::ZERO,
@@ -131,6 +134,7 @@ impl<B: BidAdjustor> Context<B> {
             sim_inbound,
             accept_optimistic,
             failsafe_triggered,
+            alert_manager,
         }
     }
 
@@ -189,6 +193,10 @@ impl<B: BidAdjustor> Context<B> {
                             block_hash,
                             reason,
                             failsafe_triggered,
+                            &self.alert_manager,
+                            &self.config.website.network_name,
+                            &self.config.postgres.region_name,
+                            &self.builder_info(&builder).builder_id(),
                         );
                     } else {
                         warn!(%err, %builder, %block_hash, "builder already demoted, skipping demotion");
@@ -312,9 +320,27 @@ impl<B: BidAdjustor> Context<B> {
             let db = self.db.clone();
             let failsafe = self.failsafe_triggered.clone();
             let slot_u64 = slot.as_u64();
+            let alert_manager = self.alert_manager.clone();
+            let network = self.config.website.network_name.clone();
+            let region = self.config.postgres.region_name.clone();
+            let builder_id = self
+                .cache
+                .get_builder_info(&builder_pubkey)
+                .and_then(|i| i.builder_id)
+                .unwrap_or_default();
 
             spawn_tracked!(async move {
-                db.db_demote_builder(slot_u64, builder_pubkey, block_hash, reason, failsafe)
+                db.db_demote_builder(
+                    slot_u64,
+                    builder_pubkey,
+                    block_hash,
+                    reason,
+                    failsafe,
+                    &alert_manager,
+                    &network,
+                    &region,
+                    &builder_id,
+                )
             });
         } else {
             warn!(%reason, %builder_pubkey, %block_hash, "builder already demoted, skipping demotion");
@@ -350,7 +376,10 @@ pub fn send_submission_result<P>(
             if let Some(future) = future_results.get(future_ix) {
                 future.set(result);
             } else {
-                tracing::warn!(future_ix, "submission result dropped: no future found (connection may have closed)");
+                tracing::warn!(
+                    future_ix,
+                    "submission result dropped: no future found (connection may have closed)"
+                );
             }
         }
         SubmissionRef::Tcp { .. } => producers.produce(result),

--- a/crates/relay/src/auctioneer/mod.rs
+++ b/crates/relay/src/auctioneer/mod.rs
@@ -22,6 +22,7 @@ use flux_utils::SharedVector;
 pub use handle::{AuctioneerHandle, GetPayloadKind};
 use helix_common::{
     PayloadAttributesUpdate, RelayConfig,
+    alerts::AlertManager,
     api::builder_api::{BuilderGetValidatorsResponseEntry, InclusionListWithMetadata},
     chain_info::ChainInfo,
     local_cache::LocalCache,
@@ -87,6 +88,7 @@ impl<B: BidAdjustor> Auctioneer<B> {
         accept_optimistic: Arc<AtomicBool>,
         failsafe_triggered: Arc<AtomicBool>,
         slot_events: Arc<SharedVector<SlotUpdate>>,
+        alert_manager: Arc<AlertManager>,
     ) -> Self {
         let ctx = Context::new(
             chain_info,
@@ -101,6 +103,7 @@ impl<B: BidAdjustor> Auctioneer<B> {
             decoded,
             future_results,
             auctioneer_handle,
+            alert_manager,
         );
         Self {
             ctx,

--- a/crates/relay/src/main.rs
+++ b/crates/relay/src/main.rs
@@ -16,6 +16,7 @@ use flux::{
 use flux_utils::SharedVector;
 use helix_common::{
     RelayConfig,
+    alerts::AlertManager,
     api_provider::DefaultApiProvider,
     beacon::{create_beacon_client, load_chain_info},
     expect_env_var, load_config, load_keypair,
@@ -185,6 +186,7 @@ async fn run(
         let decoded = Arc::new(SharedVector::<SubmissionDataWithSpan>::with_capacity(
             MAX_SUBMISSIONS_PER_SLOT,
         ));
+        let alert_manager = Arc::new(AlertManager::from_relay_config(&config));
 
         let bid_producer =
             spine.spine.standalone_dcache_producer_for(TileName::from_str_truncate("Api"));
@@ -207,6 +209,7 @@ async fn run(
             future_results.clone(),
             http_submissions.clone(),
             web_socket_send,
+            alert_manager.clone(),
         );
 
         if config.website.enabled {
@@ -311,6 +314,7 @@ async fn run(
                 accept_optimistic,
                 failsafe_triggered,
                 slot_events,
+                alert_manager.clone(),
             );
             attach_tile(
                 auctioneer,

--- a/crates/relay/src/simulator/tile.rs
+++ b/crates/relay/src/simulator/tile.rs
@@ -219,15 +219,12 @@ impl SimulatorTile {
             // A dropped dehydrated request may carry full transactions that haven't
             // been inserted into the cache yet. Hydrate it now so subsequent
             // dehydrated submissions from this builder can resolve their tx hashes.
-            if let Some(evicted_req) = evicted
-                && let Some(data) = self.decoded.get(evicted_req.decoded_ix)
-                    && let Submission::Dehydrated(d) =
-                        data.submission_data.submission.clone()
-                    {
-                        let _ = self
-                            .hydration_cache
-                            .hydrate(d, self.chain_info.max_blobs_per_block());
-                    }
+            if let Some(evicted_req) = evicted &&
+                let Some(data) = self.decoded.get(evicted_req.decoded_ix) &&
+                let Submission::Dehydrated(d) = data.submission_data.submission.clone()
+            {
+                let _ = self.hydration_cache.hydrate(d, self.chain_info.max_blobs_per_block());
+            }
         }
     }
 

--- a/crates/tcp-types/src/lib.rs
+++ b/crates/tcp-types/src/lib.rs
@@ -145,7 +145,7 @@ impl TryFrom<&[u8]> for BidSubmissionHeader {
 
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         if value.len() < BID_SUB_HEADER_SIZE {
-            return Err(ParseError::SubmissionTooShort)
+            return Err(ParseError::SubmissionTooShort);
         }
         let sequence_number = u32::from_be_bytes(value[..4].try_into().unwrap());
         let merge_type =


### PR DESCRIPTION
## Changes

### Alert on demotion
When a builder is demoted due to block validation failure in `_get_payload`, a Telegram message is sent to all configured chat IDs containing:
- beaconcha.in link for the slot
- slot, network, region, builder pubkey, builder ID, block hash, reason
- Inline "🔁 Repromote" button linking to the promote endpoint with a one-shot UUID token

### Repromote endpoint
`GET /relay/v2/data/promote?token=<uuid>` on BuilderApi:
- Validates the token against the in-memory PromotionTokenCache (tokens are one-shot and consumed on use)
- Promotes the builder in LocalCache
- Fires `db_promote_builder` to update `builder_info` in the DB
- Sends a success Telegram alert

### AlertManager changes
- Added `PromotionTokenCache` (`Arc<DashMap<String, BlsPublicKeyBytes>>`) to the `Telegram` variant
- Added `send_demotion` for sending the alert with the inline keyboard
- Added `generate_token` and `consume_promotion_token` helpers
- `AlertManager` is now constructed once as `Arc<AlertManager>` and shared between `ProposerApi` and `BuilderApi`


Closes #437 