### PR TITLE
Set TCP_NODELAY on raw websocket connections

### DIFF
--- a/crates/relay/src/api/extract/raw_web_socket.rs
+++ b/crates/relay/src/api/extract/raw_web_socket.rs
@@ -114,6 +114,12 @@ impl RawWebSocketUpgrade {
                 }
             };
 
+            // Without TCP_NODELAY, Nagle + the subscriber's delayed ACKs
+            // batch the small frames into ~40ms bursts.
+            if let Err(e) = std_tcp.set_nodelay(true) {
+                error!("failed to set TCP_NODELAY on upgraded websocket: {e}");
+            }
+
             let ws =
                 protocol::WebSocket::from_raw_socket(std_tcp, protocol::Role::Server, Some(config));
             callback(ws);

--- a/crates/relay/src/api/extract/raw_web_socket.rs
+++ b/crates/relay/src/api/extract/raw_web_socket.rs
@@ -114,12 +114,6 @@ impl RawWebSocketUpgrade {
                 }
             };
 
-            // Without TCP_NODELAY, Nagle + the subscriber's delayed ACKs
-            // batch the small frames into ~40ms bursts.
-            if let Err(e) = std_tcp.set_nodelay(true) {
-                error!("failed to set TCP_NODELAY on upgraded websocket: {e}");
-            }
-
             let ws =
                 protocol::WebSocket::from_raw_socket(std_tcp, protocol::Role::Server, Some(config));
             callback(ws);

--- a/crates/relay/src/api/service.rs
+++ b/crates/relay/src/api/service.rs
@@ -4,6 +4,7 @@ use std::{
     time::Duration,
 };
 
+use axum::serve::ListenerExt;
 use bytes::Bytes;
 use crossbeam_channel::Sender;
 use flux::spine::StandaloneDCacheProducer;
@@ -183,8 +184,14 @@ pub async fn run_api_service<A: Api>(
         terminating,
     );
 
-    let listener =
-        tokio::net::TcpListener::bind(format!("0.0.0.0:{}", config.api_port)).await.unwrap();
+    let listener = tokio::net::TcpListener::bind(format!("0.0.0.0:{}", config.api_port))
+        .await
+        .unwrap()
+        .tap_io(|tcp_stream| {
+            if let Err(e) = tcp_stream.set_nodelay(true) {
+                error!("failed to set TCP_NODELAY on incoming connection: {e}");
+            }
+        });
     match axum::serve(listener, router.into_make_service_with_connect_info::<SocketAddr>()).await {
         Ok(_) => info!("Server exited successfully"),
         Err(e) => error!("Server exited with error: {e}"),


### PR DESCRIPTION
## What

Sets `TCP_NODELAY` on every accepted API connection via `ListenerExt::tap_io` on the accept path. Covers both websocket streams — `/top_bid` (raw websocket) and `/header_stream` (axum websocket, whose socket is not reachable per-endpoint) — as well as the HTTP endpoints.

## Why

Top-bid frames are small (~180B) and sent every ~1-2ms. With Nagle on, once a segment is in flight the following frames are held until it is ACKed — and a read-only subscriber only ACKs on its delayed-ACK timer. The result is that updates stamped (`TopBidUpdate.timestamp`) tens of milliseconds apart are delivered in a single burst.

Measured from four subscriber connections (two hosts collocated with the relay, two connections each), comparing `TopBidUpdate.timestamp` against local receive time:

- baseline delivery lag: p50 < 1ms, p90 ~1-3ms
- ~20% of slots contain a 20-150ms stall; p999 ≈ 40ms — the classic Nagle × delayed-ACK number
- during a stall, frames stamped across a ~40ms span all arrive within ~0.15ms of each other
- stalls are frequently synchronized across independent connections and hosts (same fanout write pattern hits every Nagle-enabled socket at the same moment), with the remainder per-connection

Example: frames stamped over a 38ms span arrived as one burst, lag jumping 0.2ms → 37.7ms with no intermediate values, while a second connection on the same client host happened to receive the same frames on time.

Dense update streams self-heal (frames accumulate a full MSS and flush), which is why only a fraction of slots are affected — but the stalls land exactly during bid races, where subscribers are most latency-sensitive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
