### PR TITLE
test(operator): reproduce overlapping peer replacement failure

### DIFF
--- a/crates/operator/src/lib.rs
+++ b/crates/operator/src/lib.rs
@@ -77,6 +77,8 @@ impl OperatorPubSub {
             out_recv,
             in_send,
             mode,
+            #[cfg(test)]
+            None,
         ));
 
         Self { outgoing_msgs, incoming_msgs, task_handle: handle.abort_handle() }
@@ -261,13 +263,14 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
+    use std::{collections::HashSet, net::UdpSocket, str::FromStr, time::Duration};
 
     use alloy_primitives::B256;
+    use async_channel::{Receiver, bounded};
     use helix_types::{BlsPublicKeyBytes, Demotion, OperatorMessage, Promotion};
-    use libp2p::{Multiaddr, identity::Keypair};
+    use libp2p::{Multiaddr, PeerId, identity::Keypair};
 
-    use crate::{Operator, OperatorPubSub};
+    use crate::{Operator, OperatorPubSub, pubsub::TestNetEvent};
 
     #[tokio::test]
     async fn operator_p2p() {
@@ -317,5 +320,222 @@ mod tests {
         op_b.send(OperatorMessage::Promotion(promotion)).await.unwrap();
         let (_, msg) = op_a.recv().await.unwrap();
         assert!(matches!(msg, OperatorMessage::Promotion(_)));
+    }
+
+    #[tokio::test]
+    async fn replacement_with_same_peer_id_receives_replay_from_incumbents() {
+        let mesh = overlapping_replacement_mesh().await;
+
+        assert_eq!(
+            receive_demotion_sources(&mesh.replacement, 2).await,
+            HashSet::from(["operator A".to_string(), "operator B".to_string()]),
+            "replacement should receive each incumbent's subscription-triggered replay",
+        );
+    }
+
+    #[tokio::test]
+    async fn replacement_with_same_peer_id_publishes_after_stale_connection_closes() {
+        let mut mesh = overlapping_replacement_mesh().await;
+        drop(mesh.original);
+        wait_for_connection_closed(&mesh.events_a, mesh.replacement_peer_id, 1).await;
+        wait_for_connection_closed(&mesh.events_b, mesh.replacement_peer_id, 1).await;
+
+        let builder_pubkey = BlsPublicKeyBytes::random();
+        mesh.replacement
+            .send(OperatorMessage::Promotion(Promotion { ts_ms: 3, slot: 3, builder_pubkey }))
+            .await
+            .unwrap();
+
+        receive_promotion_from(&mut mesh.incumbent_a, "operator C", builder_pubkey).await;
+        receive_promotion_from(&mut mesh.incumbent_b, "operator C", builder_pubkey).await;
+    }
+
+    struct ReplacementMesh {
+        incumbent_a: OperatorPubSub,
+        incumbent_b: OperatorPubSub,
+        original: OperatorPubSub,
+        replacement: OperatorPubSub,
+        events_a: Receiver<TestNetEvent>,
+        events_b: Receiver<TestNetEvent>,
+        replacement_peer_id: PeerId,
+    }
+
+    async fn overlapping_replacement_mesh() -> ReplacementMesh {
+        let [port_a, port_b, port_c, port_c_replacement] = unused_udp_ports();
+        let keypair_a = Keypair::generate_secp256k1();
+        let keypair_b = Keypair::generate_secp256k1();
+        let keypair_c = Keypair::generate_secp256k1();
+        let replacement_peer_id = PeerId::from_public_key(&keypair_c.public());
+
+        let operator_a = operator("operator A", &keypair_a, port_a);
+        let operator_b = operator("operator B", &keypair_b, port_b);
+        let operator_c = operator("operator C", &keypair_c, port_c);
+
+        // Start C first so A and B each establish exactly one initial connection to it.
+        let (original, _) =
+            test_pubsub(port_c, keypair_c.clone(), vec![operator_a.clone(), operator_b.clone()]);
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        let (incumbent_a, events_a) =
+            test_pubsub(port_a, keypair_a, vec![operator_c.clone()]);
+        let (incumbent_b, events_b) = test_pubsub(port_b, keypair_b, vec![operator_c]);
+        wait_for_connection_established(&events_a, replacement_peer_id, 1).await;
+        wait_for_connection_established(&events_b, replacement_peer_id, 1).await;
+
+        incumbent_a
+            .send(OperatorMessage::Demotion(Demotion {
+                ts_ms: 1,
+                slot: 1,
+                builder_pubkey: BlsPublicKeyBytes::random(),
+                block_hash: B256::random(),
+                reason_msg: b"operator A replay".to_vec(),
+            }))
+            .await
+            .unwrap();
+        incumbent_b
+            .send(OperatorMessage::Demotion(Demotion {
+                ts_ms: 2,
+                slot: 2,
+                builder_pubkey: BlsPublicKeyBytes::random(),
+                block_hash: B256::random(),
+                reason_msg: b"operator B replay".to_vec(),
+            }))
+            .await
+            .unwrap();
+        assert_eq!(
+            receive_demotion_sources(&original, 2).await,
+            HashSet::from(["operator A".to_string(), "operator B".to_string()]),
+        );
+
+        // A replacement process uses C's identity while C's old connections remain alive.
+        let (replacement, _) =
+            test_pubsub(port_c_replacement, keypair_c, vec![operator_a, operator_b]);
+        wait_for_connection_established(&events_a, replacement_peer_id, 2).await;
+        wait_for_connection_established(&events_b, replacement_peer_id, 2).await;
+
+        ReplacementMesh {
+            incumbent_a,
+            incumbent_b,
+            original,
+            replacement,
+            events_a,
+            events_b,
+            replacement_peer_id,
+        }
+    }
+
+    fn test_pubsub(
+        port: u16,
+        keypair: Keypair,
+        operators: Vec<Operator>,
+    ) -> (OperatorPubSub, Receiver<TestNetEvent>) {
+        let (outgoing_msgs, out_recv) = bounded(128);
+        let (in_send, incoming_msgs) = bounded(128);
+        let (event_send, event_recv) = bounded(128);
+        let handle = tokio::spawn(crate::pubsub::run_operator_connection(
+            port,
+            keypair,
+            operators,
+            out_recv,
+            in_send,
+            helix_common::OperatorP2pMode::On,
+            Some(event_send),
+        ));
+        (
+            OperatorPubSub { outgoing_msgs, incoming_msgs, task_handle: handle.abort_handle() },
+            event_recv,
+        )
+    }
+
+    fn operator(name: &str, keypair: &Keypair, port: u16) -> Operator {
+        Operator {
+            name: name.into(),
+            pubkey: keypair.public(),
+            multiaddr: Multiaddr::from_str(&format!("/ip4/127.0.0.1/udp/{port}/quic-v1")).unwrap(),
+            operator_group: None,
+        }
+    }
+
+    fn unused_udp_ports() -> [u16; 4] {
+        let sockets =
+            std::array::from_fn::<_, 4, _>(|_| UdpSocket::bind(("127.0.0.1", 0)).unwrap());
+        sockets.map(|socket| socket.local_addr().unwrap().port())
+    }
+
+    async fn wait_for_connection_established(
+        events: &Receiver<TestNetEvent>,
+        expected_peer: PeerId,
+        expected_count: u32,
+    ) {
+        tokio::time::timeout(Duration::from_secs(10), async {
+            loop {
+                if let TestNetEvent::ConnectionEstablished { peer_id, num_established } =
+                    events.recv().await.unwrap()
+                    && peer_id == expected_peer
+                    && num_established == expected_count
+                {
+                    return;
+                }
+            }
+        })
+        .await
+        .expect("expected peer connection was not established");
+    }
+
+    async fn wait_for_connection_closed(
+        events: &Receiver<TestNetEvent>,
+        expected_peer: PeerId,
+        expected_remaining: u32,
+    ) {
+        tokio::time::timeout(Duration::from_secs(10), async {
+            loop {
+                if let TestNetEvent::ConnectionClosed { peer_id, remaining_established } =
+                    events.recv().await.unwrap()
+                    && peer_id == expected_peer
+                    && remaining_established == expected_remaining
+                {
+                    return;
+                }
+            }
+        })
+        .await
+        .expect("stale peer connection was not closed");
+    }
+
+    async fn receive_demotion_sources(pubsub: &OperatorPubSub, expected: usize) -> HashSet<String> {
+        tokio::time::timeout(Duration::from_secs(3), async {
+            let mut sources = HashSet::new();
+            while sources.len() < expected {
+                let (operator, message) = pubsub.recv().await.unwrap();
+                if matches!(message, OperatorMessage::Demotion(_)) {
+                    sources.insert(operator.name);
+                }
+            }
+            sources
+        })
+        .await
+        .expect("timed out waiting for incumbent replay")
+    }
+
+    async fn receive_promotion_from(
+        pubsub: &mut OperatorPubSub,
+        expected_operator: &str,
+        expected_pubkey: BlsPublicKeyBytes,
+    ) {
+        tokio::time::timeout(Duration::from_secs(3), async {
+            loop {
+                let (operator, message) = pubsub.recv().await.unwrap();
+                if operator.name == expected_operator
+                    && matches!(
+                        message,
+                        OperatorMessage::Promotion(Promotion { builder_pubkey, .. })
+                            if builder_pubkey == expected_pubkey
+                    )
+                {
+                    return;
+                }
+            }
+        })
+        .await
+        .expect("incumbent did not receive replacement's live publication");
     }
 }

--- a/crates/operator/src/pubsub.rs
+++ b/crates/operator/src/pubsub.rs
@@ -24,6 +24,13 @@ struct NetBehaviour {
     ping: ping::Behaviour,
 }
 
+#[cfg(test)]
+#[derive(Debug)]
+pub(super) enum TestNetEvent {
+    ConnectionEstablished { peer_id: PeerId, num_established: u32 },
+    ConnectionClosed { peer_id: PeerId, remaining_established: u32 },
+}
+
 pub(super) async fn run_operator_connection(
     quic_port: u16,
     keypair: Keypair,
@@ -31,6 +38,7 @@ pub(super) async fn run_operator_connection(
     outgoing: Receiver<OperatorMessage>,
     incoming: Sender<(Operator, OperatorMessage)>,
     mode: OperatorP2pMode,
+    #[cfg(test)] test_events: Option<Sender<TestNetEvent>>,
 ) -> Result<(), OperatorError> {
     let floodsub_topic = floodsub::Topic::new("operator");
     let local_peer_id = PeerId::from_public_key(&keypair.public());
@@ -170,14 +178,28 @@ pub(super) async fn run_operator_connection(
                     }
                     NetBehaviourEvent::Ping(_) => {}
                 }
-                SwarmEvent::ConnectionEstablished { peer_id, .. } => {
+                SwarmEvent::ConnectionEstablished { peer_id, num_established, .. } => {
                     if peers.contains_key(&peer_id) {
                         connected_peers += 1;
+                        #[cfg(test)]
+                        if let Some(events) = &test_events {
+                            let _ = events.try_send(TestNetEvent::ConnectionEstablished {
+                                peer_id,
+                                num_established: num_established.get(),
+                            });
+                        }
                     }
                 }
-                SwarmEvent::ConnectionClosed { peer_id, .. } => {
+                SwarmEvent::ConnectionClosed { peer_id, num_established, .. } => {
                     if peers.contains_key(&peer_id) {
                         connected_peers = connected_peers.saturating_sub(1);
+                        #[cfg(test)]
+                        if let Some(events) = &test_events {
+                            let _ = events.try_send(TestNetEvent::ConnectionClosed {
+                                peer_id,
+                                remaining_established: num_established,
+                            });
+                        }
                     }
                 }
                 _ => {},


### PR DESCRIPTION
## Purpose

This is a test-only reproduction of operator P2P failure during an overlapping process replacement that reuses the same libp2p identity (`PeerId`). It intentionally does not propose a production fix, so the maintainers can decide whether this replacement pattern should be supported.

The fixture creates two incumbent peers connected to an original process, then starts a replacement process with the original process's identity while the old connections are still established.

It demonstrates both directions separately:

- the replacement does not receive the incumbents' subscription-triggered replay;
- after the old connections close, the incumbents do not receive a live publication from the replacement.

Only `#[cfg(test)]` event hooks and test code are added; release behavior is unchanged.

## Why this happens

Floodsub exchanges topic subscriptions only on the first established connection to a `PeerId`. The overlapping replacement creates a second connection for that same `PeerId`, so it does not receive the incumbent subscription state. Replay triggered by the replacement's subscription can also be sent through either connection. When the old connection closes while the replacement connection remains, floodsub does not treat the peer as disconnected and rebuild the missing state.

## Reproduction

On current `develop`:

```text
cargo test -q -p helix-operator operator_p2p -- --nocapture
# passes

cargo test -q -p helix-operator replacement_with_same_peer_id_receives_replay_from_incumbents -- --nocapture
# fails: timed out waiting for incumbent replay

cargo test -q -p helix-operator replacement_with_same_peer_id_publishes_after_stale_connection_closes -- --nocapture
# fails: incumbent did not receive replacement's live publication
```

Each regression failed 10/10 runs during verification. The existing `operator_p2p` test still passes.

## Scope caveat

The deterministic fixture uses a valid three-peer topology where the two incumbents connect to the replacement identity but not to each other. In a full mesh, connection ordering can mask the replay-in direction, but the replacement's live publish-out direction still reproduced.

If overlapping replacement with a shared identity is intended to work, these tests can accompany a fix. If it is intentionally unsupported, this PR can be closed and the required stop-before-start lifecycle documented instead.
