### PR TITLE
combined adjustable + mergeable submissions

### DIFF
--- a/crates/common/src/decoder.rs
+++ b/crates/common/src/decoder.rs
@@ -8,9 +8,12 @@ use flate2::read::GzDecoder;
 use flux_profiler::timed;
 use helix_types::{
     BidAdjustmentData, BlockMergingData, Compression, DehydratedBidSubmission,
-    DehydratedBidSubmissionFuluWithAdjustments, DehydratedBidSubmissionFuluWithMergingData,
-    ForkName, ForkVersionDecode, MergeType, SignedBidSubmission,
-    SignedBidSubmissionWithAdjustments, SignedBidSubmissionWithMergingData, Submission,
+    DehydratedBidSubmissionFuluWithAdjustments,
+    DehydratedBidSubmissionFuluWithAdjustmentsAndMergingData,
+    DehydratedBidSubmissionFuluWithMergingData, ForkName, ForkVersionDecode, MergeType,
+    SignedBidSubmission, SignedBidSubmissionWithAdjustments,
+    SignedBidSubmissionWithAdjustmentsAndMergingData, SignedBidSubmissionWithMergingData,
+    Submission,
 };
 use http::{
     HeaderMap, HeaderValue, StatusCode,
@@ -280,6 +283,18 @@ impl SubmissionDecoder {
     ) -> Result<(Submission, Option<BlockMergingData>, Option<BidAdjustmentData>), DecoderError>
     {
         if self.merge_type == MergeType::Mergeable {
+            if self.with_adjustments {
+                let sub: DehydratedBidSubmissionFuluWithAdjustmentsAndMergingData =
+                    self.decode_by_fork(body, self.fork_name)?;
+                let (submission, adjustment_data, merging_data) = sub.split();
+
+                return Ok((
+                    Submission::Dehydrated(submission),
+                    Some(merging_data),
+                    Some(adjustment_data),
+                ));
+            }
+
             let sub_with_merging: DehydratedBidSubmissionFuluWithMergingData =
                 self.decode_by_fork(body, self.fork_name)?;
             let (submission, merging_data) = sub_with_merging.split();
@@ -326,22 +341,32 @@ impl SubmissionDecoder {
         body: &[u8],
     ) -> Result<(Submission, Option<BlockMergingData>, Option<BidAdjustmentData>), DecoderError>
     {
-        let sub_with_merging: SignedBidSubmissionWithMergingData = self._decode(body)?;
+        let (submission, merging_data, bid_adjustment) = if self.with_adjustments {
+            let sub: SignedBidSubmissionWithAdjustmentsAndMergingData = self._decode(body)?;
+            let (submission, adjustment_data, merging_data) = sub.split();
+
+            (submission, merging_data, Some(adjustment_data))
+        } else {
+            let sub_with_merging: SignedBidSubmissionWithMergingData = self._decode(body)?;
+
+            (sub_with_merging.submission, sub_with_merging.merging_data, None)
+        };
+
         let merging_data = match self.merge_type {
-            MergeType::Mergeable => Some(sub_with_merging.merging_data),
+            MergeType::Mergeable => Some(merging_data),
             //Handle append-only by creating empty mergeable orders
             //this allows builder to switch between append-only and mergeable without changing
             // submission alternatively we could reject or ignore append-only here if the
             // submission is mergeable?
             MergeType::AppendOnly => Some(BlockMergingData {
-                allow_appending: sub_with_merging.merging_data.allow_appending,
-                builder_address: sub_with_merging.merging_data.builder_address,
+                allow_appending: merging_data.allow_appending,
+                builder_address: merging_data.builder_address,
                 merge_orders: vec![],
             }),
-            MergeType::None => Some(sub_with_merging.merging_data),
+            MergeType::None => Some(merging_data),
             MergeType::Pause => None,
         };
-        Ok((Submission::Full(sub_with_merging.submission), merging_data, None))
+        Ok((Submission::Full(submission), merging_data, bid_adjustment))
     }
 
     #[timed]
@@ -486,7 +511,9 @@ fn gzip_size_hint(buf: &[u8]) -> Option<usize> {
 mod tests {
     use helix_types::{
         BidAdjData, BidAdjustmentDataV1, BlobsBundle, BundleOrder, DehydratedBidSubmission,
-        DehydratedBidSubmissionFuluWithMergingData, MergeType, Order, TestRandom,
+        DehydratedBidSubmissionFuluWithAdjustmentsAndMergingData,
+        DehydratedBidSubmissionFuluWithMergingData, MergeType, Order,
+        SignedBidSubmissionWithAdjustmentsAndMergingData, TestRandom,
     };
     use ssz::Encode;
 
@@ -886,5 +913,127 @@ mod tests {
         assert!(matches!(decoded_submission, Submission::Dehydrated(_)));
         assert!(merging_data.is_none());
         assert!(bid_adjustment.is_none());
+    }
+
+    #[test]
+    fn decode_dehydrated_mergeable_with_adjustments_carries_both() {
+        let submission = DehydratedBidSubmissionFuluWithAdjustmentsAndMergingData::random_for_test(
+            &mut rand::rng(),
+        );
+        let body = submission.as_ssz_bytes();
+        let (_, expected_adjustment_data, expected_merging_data) = submission.split();
+
+        let params = SubmissionDecoderParams {
+            compression: Compression::None,
+            encoding: Encoding::Ssz,
+            merge_type: MergeType::Mergeable,
+            is_dehydrated: true,
+            with_mergeable_data: false,
+            with_adjustments: true,
+            mark_all_txs_mergeable: false,
+            fork_name: ForkName::Fulu,
+        };
+        let mut decoder = SubmissionDecoder::new(&params);
+        let mut buf = Vec::new();
+        let (decoded_submission, merging_data, bid_adjustment_data) =
+            decoder.decode(&body, &mut buf).expect("decode should succeed");
+
+        assert!(matches!(decoded_submission, Submission::Dehydrated(_)));
+        assert_eq!(
+            merging_data.expect("combined submission should carry merging data"),
+            expected_merging_data
+        );
+        assert_eq!(
+            bid_adjustment_data.expect("combined submission should carry adjustment data"),
+            expected_adjustment_data
+        );
+    }
+
+    #[test]
+    fn decode_merge_mergeable_with_adjustments_carries_both() {
+        let submission =
+            SignedBidSubmissionWithAdjustmentsAndMergingData::random_for_test(&mut rand::rng());
+        let body = submission.as_ssz_bytes();
+        let expected_block_hash = submission.message.block_hash;
+        let (_, expected_adjustment_data, expected_merging_data) = submission.split();
+
+        let params = SubmissionDecoderParams {
+            compression: Compression::None,
+            encoding: Encoding::Ssz,
+            merge_type: MergeType::Mergeable,
+            is_dehydrated: false,
+            with_mergeable_data: true,
+            with_adjustments: true,
+            mark_all_txs_mergeable: false,
+            fork_name: ForkName::Fulu,
+        };
+        let mut decoder = SubmissionDecoder::new(&params);
+        let mut buf = Vec::new();
+        let (decoded_submission, merging_data, bid_adjustment_data) =
+            decoder.decode(&body, &mut buf).expect("decode should succeed");
+
+        match decoded_submission {
+            Submission::Full(s) => assert_eq!(s.message.block_hash, expected_block_hash),
+            Submission::Dehydrated(_) => panic!("expected full submission"),
+        }
+        assert_eq!(
+            merging_data.expect("combined submission should carry merging data"),
+            expected_merging_data
+        );
+        assert_eq!(
+            bid_adjustment_data.expect("combined submission should carry adjustment data"),
+            expected_adjustment_data
+        );
+    }
+
+    #[test]
+    fn decode_merge_append_only_with_adjustments_carries_adjustments_and_clears_orders() {
+        // Retry until a non-empty `merge_orders` shows up, since that's what proves AppendOnly
+        // actively clears them on the adjustments path too.
+        let (body, expected_adjustment_data, expected_allow_appending, expected_builder_address) =
+            (0..100)
+                .find_map(|_| {
+                    let submission =
+                        SignedBidSubmissionWithAdjustmentsAndMergingData::random_for_test(
+                            &mut rand::rng(),
+                        );
+                    if submission.merging_data.merge_orders.is_empty() {
+                        return None;
+                    }
+                    let body = submission.as_ssz_bytes();
+                    let (_, adjustment_data, merging_data) = submission.split();
+                    Some((
+                        body,
+                        adjustment_data,
+                        merging_data.allow_appending,
+                        merging_data.builder_address,
+                    ))
+                })
+                .expect("should produce a submission with non-empty merge_orders within 100 tries");
+
+        let params = SubmissionDecoderParams {
+            compression: Compression::None,
+            encoding: Encoding::Ssz,
+            merge_type: MergeType::AppendOnly,
+            is_dehydrated: false,
+            with_mergeable_data: true,
+            with_adjustments: true,
+            mark_all_txs_mergeable: false,
+            fork_name: ForkName::Fulu,
+        };
+        let mut decoder = SubmissionDecoder::new(&params);
+        let mut buf = Vec::new();
+        let (decoded_submission, merging_data, bid_adjustment_data) =
+            decoder.decode(&body, &mut buf).expect("decode should succeed");
+
+        assert!(matches!(decoded_submission, Submission::Full(_)));
+        let merging_data = merging_data.expect("append-only should still carry merging data");
+        assert!(merging_data.merge_orders.is_empty());
+        assert_eq!(merging_data.allow_appending, expected_allow_appending);
+        assert_eq!(merging_data.builder_address, expected_builder_address);
+        assert_eq!(
+            bid_adjustment_data.expect("adjustments should be carried"),
+            expected_adjustment_data
+        );
     }
 }

--- a/crates/types/src/bid_submission.rs
+++ b/crates/types/src/bid_submission.rs
@@ -15,9 +15,11 @@ use tree_hash::TreeHash;
 use tree_hash_derive::TreeHash;
 
 use crate::{
-    BlobsBundle, BlobsError, Bloom, BlsPublicKey, BlsPublicKeyBytes, BlsSignature,
-    BlsSignatureBytes, DehydratedBidSubmission, ExecutionPayload, ExtraData, PayloadAndBlobs,
-    SszError, TestRandom, bid_adjustment_data::BidAdjustmentData, error::SigError,
+    BlobsBundle, BlobsError, BlockMergingData, Bloom, BlsPublicKey, BlsPublicKeyBytes,
+    BlsSignature, BlsSignatureBytes, DehydratedBidSubmission, ExecutionPayload, ExtraData,
+    PayloadAndBlobs, SszError, TestRandom,
+    bid_adjustment_data::{BidAdjData, BidAdjustmentData, BidAdjustmentDataV1},
+    error::SigError,
     fields::ExecutionRequests,
 };
 
@@ -734,6 +736,51 @@ impl SignedBidSubmissionWithAdjustments {
     }
 }
 
+/// Flat combination of [`SignedBidSubmissionWithAdjustments`] and merging data:
+/// core fields ++ bid_adjustment_data ++ merging_data.
+#[derive(Debug, Clone, Serialize, Deserialize, Encode, Decode)]
+pub struct SignedBidSubmissionWithAdjustmentsAndMergingData {
+    pub message: BidTrace,
+    pub execution_payload: Arc<ExecutionPayload>,
+    pub blobs_bundle: Arc<BlobsBundle>,
+    pub execution_requests: Arc<ExecutionRequests>,
+    pub signature: BlsSignatureBytes,
+    pub bid_adjustment_data: BidAdjustmentData,
+    pub merging_data: BlockMergingData,
+}
+
+impl SignedBidSubmissionWithAdjustmentsAndMergingData {
+    pub fn split(self) -> (SignedBidSubmission, BidAdjustmentData, BlockMergingData) {
+        (
+            SignedBidSubmission {
+                message: self.message,
+                execution_payload: self.execution_payload,
+                blobs_bundle: self.blobs_bundle,
+                execution_requests: self.execution_requests,
+                signature: self.signature,
+            },
+            self.bid_adjustment_data,
+            self.merging_data,
+        )
+    }
+}
+
+impl TestRandom for SignedBidSubmissionWithAdjustmentsAndMergingData {
+    fn random_for_test(rng: &mut impl rand::RngCore) -> Self {
+        Self {
+            message: BidTrace::random_for_test(rng),
+            execution_payload: ExecutionPayload::random_for_test(rng).into(),
+            blobs_bundle: BlobsBundle::with_capacity(0).into(),
+            execution_requests: ExecutionRequests::random_for_test(rng).into(),
+            signature: BlsSignatureBytes::random(),
+            bid_adjustment_data: BidAdjustmentData::V1(BidAdjustmentDataV1::Original(
+                BidAdjData::default(),
+            )),
+            merging_data: BlockMergingData::random_for_test(rng),
+        }
+    }
+}
+
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct SubmissionVersion {
     on_receive_ns: u64,
@@ -864,5 +911,28 @@ mod tests {
         let s = test_encode_decode_ssz::<SignedBidSubmission>(&data_ssz);
         assert_eq!(data_ssz, s.as_ssz_bytes().as_slice());
         assert_eq!(s.fork_name(), ForkName::Fulu);
+    }
+
+    #[test]
+    fn with_adjustments_and_merging_data_ssz_round_trip() {
+        let data_ssz =
+            SignedBidSubmissionWithAdjustmentsAndMergingData::random_for_test(&mut rand::rng())
+                .as_ssz_bytes();
+        let s =
+            test_encode_decode_ssz::<SignedBidSubmissionWithAdjustmentsAndMergingData>(&data_ssz);
+        assert_eq!(data_ssz, s.as_ssz_bytes().as_slice());
+    }
+
+    #[test]
+    // the combined type is a flat append: the variable-size heap ends with the
+    // bid_adjustment_data bytes followed by the merging_data bytes
+    fn with_adjustments_and_merging_data_flat_layout() {
+        let combined =
+            SignedBidSubmissionWithAdjustmentsAndMergingData::random_for_test(&mut rand::rng());
+        let bytes = combined.as_ssz_bytes();
+
+        let mut tail = combined.bid_adjustment_data.as_ssz_bytes();
+        tail.extend(combined.merging_data.as_ssz_bytes());
+        assert!(bytes.ends_with(&tail));
     }
 }

--- a/crates/types/src/hydration.rs
+++ b/crates/types/src/hydration.rs
@@ -13,7 +13,7 @@ use tree_hash::TreeHash;
 use crate::{
     BidTrace, Blob, BlobsBundle, BlockMergingData, BlockValidationError, BlsPublicKeyBytes,
     BlsSignatureBytes, ExecutionPayload, SignedBidSubmission, TestRandom,
-    bid_adjustment_data::BidAdjustmentData,
+    bid_adjustment_data::{BidAdjData, BidAdjustmentData, BidAdjustmentDataV1},
     bid_submission,
     fields::{ExecutionRequests, KzgCommitment, KzgProof, Transaction},
 };
@@ -272,6 +272,72 @@ impl TestRandom for DehydratedBidSubmissionFuluWithMergingData {
             execution_requests: Arc::new(ExecutionRequests::random_for_test(rng)),
             signature: BlsSignatureBytes::random(),
             tx_root: None,
+            merging_data: BlockMergingData::random_for_test(rng),
+        }
+    }
+}
+
+/// Flat combination of [`DehydratedBidSubmissionFuluWithAdjustments`] and merging data:
+/// core fields ++ bid_adjustment_data ++ merging_data.
+#[derive(Debug, Clone, Serialize, Deserialize, Encode, Decode)]
+pub struct DehydratedBidSubmissionFuluWithAdjustmentsAndMergingData {
+    message: BidTrace,
+    execution_payload: ExecutionPayload,
+    blobs_bundle: DehydratedBlobsFulu,
+    execution_requests: Arc<ExecutionRequests>,
+    signature: BlsSignatureBytes,
+    tx_root: Option<B256>,
+    bid_adjustment_data: BidAdjustmentData,
+    merging_data: BlockMergingData,
+}
+
+impl DehydratedBidSubmissionFuluWithAdjustmentsAndMergingData {
+    pub fn split(self) -> (DehydratedBidSubmission, BidAdjustmentData, BlockMergingData) {
+        (
+            DehydratedBidSubmission::Fulu(DehydratedBidSubmissionFulu {
+                message: self.message,
+                execution_payload: self.execution_payload,
+                blobs_bundle: self.blobs_bundle,
+                execution_requests: self.execution_requests,
+                signature: self.signature,
+                tx_root: self.tx_root,
+            }),
+            self.bid_adjustment_data,
+            self.merging_data,
+        )
+    }
+}
+
+impl ForkVersionDecode for DehydratedBidSubmissionFuluWithAdjustmentsAndMergingData {
+    fn from_ssz_bytes_by_fork(bytes: &[u8], fork: ForkName) -> Result<Self, DecodeError> {
+        match fork {
+            ForkName::Base |
+            ForkName::Altair |
+            ForkName::Bellatrix |
+            ForkName::Capella |
+            ForkName::Deneb |
+            ForkName::Gloas |
+            ForkName::Heze |
+            ForkName::Electra => Err(DecodeError::NoMatchingVariant),
+            ForkName::Fulu => {
+                DehydratedBidSubmissionFuluWithAdjustmentsAndMergingData::from_ssz_bytes(bytes)
+            }
+        }
+    }
+}
+
+impl TestRandom for DehydratedBidSubmissionFuluWithAdjustmentsAndMergingData {
+    fn random_for_test(rng: &mut impl rand::RngCore) -> Self {
+        Self {
+            message: BidTrace::random_for_test(rng),
+            execution_payload: ExecutionPayload::random_for_test(rng),
+            blobs_bundle: DehydratedBlobsFulu { commitments: vec![], new_items: vec![] },
+            execution_requests: Arc::new(ExecutionRequests::random_for_test(rng)),
+            signature: BlsSignatureBytes::random(),
+            tx_root: None,
+            bid_adjustment_data: BidAdjustmentData::V1(BidAdjustmentDataV1::Original(
+                BidAdjData::default(),
+            )),
             merging_data: BlockMergingData::random_for_test(rng),
         }
     }
@@ -642,6 +708,38 @@ mod tests {
 
         let (dehydrated, split_merging_data) = submission.split();
 
+        assert_eq!(split_merging_data, expected_merging_data);
+        assert!(matches!(dehydrated, DehydratedBidSubmission::Fulu(_)));
+    }
+
+    #[test]
+    fn dehydrated_with_adjustments_and_merging_data_ssz_round_trip() {
+        let submission = DehydratedBidSubmissionFuluWithAdjustmentsAndMergingData::random_for_test(
+            &mut rand::rng(),
+        );
+
+        let bytes = submission.as_ssz_bytes();
+        let decoded =
+            DehydratedBidSubmissionFuluWithAdjustmentsAndMergingData::from_ssz_bytes(&bytes)
+                .expect("SSZ decode should succeed");
+
+        assert_eq!(submission.message, decoded.message);
+        assert_eq!(submission.bid_adjustment_data, decoded.bid_adjustment_data);
+        assert_eq!(submission.merging_data, decoded.merging_data);
+        assert_eq!(bytes, decoded.as_ssz_bytes());
+    }
+
+    #[test]
+    fn dehydrated_with_adjustments_and_merging_data_split() {
+        let submission = DehydratedBidSubmissionFuluWithAdjustmentsAndMergingData::random_for_test(
+            &mut rand::rng(),
+        );
+        let expected_adjustment_data = submission.bid_adjustment_data.clone();
+        let expected_merging_data = submission.merging_data.clone();
+
+        let (dehydrated, split_adjustment_data, split_merging_data) = submission.split();
+
+        assert_eq!(split_adjustment_data, expected_adjustment_data);
         assert_eq!(split_merging_data, expected_merging_data);
         assert!(matches!(dehydrated, DehydratedBidSubmission::Fulu(_)));
     }


### PR DESCRIPTION
# Issue

A submission can carry bid adjustment data or block merging data, but not both. The two are signaled independently (`WITH_ADJUSTMENTS` flag, `merge_type`), but no body encoding carries both extensions, and the decoder drops one of the two when both are signaled: the dehydrated mergeable path ignores the with-adjustments flag, and the with-adjustments path errors on `merge_type: mergeable`.

A builder submitting mergeable blocks therefore loses bid adjustment on those bids entirely.

# Solution

Add a combined body encoding — core fields ++ `bid_adjustment_data` ++ `merging_data` — selected by the existing signals (with-adjustments flag set and `merge_type: mergeable`), and have the decoder return both extensions. Existing single-extension wire formats are unchanged.

The body layout matches the combined submission format already accepted by the ultra sound relay, so builders can use a single encoder for both relays.

# Details

- new flat body types `SignedBidSubmissionWithAdjustmentsAndMergingData` and `DehydratedBidSubmissionFuluWithAdjustmentsAndMergingData` carrying both `bid_adjustment_data` and `merging_data` (core fields ++ bid_adjustment_data ++ merging_data)
- decoder dispatches on (with_adjustments, merge_type) instead of treating them as exclusive: dehydrated and default paths decode the combined body when the with-adjustments flag is set and merge_type is mergeable, returning both merging and adjustment data
- existing single-extension wire formats and AppendOnly / mark_all_txs_mergeable behavior unchanged
- tests: SSZ round-trips for both new types, flat byte-layout assertion, decoder dispatch tests for both paths
