### PR TITLE
Fix for missing reg db updates

### DIFF
--- a/crates/database/src/lib.rs
+++ b/crates/database/src/lib.rs
@@ -45,7 +45,6 @@ pub async fn start_db_service(
             let postgres_db = postgres_db.clone();
             let local_cache = local_cache.clone();
             let is_registration_instance = config.is_registration_instance;
-            let mut validator_reg_update_time = SystemTime::now();
             async move {
                 load_known_validators_with_snapshot(
                     &postgres_db,
@@ -54,7 +53,7 @@ pub async fn start_db_service(
                 )
                 .await;
 
-                load_validator_registrations_with_snapshot(
+                let mut validator_reg_update_time = load_validator_registrations_with_snapshot(
                     &postgres_db,
                     &local_cache,
                     snapshot_dir.as_deref(),
@@ -81,7 +80,7 @@ pub async fn start_db_service(
                     postgres_db.update_validator_registrations(validator_reg_update_time).await;
                     validator_reg_update_time = fetch_time;
                     if let Some(dir) = &snapshot_dir {
-                        save_validator_registrations_snapshot(&local_cache, dir);
+                        save_validator_registrations_snapshot(&local_cache, dir, fetch_time);
                     }
                     postgres_db.load_builder_infos(local_cache.clone()).await;
                 }
@@ -115,35 +114,42 @@ async fn load_known_validators_with_snapshot(
     }
 }
 
+/// Returns the fetch watermark to resume incremental registration updates from.
 async fn load_validator_registrations_with_snapshot(
     db: &PostgresDatabaseService,
     cache: &local_cache::LocalCache,
     snapshot_dir: Option<&std::path::Path>,
-) {
+) -> SystemTime {
     if let Some(dir) = snapshot_dir &&
-        let Some(entries) = snapshot::try_load_validator_registrations(dir).await
+        let Some((fetched_at, entries)) = snapshot::try_load_validator_registrations(dir).await
     {
         let count = entries.len();
         info!(count, "using validator_registrations snapshot");
         for (key, entry) in entries {
             cache.validator_registration_cache.insert(key, entry);
         }
-        return;
+        return fetched_at;
     }
     // Fallback to DB
+    let fetch_time = SystemTime::now();
     db.load_validator_registrations().await;
     // Save snapshot for next startup
     if let Some(dir) = snapshot_dir {
-        save_validator_registrations_snapshot(cache, dir);
+        save_validator_registrations_snapshot(cache, dir, fetch_time);
     }
+    fetch_time
 }
 
-fn save_validator_registrations_snapshot(cache: &local_cache::LocalCache, dir: &std::path::Path) {
+fn save_validator_registrations_snapshot(
+    cache: &local_cache::LocalCache,
+    dir: &std::path::Path,
+    fetched_at: SystemTime,
+) {
     let entries: Vec<_> =
         cache.validator_registration_cache.iter().map(|r| (*r.key(), r.value().clone())).collect();
     let dir = dir.to_path_buf();
     tokio::task::spawn_blocking(move || {
-        if let Err(e) = snapshot::save_validator_registrations(&dir, &entries) {
+        if let Err(e) = snapshot::save_validator_registrations(&dir, fetched_at, &entries) {
             tracing::warn!("failed to save validator_registrations snapshot: {e}");
         }
     });

--- a/crates/database/src/snapshot.rs
+++ b/crates/database/src/snapshot.rs
@@ -2,6 +2,7 @@ use std::{
     fs,
     io::{self, BufReader, BufWriter},
     path::Path,
+    time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
 use helix_common::SignedValidatorRegistrationEntry;
@@ -46,9 +47,13 @@ pub fn load_known_validators(dir: &Path) -> io::Result<FxHashSet<BlsPublicKeyByt
 }
 
 // -- Validator registrations --
+//
+// Format: (fetched_at unix ms, entries). `fetched_at` is captured before the DB fetch that
+// produced the entries, so resuming incremental updates from it cannot miss registrations.
 
 pub fn save_validator_registrations(
     dir: &Path,
+    fetched_at: SystemTime,
     entries: &[(BlsPublicKeyBytes, SignedValidatorRegistrationEntry)],
 ) -> io::Result<()> {
     fs::create_dir_all(dir)?;
@@ -56,7 +61,9 @@ pub fn save_validator_registrations(
     let tmp = path.with_extension("bin.tmp");
     let file = fs::File::create(&tmp)?;
     let writer = BufWriter::new(file);
-    serde_json::to_writer(writer, entries).map_err(io::Error::other)?;
+    let fetched_at_ms =
+        fetched_at.duration_since(UNIX_EPOCH).unwrap_or_default().as_millis() as u64;
+    serde_json::to_writer(writer, &(fetched_at_ms, entries)).map_err(io::Error::other)?;
     fs::rename(&tmp, &path)?;
     info!(count = entries.len(), "saved validator_registrations snapshot");
     Ok(())
@@ -64,15 +71,17 @@ pub fn save_validator_registrations(
 
 pub fn load_validator_registrations(
     dir: &Path,
-) -> io::Result<Vec<(BlsPublicKeyBytes, SignedValidatorRegistrationEntry)>> {
+) -> io::Result<(SystemTime, Vec<(BlsPublicKeyBytes, SignedValidatorRegistrationEntry)>)> {
     let path = dir.join(VALIDATOR_REGISTRATIONS_FILE);
     let file = fs::File::open(&path)?;
     let reader = BufReader::new(file);
-    let entries: Vec<(BlsPublicKeyBytes, SignedValidatorRegistrationEntry)> =
-        serde_json::from_reader(reader)
-            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+    let (fetched_at_ms, entries): (
+        u64,
+        Vec<(BlsPublicKeyBytes, SignedValidatorRegistrationEntry)>,
+    ) = serde_json::from_reader(reader)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
     info!(count = entries.len(), "loaded validator_registrations from snapshot");
-    Ok(entries)
+    Ok((UNIX_EPOCH + Duration::from_millis(fetched_at_ms), entries))
 }
 
 /// Try to load from snapshot, returning None on any failure (missing file, corrupt, etc).
@@ -93,10 +102,10 @@ pub async fn try_load_known_validators(dir: &Path) -> Option<FxHashSet<BlsPublic
 
 pub async fn try_load_validator_registrations(
     dir: &Path,
-) -> Option<Vec<(BlsPublicKeyBytes, SignedValidatorRegistrationEntry)>> {
+) -> Option<(SystemTime, Vec<(BlsPublicKeyBytes, SignedValidatorRegistrationEntry)>)> {
     let dir = dir.to_path_buf();
     match tokio::task::spawn_blocking(move || load_validator_registrations(&dir)).await {
-        Ok(Ok(entries)) => Some(entries),
+        Ok(Ok(snapshot)) => Some(snapshot),
         Ok(Err(e)) => {
             warn!("validator_registrations snapshot unavailable: {e}");
             None


### PR DESCRIPTION
Currently if helix crashes and is down for over five mins, it will be reg updates to the db that happened when it was down.

To fix this we now store the last update time in the snapshot file.