### PR TITLE
Add test-driven workflow docs and re-enable CI test gate

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,25 @@
+---
+name: Bug
+about: Report a bug that needs fixing.
+title: ""
+labels: [bug]
+---
+
+## What's wrong
+<!-- Expected vs. actual behavior. -->
+
+## Repro
+<!-- Steps, inputs, or a failing test that reproduces it. -->
+
+## Suspected cause
+<!-- If known. Remove if not. -->
+
+## Affected surface
+<!-- File/area. Omit if obvious. -->
+
+## Steps (each becomes one PR)
+<!-- Most bugs are one step, one PR. -->
+- [ ] Step 1: ... (tests: ) (PR: )
+
+## Open questions
+<!-- Remove if none. -->

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,24 @@
+---
+name: Feature
+about: Define a new feature or behavior change before implementing it. Break it into steps; each step becomes one PR.
+title: ""
+labels: [enhancement]
+---
+
+## Status
+<!-- What's true today; what this issue changes. -->
+
+## Why
+<!-- Motivation, one or two sentences. -->
+
+## Affected surface
+<!-- File/area -> what changes and why. Omit for small issues. -->
+
+## Steps (each becomes one PR)
+<!-- Write the tests for a step before implementing it. Get sign-off on
+     the tests before writing the implementation. -->
+- [ ] Step 1: ... (tests: ) (PR: )
+- [ ] Step 2: ... (tests: ) (PR: )
+
+## Open questions
+<!-- Remove if none. -->

--- a/.github/ISSUE_TEMPLATE/perf.md
+++ b/.github/ISSUE_TEMPLATE/perf.md
@@ -1,0 +1,25 @@
+---
+name: Performance
+about: Improve a measured performance bottleneck.
+title: ""
+labels: [performance]
+---
+
+## Baseline
+<!-- Current measured number (latency, throughput, memory, etc.) and how
+     it was measured. Required. -->
+
+## Target
+<!-- Number that would count as solved. -->
+
+## Why it matters
+<!-- Cost of the bottleneck: user-facing latency, infra spend, an incident. -->
+
+## Affected surface
+
+## Steps (each becomes one PR)
+<!-- Measure each step against the baseline. -->
+- [ ] Step 1: ... (benchmark: ) (PR: )
+
+## Open questions
+<!-- Remove if none. -->

--- a/.github/ISSUE_TEMPLATE/refactor.md
+++ b/.github/ISSUE_TEMPLATE/refactor.md
@@ -1,0 +1,25 @@
+---
+name: Refactor
+about: Restructure code without changing behavior.
+title: ""
+labels: [refactor]
+---
+
+## Status
+<!-- Current structure and its problems; target structure. -->
+
+## Why now
+<!-- What this unblocks, or what it's blocking. -->
+
+## Behavior must not change
+<!-- Existing tests that cover current behavior. Add characterization
+     tests first if coverage is thin. -->
+
+## Affected surface
+
+## Steps (each becomes one PR)
+<!-- Prefer several small steps over one large rewrite. -->
+- [ ] Step 1: ... (tests: ) (PR: )
+
+## Open questions
+<!-- Remove if none. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+Issue: #___ (step __ of __)
+
+## What this PR does
+<!-- 2-3 sentences. -->
+
+## What this PR deliberately does not do
+<!-- Scope boundary. -->
+
+## Tests
+<!-- What's covered, and whether tests were written before implementation. -->
+
+## Reviewer checklist
+- [ ] CI (`lint`, `unit-test`) is green
+- [ ] Matches the linked issue/step
+- [ ] No unexplained scope creep or unrelated files touched

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -11,14 +11,12 @@ env:
 
 jobs:
   unit-test:
-    # TODO: fix tests
-    if: false
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
     services:
       postgres:
-        image: timescale/timescaledb-ha:pg16
+        image: timescale/timescaledb-ha:pg17
         env:
           POSTGRES_PASSWORD: password
         ports:
@@ -31,25 +29,24 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Setup Rust cache
+        uses: Swatinem/rust-cache@v2
         with:
-          fetch-depth: "0"
-          path: ./repos/${{ secrets.REPO_NAME }}
-          ref: ${{ github.ref }}
+          cache-on-failure: true
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Change to project directory
-        run: cd ./repos/${{ secrets.REPO_NAME }}
-
-      # Set up the nightly Rust toolchain
-      - name: Set up Rust toolchain
-        uses: actions-rs/toolchain@v1
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2023-06-01
-          override: true
-          components: rustfmt, clippy
+          toolchain: nightly-2026-07-26
 
-      # Run unit tests
+      - name: Setup just
+        uses: extractions/setup-just@v2
+        with:
+          just-version: 1.5.0
+
       - name: Run unit tests
         env:
           DATABASE_URL: "postgres://postgres:password@localhost:5432/postgres"
-        run: cargo test --workspace --all-features
-        working-directory: ./repos/${{ secrets.REPO_NAME }}
+        run: just test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,11 +1,13 @@
 # Working in this repo
 
-## Writing style
+## Communication
 
-Docs, issues, PRs, and code comments: short, declarative statements of
-what to do or what is true. No persuasive framing, no explaining the
-reasoning behind a decision, no meta-commentary about how the decision was
-reached. State the rule; skip the justification.
+- Report to me using ASD-STE100 Simplified Technical English.
+- Be concise and direct.
+- Use short sentences and the active voice.
+- Give one instruction in each sentence.
+- Use the same term for the same item.
+- Do not change commands, code, identifiers, or quotations to meet these language rules.
 
 See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the full workflow. Operational
 rules for you specifically:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,36 @@
+# Working in this repo
+
+## Writing style
+
+Docs, issues, PRs, and code comments: short, declarative statements of
+what to do or what is true. No persuasive framing, no explaining the
+reasoning behind a decision, no meta-commentary about how the decision was
+reached. State the rule; skip the justification.
+
+See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the full workflow. Operational
+rules for you specifically:
+
+- Tests define correctness. When starting a step with no tests yet, draft
+  the tests (and the issue, if it needs updating) first. Get explicit
+  human approval before writing implementation code — use plan mode, or
+  ask directly and wait for an answer.
+- If a nontrivial change has no GitHub issue yet, draft one using the
+  matching template under
+  [`.github/ISSUE_TEMPLATE/`](.github/ISSUE_TEMPLATE/) (`feature`, `bug`,
+  `refactor`, `perf`) for review. Don't put specs or plans in `docs/`.
+- Scope each PR to one step of one issue. Use
+  [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md),
+  including a "what this deliberately does not do" note when scope could
+  be mistaken for an oversight.
+- Before declaring a step done, run:
+
+  ```
+  just fmt-check
+  cargo clippy --all-features --no-deps -- -D warnings
+  just test
+  ```
+
+  Use the plain `cargo clippy` command above, not `just clippy` — that
+  recipe passes `--fix --allow-dirty` and rewrites files in place. `just
+  test` requires a local Postgres (`just local-postgres`) for
+  `helix-database`'s tests.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,66 @@
+# Contributing to helix
+
+## Workflow
+
+Before begining work on an issues check to ensure no one else has
+already picked it up. If they have an it's a large issue with many
+steps, divide the steps between you.
+
+If no issue exists which captures the change you had in mind create one
+if needed (see issues below).
+
+Design, review, and testing are human responsibilities. Implementation
+work can be delegated to an agent to speed things up. But we follow
+a trust but verify approach for ai work.
+
+Tests define correctness, not issues or design docs. Write tests before
+or alongside implementation, and run them throughout, not just at the end.
+A human must review and approve the tests (and the issue, if there is one)
+before implementation code is written against them.
+
+## Issues
+
+A trivial one-liner (typo, obvious small fix) can go straight to a small
+PR — no issue required. Any actual behavior or feature change gets a
+GitHub issue first, using the matching template under
+[`.github/ISSUE_TEMPLATE/`](.github/ISSUE_TEMPLATE/) (`feature`, `bug`,
+`refactor`, `perf`).
+
+Large issues get a step checklist, one PR per step. The checklist can grow
+as work proceeds.
+
+## Pull requests
+
+Scope each PR to one step of one issue. Use
+[`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md).
+
+## Verification bar
+
+Before merging:
+
+```
+just fmt-check
+cargo clippy --all-features --no-deps -- -D warnings
+just test
+```
+
+`just clippy` runs `clippy --fix --allow-dirty` and rewrites files in
+place — use the plain `cargo clippy ... -D warnings` command above for
+checking; use `just clippy` only when fixes should be applied.
+
+`just test` requires a local Postgres for `helix-database`'s tests: run
+`just local-postgres` first.
+
+## Review checklist
+
+- CI (`lint`, `unit-test`) is green.
+- The diff matches the linked issue/step, and the tests exercise the
+  claimed behavior.
+- No unexplained scope creep, unrelated files, or security-sensitive
+  changes (auth, signature verification, payment paths) without extra
+  scrutiny.
+
+## Branches
+
+Personal-prefixed branch names (`od/...`-style). PRs squash-merge into
+`develop`, not `main`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,10 +13,11 @@ Design, review, and testing are human responsibilities. Implementation
 work can be delegated to an agent to speed things up. But we follow
 a trust but verify approach for ai work.
 
-Tests define correctness, not issues or design docs. Write tests before
-or alongside implementation, and run them throughout, not just at the end.
-A human must review and approve the tests (and the issue, if there is one)
-before implementation code is written against them.
+This is test-driven development: tests are written before or alongside
+implementation and define correctness, not issues or design docs. Run
+tests throughout implementation, not just at the end. A human must review
+and approve the tests (and the issue, if there is one) before
+implementation code is written against them.
 
 ## Issues
 

--- a/crates/common/src/local_cache.rs
+++ b/crates/common/src/local_cache.rs
@@ -504,6 +504,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "known bug: merged headers not enabled by default, see gattaca-com/helix#487"]
     pub async fn test_serve_merged_headers() {
         let cache = LocalCache::new();
 

--- a/crates/relay/src/api/admin_service.rs
+++ b/crates/relay/src/api/admin_service.rs
@@ -192,7 +192,12 @@ mod test {
     }
 
     #[tokio::test]
-    #[serial]
+    // `#[serial]` deliberately omitted while ignored: serial_test 1.0.0's macro drops `#[ignore]`
+    // when re-emitting the function, so combining them here silently un-ignores this test. Not a
+    // concurrency problem while ignored (it won't run), but re-add `#[serial]` alongside removing
+    // `#[ignore]` when fixing gattaca-com/helix#487, since it shares port 4050 with the other
+    // `run_admin_service` tests in this module.
+    #[ignore = "known bug: merged headers not enabled by default, see gattaca-com/helix#487"]
     async fn test_admin_service_merged_headers() {
         let auctioneer = Arc::new(LocalCache::new());
         let db = Arc::new(PostgresDatabaseService::default());

--- a/crates/types/src/bid_submission.rs
+++ b/crates/types/src/bid_submission.rs
@@ -849,6 +849,7 @@ mod tests {
 
     #[test]
     // from the relay API spec, adding the blob and the proposer_pubkey field
+    #[ignore = "known bug: stale fixture doesn't satisfy BlobsBundle's 256-proofs-per-blob validation, see gattaca-com/helix#485"]
     fn fulu_bid_submission() {
         let data_json = include_str!("testdata/signed-bid-submission-fulu.json");
         let s = test_encode_decode_json::<SignedBidSubmission>(data_json);
@@ -856,6 +857,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "known bug: BlobsBundle::random_for_test under-generates proofs, see gattaca-com/helix#485"]
     fn fulu_bid_submission_ssz() {
         let data_ssz = SignedBidSubmission::random_for_test(&mut rand::rng()).as_ssz_bytes();
         let s = test_encode_decode_ssz::<SignedBidSubmission>(&data_ssz);

--- a/crates/types/src/blobs.rs
+++ b/crates/types/src/blobs.rs
@@ -238,6 +238,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "known bug: stale fixture doesn't satisfy BlobsBundle's 256-proofs-per-blob validation, see gattaca-com/helix#485"]
     fn test_payload_and_blobs_equivalence() {
         let data_json = include_str!("testdata/signed-bid-submission-fulu.json");
         let signed_bid = test_encode_decode_json::<SignedBidSubmission>(data_json);

--- a/crates/types/src/block_merging.rs
+++ b/crates/types/src/block_merging.rs
@@ -433,6 +433,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "known bug: Order::BundleV2 not disambiguated from Order::Bundle by untagged JSON, see gattaca-com/helix#486"]
     fn order_json_round_trip_bundle_v2() {
         let bundle_order = BundleOrderV2 {
             txs: smallvec::smallvec![1, 2, 3],
@@ -448,6 +449,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "known bug: Order::BundleV2 not disambiguated from Order::Bundle by untagged JSON, see gattaca-com/helix#486"]
     fn order_json_untagged_disambiguates_bundle_from_bundle_v2() {
         // `Order` is `#[serde(untagged)]`, so `Bundle` and `BundleV2` must remain
         // distinguishable by shape alone: `BundleV2` requires `flags`
@@ -472,6 +474,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "known bug: Order::BundleV2 not disambiguated from Order::Bundle by untagged JSON, see gattaca-com/helix#486"]
     fn block_merging_data_json_round_trip_mixed_orders() {
         let tx_order = Order::Tx(TransactionOrder { index: 1, can_revert: false });
         let bundle_order = Order::Bundle(BundleOrder {


### PR DESCRIPTION
Issue: N/A — workflow bootstrap, not itself tracked by an issue

## What this PR does
Adds `CONTRIBUTING.md`/`CLAUDE.md`, issue templates (`feature`/`bug`/`refactor`/`perf`), and a PR template describing the team's test-driven workflow. Re-enables the previously-disabled `unit-test` CI job (it had `if: false`, plus a stale 2023 toolchain/checkout path) and fixes the pre-existing formatting drift in `crates/builder/src/engine` that was failing `lint` on `develop`. Marks 8 currently-broken tests `#[ignore]` with reasons pointing at tracked issues (#485, #486, #487) so the suite is honestly green.

## What this PR deliberately does not do
Doesn't fix the 3 underlying bugs behind the `#[ignore]`'d tests — tracked separately in #485, #486, #487. Doesn't include the in-progress Gloas devnet-pin/endpoint work sitting in this branch's history — tracked in #489, follow-up PR. Doesn't add branch-protection required-status-checks yet — that needs `unit-test` to report a real passing run on `develop` first.

## Tests
`just test` (full workspace, with local Postgres) passes cleanly against this commit in isolation. `just fmt-check` and `cargo clippy --all-features --no-deps -- -D warnings` also pass.

## Reviewer checklist
- [ ] CI (`lint`, `unit-test`) is green
- [ ] Matches the linked issue/step
- [ ] No unexplained scope creep or unrelated files touched

