### PR TITLE
Fix for api_key cache bug:

### DIFF
--- a/crates/common/src/local_cache.rs
+++ b/crates/common/src/local_cache.rs
@@ -91,8 +91,8 @@ pub struct LocalCache {
     // TODO: this should be an ArcSwap
     pub inclusion_list: Arc<RwLock<Option<InclusionListWithKey>>>,
     builder_info_cache: Arc<DashMap<BlsPublicKeyBytes, BuilderInfo>>,
-    /// Api key -> builder pubkey
-    pub api_key_cache: Arc<DashMap<String, Vec<BlsPublicKeyBytes>>>,
+    /// Cache of API keys for builders. Used to validate incoming requests.
+    pub api_key_cache: Arc<DashSet<String>>,
     primev_proposers: Arc<DashSet<BlsPublicKeyBytes>>,
     kill_switch: Arc<AtomicBool>,
     proposer_duties: Arc<RwLock<Vec<BuilderGetValidatorsResponseEntry>>>,
@@ -109,7 +109,7 @@ impl LocalCache {
     pub fn new() -> Self {
         let builder_info_cache =
             Arc::new(DashMap::with_capacity(ESTIMATED_BUILDER_INFOS_UPPER_BOUND));
-        let api_key_cache = Arc::new(DashMap::with_capacity(ESTIMATED_BUILDER_INFOS_UPPER_BOUND));
+        let api_key_cache = Arc::new(DashSet::with_capacity(ESTIMATED_BUILDER_INFOS_UPPER_BOUND));
         let primev_proposers = Arc::new(DashSet::with_capacity(MAX_PRIMEV_PROPOSERS));
         let kill_switch = Arc::new(AtomicBool::new(false));
         let proposer_duties = Arc::new(RwLock::new(Vec::with_capacity(1000)));
@@ -156,11 +156,7 @@ impl LocalCache {
     }
 
     pub fn contains_api_key(&self, api_key: &str) -> bool {
-        self.api_key_cache.contains_key(api_key)
-    }
-
-    pub fn validate_api_key(&self, api_key: &str, pubkey: &BlsPublicKeyBytes) -> bool {
-        self.api_key_cache.get(api_key).is_some_and(|p| p.value().contains(pubkey))
+        self.api_key_cache.contains(api_key)
     }
 
     /// Returns whether builder was optimistic before the demotion
@@ -200,7 +196,7 @@ impl LocalCache {
 
         for builder_info in builder_infos {
             if let Some(api_key) = builder_info.builder_info.api_key.as_ref() {
-                self.api_key_cache.entry(api_key.clone()).or_default().push(builder_info.pub_key);
+                self.api_key_cache.insert(api_key.clone());
             }
 
             self.builder_info_cache.insert(builder_info.pub_key, builder_info.builder_info.clone());

--- a/crates/relay/src/bid_decoder/tile.rs
+++ b/crates/relay/src/bid_decoder/tile.rs
@@ -320,7 +320,7 @@ impl DecoderTile {
 
             true
         } else {
-            header.api_key.is_some_and(|api_key| cache.validate_api_key(&api_key, &builder_pubkey))
+            header.api_key.is_some_and(|api_key| cache.contains_api_key(&api_key))
         };
 
         match submission {

--- a/crates/relay/src/tcp_bid_recv/mod.rs
+++ b/crates/relay/src/tcp_bid_recv/mod.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, net::SocketAddr, sync::Arc};
 
 use bytes::Bytes;
-use dashmap::DashMap;
+use dashmap::DashSet;
 use flux::{spine::FluxSpine, tile::Tile, timing::Nanos};
 use flux_network::{
     Token,
@@ -35,7 +35,7 @@ type SubmissionError = (Token, Option<u32>, Option<Uuid>, BidSubmissionError);
 pub struct BidSubmissionTcpListener {
     listener: TcpConnector,
 
-    api_key_cache: Arc<DashMap<String, Vec<BlsPublicKeyBytes>>>,
+    api_key_cache: Arc<DashSet<String>>,
 
     to_disconnect: Vec<Token>,
     registered: HashMap<Token, BlsPublicKeyBytes>,
@@ -49,7 +49,7 @@ pub struct BidSubmissionTcpListener {
 impl BidSubmissionTcpListener {
     pub fn new(
         listener_addr: SocketAddr,
-        api_key_cache: Arc<DashMap<String, Vec<BlsPublicKeyBytes>>>,
+        api_key_cache: Arc<DashSet<String>>,
         max_connections: usize,
         dcache_ptr: DCachePtr,
         http_submissions: Arc<SharedVector<Bytes>>,
@@ -143,11 +143,7 @@ impl Tile<HelixSpine> for BidSubmissionTcpListener {
                     match RegistrationMsg::from_ssz_bytes(payload) {
                         Ok(msg) => {
                             let api_key = Uuid::from_bytes(msg.api_key).to_string();
-                            if self
-                                .api_key_cache
-                                .get(&api_key)
-                                .is_some_and(|p| p.value().contains(&msg.builder_pubkey))
-                            {
+                            if self.api_key_cache.contains(&api_key) {
                                 self.registered.insert(token, msg.builder_pubkey);
                             } else {
                                 tracing::error!(


### PR DESCRIPTION
The api_key_cache can not be a mapping to builder pubkey as the api_key is not unique per pubkey. There is only one key given to each builder and each builder can have many pubkeys.

This can currently lead to validation failing for a valid bid submission. It is sufficient to check that the key used is valid without ensuring the key relates to the pubkey used.