### PR TITLE
Fix develop's compile/format breakage uncovered by enabling unit-test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,12 @@ proptest-regressions/
 # Release artifacts
 dist/
 
+# crates/admin/frontend/dist/ needs to exist (via .gitkeep, see
+# crates/admin/frontend/.gitignore) for its `#[derive(RustEmbed)]` folder
+# to resolve at compile time -- the blanket rule above prunes the
+# directory before that nested .gitignore is ever consulted.
+!crates/admin/frontend/dist/
+
 # Database debugging tools
 db-tools/
 

--- a/crates/builder/src/engine/mod.rs
+++ b/crates/builder/src/engine/mod.rs
@@ -402,7 +402,8 @@ impl MergeEngine {
                     } else {
                         // Head gating: the base must build on our synced head.
                         let head_hash = convert::b256(head.hash);
-                        let beneficiary_alloy = base.payload.payload_inner.payload_inner.fee_recipient;
+                        let beneficiary_alloy =
+                            base.payload.payload_inner.payload_inner.fee_recipient;
                         let result = if !head.is_synced {
                             Err(MergeError::NotSynced)
                         } else if head_hash != state.parent_hash {

--- a/crates/builder/src/engine/session.rs
+++ b/crates/builder/src/engine/session.rs
@@ -237,7 +237,13 @@ impl MergeSession {
 
         let last_ix = base.txs.len() - 1;
         let checkpoint_hit = checkpoint.is_some_and(|ck| {
-            ck.extends_to(base, beneficiary_alloy, slot.proposer_fee_recipient, v1.parent_hash, v1.gas_limit)
+            ck.extends_to(
+                base,
+                beneficiary_alloy,
+                slot.proposer_fee_recipient,
+                v1.parent_hash,
+                v1.gas_limit,
+            )
         });
 
         let (mut ctx, mut tx_hashes, replay_from) = if checkpoint_hit {
@@ -328,7 +334,8 @@ impl MergeSession {
             }
             if ix == last_ix {
                 proposer_balance_before_payment = Some(
-                    balance_of(&mut ctx.vm, proposer).map_err(|e| MergeError::Internal(e.to_string()))?,
+                    balance_of(&mut ctx.vm, proposer)
+                        .map_err(|e| MergeError::Internal(e.to_string()))?,
                 );
                 new_checkpoint = Some(ReplayCheckpoint {
                     beneficiary_alloy,
@@ -352,8 +359,8 @@ impl MergeSession {
                 .map_err(|e| MergeError::InvalidBaseBlock(format!("base tx failed: {e}")))?;
             tx_hashes.insert(decoded.hash);
         }
-        let new_checkpoint =
-            new_checkpoint.expect("base.txs is non-empty (checked above), so last_ix is always visited");
+        let new_checkpoint = new_checkpoint
+            .expect("base.txs is non-empty (checked above), so last_ix is always visited");
         debug!(
             base_block_hash = %base.block_hash,
             txs = base.txs.len(),
@@ -775,10 +782,8 @@ impl MergeSession {
                 txs: revenue.txs.clone(),
             })
             .collect();
-        let relay_revenue = updated_revenues
-            .get(&relay_config.relay_fee_recipient)
-            .cloned()
-            .unwrap_or_default();
+        let relay_revenue =
+            updated_revenues.get(&relay_config.relay_fee_recipient).cloned().unwrap_or_default();
 
         self.best_emitted = proposer_value;
         self.last_emit = Some(Instant::now());

--- a/crates/builder/src/engine/tests.rs
+++ b/crates/builder/src/engine/tests.rs
@@ -196,7 +196,11 @@ impl Fixture {
     /// chosen payment value — lets a test hold the user tx fixed (so the
     /// non-payment prefix is byte-identical) while only the trailing payment
     /// tx changes, as in a real bid-ratchet resubmission.
-    fn build_base_with_payment(&self, user_value: U256, payment_value: U256) -> (MergeableBlockV1, B256) {
+    fn build_base_with_payment(
+        &self,
+        user_value: U256,
+        payment_value: U256,
+    ) -> (MergeableBlockV1, B256) {
         let builder = &self.signers[0];
         let base_txs = vec![
             signed_transfer(
@@ -208,15 +212,7 @@ impl Fixture {
                 100 * GWEI,
                 GWEI,
             ),
-            signed_transfer(
-                builder,
-                self.chain_id,
-                0,
-                self.proposer,
-                payment_value,
-                100 * GWEI,
-                0,
-            ),
+            signed_transfer(builder, self.chain_id, 0, self.proposer, payment_value, 100 * GWEI, 0),
         ];
         let args = BuildPayloadArgs {
             parent: self.genesis_hash,
@@ -458,7 +454,10 @@ async fn checkpoint_hit_reuses_shared_prefix_on_resubmission() {
     );
 }
 
-fn revoke_event(order_hash: B256, builder_pubkey: alloy_rpc_types::beacon::BlsPublicKey) -> EngineEvent {
+fn revoke_event(
+    order_hash: B256,
+    builder_pubkey: alloy_rpc_types::beacon::BlsPublicKey,
+) -> EngineEvent {
     EngineEvent::RevokeOrder {
         msg: RevokeOrderV1 { slot: SLOT, order_hash, builder_pubkey },
         generation: 0,
@@ -483,10 +482,7 @@ async fn revoke_removes_pooled_order_before_it_applies() {
     engine.handle_event(mergeable_event(&donor_msg, 2));
 
     engine.handle_event(revoke_event(order_hash, Default::default()));
-    assert!(
-        engine.slot.as_ref().unwrap().orders.is_empty(),
-        "revoked order must leave the pool"
-    );
+    assert!(engine.slot.as_ref().unwrap().orders.is_empty(), "revoked order must leave the pool");
 
     engine.handle_event(activate_event(base_block_hash));
     engine.merge_pass();

--- a/crates/common/src/api_provider.rs
+++ b/crates/common/src/api_provider.rs
@@ -44,7 +44,7 @@ pub trait ApiProvider: Send + Sync + Clone + 'static {
         fallback: Arc<ValidatorPreferences>,
         _registrations: &[SignedValidatorRegistration],
     ) -> ValidatorPreferences;
-    
+
     fn get_filtering(&self, _headers: &HeaderMap, fallback: Filtering) -> Filtering {
         fallback
     }

--- a/crates/common/src/validator_preferences/mod.rs
+++ b/crates/common/src/validator_preferences/mod.rs
@@ -47,7 +47,9 @@ const fn default_filtering() -> Filtering {
     Filtering::Global
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[derive(
+    Debug, Clone, Copy, Default, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize,
+)]
 #[repr(u8)]
 pub enum Filtering {
     #[default]

--- a/crates/data-api/src/api.rs
+++ b/crates/data-api/src/api.rs
@@ -102,9 +102,8 @@ impl<P: ApiProvider> DataApi<P> {
             params.limit = Some(200);
         }
 
-        let filtering = data_api
-            .api_provider
-            .get_filtering(&headers, data_api.validator_preferences.filtering);
+        let filtering =
+            data_api.api_provider.get_filtering(&headers, data_api.validator_preferences.filtering);
         let cache_key = (filtering, params);
 
         if let Some(cached_result) = cache.get(&cache_key) {
@@ -162,9 +161,8 @@ impl<P: ApiProvider> DataApi<P> {
             params.limit = Some(200);
         }
 
-        let filtering = data_api
-            .api_provider
-            .get_filtering(&headers, data_api.validator_preferences.filtering);
+        let filtering =
+            data_api.api_provider.get_filtering(&headers, data_api.validator_preferences.filtering);
         let cache_key = (filtering, params);
 
         if let Some(cached_result) = cache.get(&cache_key) {

--- a/crates/relay/src/block_merging/mod.rs
+++ b/crates/relay/src/block_merging/mod.rs
@@ -170,7 +170,6 @@ mod tests {
             txs: indices(&[1, 2]),
             reverting_txs: indices(&[0]),
             dropping_txs: indices(&[1]),
-            latest_only: true,
         });
         assert_eq!(
             order_to_ref(&bundle),


### PR DESCRIPTION
Issue: #492, #493

## What this PR does
Fixes two independent compile breaks and formatting drift on `develop`, all invisible until now because `unit_test.yml` was disabled and `lint.yml`'s `cargo check` doesn't compile every crate:
- `crates/admin` never compiled on a fresh checkout: the root `.gitignore`'s blanket `dist/` rule pruned `crates/admin/frontend/dist/` entirely, so `#[derive(RustEmbed)]`'s folder never existed. Fixed by un-pruning the directory so the already-correct nested `.gitignore` is reachable, and tracking a `.gitkeep`. (#492)
- `block_merging::tests::order_conversion` didn't compile: a stale `latest_only` field left over from f6adda76. (#493)
- Pinned-nightly formatting drift in `crates/common/src/api_provider.rs`, `crates/common/src/validator_preferences/mod.rs`, `crates/data-api/src/api.rs`, and `crates/builder/src/engine/{mod,session,tests}.rs` — pure whitespace, no behavior change.

## What this PR deliberately does not do
Doesn't touch the 3 already-tracked bugs behind the tests `#[ignore]`'d in #491 (#485, #486, #487) — those need real fixes, not covered here.

## Tests
Verified against this branch directly (not through any other PR): `cargo check -p helix-admin`, `just fmt-check`, `cargo clippy --all-features --no-deps -- -D warnings`, and `cargo test --workspace --all-features` (with local Postgres) all pass, modulo the 3 already-tracked/unrelated failures in #485-487 (which #491 marks `#[ignore]`).

## Reviewer checklist
- [ ] CI (`lint`, `unit-test`) is green
- [ ] Matches the linked issues
- [ ] No unexplained scope creep or unrelated files touched
