### PR TITLE
Pin lighthouse to Gloas devnet branch, fix resulting compile breakage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1023,15 +1023,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arbitrary"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
-dependencies = [
- "derive_arbitrary",
-]
-
-[[package]]
 name = "archery"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2630,10 +2621,9 @@ dependencies = [
 [[package]]
 name = "bls"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?tag=v8.1.3#176cce585c1ba979a6210ed79b6b6528596cdb8c"
+source = "git+https://github.com/sigp/lighthouse?rev=f064e9e061997c41658c3544da47627c6db92bc9#f064e9e061997c41658c3544da47627c6db92bc9"
 dependencies = [
  "alloy-primitives",
- "arbitrary",
  "blst",
  "ethereum_hashing",
  "ethereum_serde_utils",
@@ -2780,6 +2770,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "builder_types"
+version = "0.1.0"
+source = "git+https://github.com/sigp/lighthouse?rev=f064e9e061997c41658c3544da47627c6db92bc9#f064e9e061997c41658c3544da47627c6db92bc9"
+dependencies = [
+ "bls",
+ "context_deserialize",
+ "ethereum_serde_utils",
+ "ethereum_ssz",
+ "ethereum_ssz_derive",
+ "sensitive_url",
+ "serde",
+ "ssz_types",
+ "tree_hash",
+ "tree_hash_derive",
+ "typenum",
+ "types",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2922,6 +2931,20 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver 1.0.28",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -4088,17 +4111,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derive_arbitrary"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
 name = "derive_more"
 version = "0.99.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4704,14 +4716,16 @@ dependencies = [
 [[package]]
 name = "eth2"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?tag=v8.1.3#176cce585c1ba979a6210ed79b6b6528596cdb8c"
+source = "git+https://github.com/sigp/lighthouse?rev=f064e9e061997c41658c3544da47627c6db92bc9#f064e9e061997c41658c3544da47627c6db92bc9"
 dependencies = [
  "bls",
+ "builder_types",
  "context_deserialize",
  "educe",
  "ethereum_serde_utils",
  "ethereum_ssz",
  "ethereum_ssz_derive",
+ "fork_choice",
  "futures",
  "futures-util",
  "mediatype",
@@ -4729,14 +4743,14 @@ dependencies = [
 [[package]]
 name = "eth2_interop_keypairs"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?tag=v8.1.3#176cce585c1ba979a6210ed79b6b6528596cdb8c"
+source = "git+https://github.com/sigp/lighthouse?rev=f064e9e061997c41658c3544da47627c6db92bc9#f064e9e061997c41658c3544da47627c6db92bc9"
 dependencies = [
  "bls",
  "ethereum_hashing",
  "hex",
  "num-bigint 0.4.8",
  "serde",
- "serde_yaml",
+ "yaml_serde",
 ]
 
 [[package]]
@@ -4841,8 +4855,7 @@ dependencies = [
 [[package]]
 name = "ethereum_ssz"
 version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e462875ad8693755ea8913d6e905715c76ea4836e2254e18c9cf0f7a8f8c2a13"
+source = "git+https://github.com/sigp/ethereum_ssz?rev=2059c21ba52cd3a7e39a8ad537012b761812a393#2059c21ba52cd3a7e39a8ad537012b761812a393"
 dependencies = [
  "alloy-primitives",
  "context_deserialize",
@@ -4857,8 +4870,7 @@ dependencies = [
 [[package]]
 name = "ethereum_ssz_derive"
 version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daf022360bdbe9456eda5f35718a50476d5b2a0d51a97ed4eae27420737a6fba"
+source = "git+https://github.com/sigp/ethereum_ssz?rev=2059c21ba52cd3a7e39a8ad537012b761812a393#2059c21ba52cd3a7e39a8ad537012b761812a393"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -4961,7 +4973,7 @@ checksum = "82d80cc6ad30b14a48ab786523af33b37f28a8623fc06afd55324816ef18fb1f"
 dependencies = [
  "arrayvec",
  "bytes",
- "cargo_metadata",
+ "cargo_metadata 0.18.1",
  "chrono",
  "const-hex",
  "elliptic-curve",
@@ -5614,7 +5626,7 @@ dependencies = [
 [[package]]
 name = "fixed_bytes"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?tag=v8.1.3#176cce585c1ba979a6210ed79b6b6528596cdb8c"
+source = "git+https://github.com/sigp/lighthouse?rev=f064e9e061997c41658c3544da47627c6db92bc9#f064e9e061997c41658c3544da47627c6db92bc9"
 dependencies = [
  "alloy-primitives",
  "safe_arith",
@@ -5779,6 +5791,23 @@ name = "foreign-types-shared"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "fork_choice"
+version = "0.1.0"
+source = "git+https://github.com/sigp/lighthouse?rev=f064e9e061997c41658c3544da47627c6db92bc9#f064e9e061997c41658c3544da47627c6db92bc9"
+dependencies = [
+ "ethereum_ssz",
+ "ethereum_ssz_derive",
+ "fixed_bytes",
+ "logging",
+ "metrics 0.2.0",
+ "proto_array",
+ "state_processing",
+ "superstruct",
+ "tracing",
+ "types",
+]
 
 [[package]]
 name = "form_urlencoded"
@@ -6787,13 +6816,13 @@ dependencies = [
  "kzg",
  "libp2p",
  "rand 0.9.5",
+ "rand_xorshift 0.4.0",
  "rustc-hash",
  "serde",
  "serde_json",
  "slot_clock",
  "smallvec",
  "ssz_types",
- "test_random_derive",
  "thiserror 1.0.69",
  "tracing",
  "tracing-subscriber 0.3.23",
@@ -7734,9 +7763,18 @@ dependencies = [
 [[package]]
 name = "int_to_bytes"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?tag=v8.1.3#176cce585c1ba979a6210ed79b6b6528596cdb8c"
+source = "git+https://github.com/sigp/lighthouse?rev=f064e9e061997c41658c3544da47627c6db92bc9#f064e9e061997c41658c3544da47627c6db92bc9"
 dependencies = [
  "bytes",
+]
+
+[[package]]
+name = "integer-sqrt"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "276ec31bcb4a9ee45f58bec6f9ec700ae4cf4f4f8f2fa7e06cb406bd5ffdd770"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -8312,10 +8350,8 @@ dependencies = [
 [[package]]
 name = "kzg"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?tag=v8.1.3#176cce585c1ba979a6210ed79b6b6528596cdb8c"
+source = "git+https://github.com/sigp/lighthouse?rev=f064e9e061997c41658c3544da47627c6db92bc9#f064e9e061997c41658c3544da47627c6db92bc9"
 dependencies = [
- "arbitrary",
- "c-kzg",
  "educe",
  "ethereum_hashing",
  "ethereum_serde_utils",
@@ -8760,6 +8796,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libyaml-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e126dda6f34391ab7b444f9922055facc83c07a910da3eb16f1e4d9c45dc777"
+
+[[package]]
 name = "libz-sys"
 version = "1.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8837,6 +8879,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 dependencies = [
  "value-bag",
+]
+
+[[package]]
+name = "logging"
+version = "0.2.0"
+source = "git+https://github.com/sigp/lighthouse?rev=f064e9e061997c41658c3544da47627c6db92bc9#f064e9e061997c41658c3544da47627c6db92bc9"
+dependencies = [
+ "chrono",
+ "logroller",
+ "metrics 0.2.0",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-appender",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber 0.3.23",
+ "workspace_members",
+]
+
+[[package]]
+name = "logroller"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7525242cbd0624fe9b76dfebc1923a2d20c003e8c5d1a7eab1324bd8c0f615ac"
+dependencies = [
+ "chrono",
+ "flate2",
+ "regex",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -9095,7 +9168,7 @@ dependencies = [
 [[package]]
 name = "merkle_proof"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?tag=v8.1.3#176cce585c1ba979a6210ed79b6b6528596cdb8c"
+source = "git+https://github.com/sigp/lighthouse?rev=f064e9e061997c41658c3544da47627c6db92bc9#f064e9e061997c41658c3544da47627c6db92bc9"
 dependencies = [
  "alloy-primitives",
  "ethereum_hashing",
@@ -9129,7 +9202,7 @@ dependencies = [
 [[package]]
 name = "metrics"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?tag=v8.1.3#176cce585c1ba979a6210ed79b6b6528596cdb8c"
+source = "git+https://github.com/sigp/lighthouse?rev=f064e9e061997c41658c3544da47627c6db92bc9#f064e9e061997c41658c3544da47627c6db92bc9"
 dependencies = [
  "prometheus 0.13.4",
 ]
@@ -9206,8 +9279,7 @@ dependencies = [
 [[package]]
 name = "milhouse"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "259dd9da2ae5e0278b95da0b7ecef9c18c309d0a2d9e6db57ed33b9e8910c5e7"
+source = "git+https://github.com/sigp/milhouse?rev=c70f128976ac0d60ea65a978dabd117a921c36ee#c70f128976ac0d60ea65a978dabd117a921c36ee"
 dependencies = [
  "alloy-primitives",
  "context_deserialize",
@@ -9924,15 +9996,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
-name = "openssl-src"
-version = "300.6.1+3.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46eb8fb9fb3b61ce1c0f8a026c4c1a0714d3a9e138e7fbde78753ce2babc3846"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "openssl-sys"
 version = "0.9.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9940,7 +10003,6 @@ checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
 dependencies = [
  "cc",
  "libc",
- "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -10830,7 +10892,7 @@ dependencies = [
 [[package]]
 name = "pretty_reqwest_error"
 version = "0.1.0"
-source = "git+https://github.com/sigp/lighthouse?tag=v8.1.3#176cce585c1ba979a6210ed79b6b6528596cdb8c"
+source = "git+https://github.com/sigp/lighthouse?rev=f064e9e061997c41658c3544da47627c6db92bc9#f064e9e061997c41658c3544da47627c6db92bc9"
 dependencies = [
  "reqwest 0.12.28",
  "sensitive_url",
@@ -10969,6 +11031,19 @@ dependencies = [
 
 [[package]]
 name = "procfs"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "731e0d9356b0c25f16f33b5be79b1c57b562f141ebfcdb0ad8ac2c13a24293b4"
+dependencies = [
+ "bitflags 2.13.1",
+ "hex",
+ "lazy_static",
+ "procfs-core 0.16.0",
+ "rustix 0.38.44",
+]
+
+[[package]]
+name = "procfs"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc5b72d8145275d844d4b5f6d4e1eef00c8cd889edb6035c21675d1bb1f45c9f"
@@ -10990,6 +11065,16 @@ dependencies = [
  "flate2",
  "procfs-core 0.18.0",
  "rustix 1.1.4",
+]
+
+[[package]]
+name = "procfs-core"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d3554923a69f4ce04c4a754260c338f505ce22642d3830e049a399fc2059a29"
+dependencies = [
+ "bitflags 2.13.1",
+ "hex",
 ]
 
 [[package]]
@@ -11022,8 +11107,10 @@ dependencies = [
  "cfg-if",
  "fnv",
  "lazy_static",
+ "libc",
  "memchr",
  "parking_lot",
+ "procfs 0.16.0",
  "protobuf 2.28.0",
  "thiserror 1.0.69",
 ]
@@ -11189,6 +11276,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
 dependencies = [
  "prost 0.14.4",
+]
+
+[[package]]
+name = "proto_array"
+version = "0.2.0"
+source = "git+https://github.com/sigp/lighthouse?rev=f064e9e061997c41658c3544da47627c6db92bc9#f064e9e061997c41658c3544da47627c6db92bc9"
+dependencies = [
+ "ethereum_ssz",
+ "ethereum_ssz_derive",
+ "fixed_bytes",
+ "safe_arith",
+ "serde",
+ "smallvec",
+ "superstruct",
+ "typenum",
+ "types",
+ "yaml_serde",
 ]
 
 [[package]]
@@ -16045,7 +16149,7 @@ dependencies = [
 [[package]]
 name = "slot_clock"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?tag=v8.1.3#176cce585c1ba979a6210ed79b6b6528596cdb8c"
+source = "git+https://github.com/sigp/lighthouse?rev=f064e9e061997c41658c3544da47627c6db92bc9#f064e9e061997c41658c3544da47627c6db92bc9"
 dependencies = [
  "metrics 0.2.0",
  "parking_lot",
@@ -16067,7 +16171,6 @@ version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 dependencies = [
- "arbitrary",
  "serde",
 ]
 
@@ -16269,8 +16372,7 @@ dependencies = [
 [[package]]
 name = "ssz_types"
 version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d625e4de8e0057eefe7e0b1510ba1dd7adf10cd375fad6cc7fcceac7c39623c9"
+source = "git+https://github.com/sigp/ssz_types?rev=9203d56ad2d7bc5f12133d043e085843f81edcd6#9203d56ad2d7bc5f12133d043e085843f81edcd6"
 dependencies = [
  "context_deserialize",
  "educe",
@@ -16289,6 +16391,34 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "state_processing"
+version = "0.2.0"
+source = "git+https://github.com/sigp/lighthouse?rev=f064e9e061997c41658c3544da47627c6db92bc9#f064e9e061997c41658c3544da47627c6db92bc9"
+dependencies = [
+ "bls",
+ "educe",
+ "ethereum_hashing",
+ "ethereum_ssz",
+ "ethereum_ssz_derive",
+ "fixed_bytes",
+ "int_to_bytes",
+ "integer-sqrt",
+ "itertools 0.14.0",
+ "merkle_proof",
+ "metrics 0.2.0",
+ "milhouse",
+ "rand 0.9.5",
+ "rayon",
+ "safe_arith",
+ "smallvec",
+ "ssz_types",
+ "tracing",
+ "tree_hash",
+ "typenum",
+ "types",
+]
 
 [[package]]
 name = "static_assertions"
@@ -16438,7 +16568,7 @@ dependencies = [
 [[package]]
 name = "swap_or_not_shuffle"
 version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?tag=v8.1.3#176cce585c1ba979a6210ed79b6b6528596cdb8c"
+source = "git+https://github.com/sigp/lighthouse?rev=f064e9e061997c41658c3544da47627c6db92bc9#f064e9e061997c41658c3544da47627c6db92bc9"
 dependencies = [
  "alloy-primitives",
  "ethereum_hashing",
@@ -16703,15 +16833,6 @@ dependencies = [
  "dirs-next",
  "rustversion",
  "winapi",
-]
-
-[[package]]
-name = "test_random_derive"
-version = "0.2.0"
-source = "git+https://github.com/sigp/lighthouse?tag=v8.1.3#176cce585c1ba979a6210ed79b6b6528596cdb8c"
-dependencies = [
- "quote",
- "syn 2.0.119",
 ]
 
 [[package]]
@@ -17605,8 +17726,7 @@ dependencies = [
 [[package]]
 name = "tree_hash"
 version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7fd51aa83d2eb83b04570808430808b5d24fdbf479a4d5ac5dee4a2e2dd2be4"
+source = "git+https://github.com/sigp/tree_hash?rev=03d9fa474586c125f306dd7a00cf46284575a01f#03d9fa474586c125f306dd7a00cf46284575a01f"
 dependencies = [
  "alloy-primitives",
  "ethereum_hashing",
@@ -17618,8 +17738,7 @@ dependencies = [
 [[package]]
 name = "tree_hash_derive"
 version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8840ad4d852e325d3afa7fde8a50b2412f89dce47d7eb291c0cc7f87cd040f38"
+source = "git+https://github.com/sigp/tree_hash?rev=03d9fa474586c125f306dd7a00cf46284575a01f#03d9fa474586c125f306dd7a00cf46284575a01f"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -17748,7 +17867,7 @@ checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 [[package]]
 name = "types"
 version = "0.2.1"
-source = "git+https://github.com/sigp/lighthouse?tag=v8.1.3#176cce585c1ba979a6210ed79b6b6528596cdb8c"
+source = "git+https://github.com/sigp/lighthouse?rev=f064e9e061997c41658c3544da47627c6db92bc9#f064e9e061997c41658c3544da47627c6db92bc9"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -17764,13 +17883,14 @@ dependencies = [
  "fixed_bytes",
  "hex",
  "int_to_bytes",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "kzg",
  "maplit",
  "merkle_proof",
  "metastruct",
  "milhouse",
  "parking_lot",
+ "paste",
  "rand 0.9.5",
  "rand_xorshift 0.4.0",
  "rayon",
@@ -17779,17 +17899,16 @@ dependencies = [
  "safe_arith",
  "serde",
  "serde_json",
- "serde_yaml",
  "smallvec",
  "ssz_types",
  "superstruct",
  "swap_or_not_shuffle",
  "tempfile",
- "test_random_derive",
  "tracing",
  "tree_hash",
  "tree_hash_derive",
  "typenum",
+ "yaml_serde",
 ]
 
 [[package]]
@@ -18839,6 +18958,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
+name = "workspace_members"
+version = "0.1.0"
+source = "git+https://github.com/sigp/lighthouse?rev=f064e9e061997c41658c3544da47627c6db92bc9#f064e9e061997c41658c3544da47627c6db92bc9"
+dependencies = [
+ "cargo_metadata 0.19.2",
+ "quote",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -18918,6 +19046,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7d8a75eaf6557bb84a65ace8609883db44a29951042ada9b393151532e41fcb"
 dependencies = [
  "xml-rs",
+]
+
+[[package]]
+name = "yaml_serde"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33b729a08a9a6be689bbad3e2bf8015926db54b6622cc89c3a5f7dc174b9e918"
+dependencies = [
+ "indexmap 2.14.0",
+ "itoa",
+ "libyaml-rs",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,12 +90,11 @@ hyper = "1.1.0"
 hyper-util = { version = "0.1", features = ["tokio"] }
 jsonrpsee = { version = "0.26.0", features = ["macros", "server"] }
 lazy_static = "1.5.0"
-lh-bls = { package = "bls", git = "https://github.com/sigp/lighthouse", tag = "v8.1.3" }
-lh-eth2 = { package = "eth2", git = "https://github.com/sigp/lighthouse", tag = "v8.1.3" }
-lh-kzg = { package = "kzg", git = "https://github.com/sigp/lighthouse", tag = "v8.1.3" }
-lh-slot-clock = { package = "slot_clock", git = "https://github.com/sigp/lighthouse", tag = "v8.1.3" }
-lh-test-random = { package = "test_random_derive", git = "https://github.com/sigp/lighthouse", tag = "v8.1.3" }
-lh-types = { package = "types", git = "https://github.com/sigp/lighthouse", tag = "v8.1.3" }
+lh-bls = { package = "bls", git = "https://github.com/sigp/lighthouse", rev = "f064e9e061997c41658c3544da47627c6db92bc9" }
+lh-eth2 = { package = "eth2", git = "https://github.com/sigp/lighthouse", rev = "f064e9e061997c41658c3544da47627c6db92bc9" }
+lh-kzg = { package = "kzg", git = "https://github.com/sigp/lighthouse", rev = "f064e9e061997c41658c3544da47627c6db92bc9" }
+lh-slot-clock = { package = "slot_clock", git = "https://github.com/sigp/lighthouse", rev = "f064e9e061997c41658c3544da47627c6db92bc9" }
+lh-types = { package = "types", git = "https://github.com/sigp/lighthouse", rev = "f064e9e061997c41658c3544da47627c6db92bc9" }
 libp2p = { version = "0.56", features = ["macros", "ping", "quic", "floodsub", "secp256k1", "tokio"] }
 metrics = "0.24.0"
 mime_guess = "2"
@@ -111,6 +110,7 @@ pin-project-lite = "0.2.16"
 prometheus = "0.13.4"
 prost = "0.12"
 rand = "0.9.2"
+rand_xorshift = "0.4"
 rayon = "1.10"
 refinery = { version = "0.8", features = ["tokio-postgres"] }
 reqwest = { version = "0.13.2", default-features = false, features = ["blocking", "json", "rustls", "stream"] }
@@ -165,3 +165,17 @@ zstd = "0.13.3"
 # crates/vendored/ethrex-crypto/VENDORED.md.
 [patch."https://github.com/lambdaclass/ethrex"]
 ethrex-crypto = { path = "crates/vendored/ethrex-crypto" }
+
+# Lighthouse's own Cargo.toml patches these crates.io deps to forked git revs (see its
+# [patch.crates-io] table) -- that patch only applies within lighthouse's own workspace
+# resolution, not ours, so without mirroring it here we resolve the plain crates.io versions
+# of ssz_types/tree_hash/ethereum_ssz/milhouse and get type mismatches against lighthouse's
+# `types` crate (which is compiled against its patched forks). Keep these revs in sync with
+# whatever lh-* rev/tag helix pins above.
+[patch.crates-io]
+ssz_types = { git = "https://github.com/sigp/ssz_types", rev = "9203d56ad2d7bc5f12133d043e085843f81edcd6" }
+milhouse = { git = "https://github.com/sigp/milhouse", rev = "c70f128976ac0d60ea65a978dabd117a921c36ee" }
+ethereum_ssz = { git = "https://github.com/sigp/ethereum_ssz", rev = "2059c21ba52cd3a7e39a8ad537012b761812a393" }
+ethereum_ssz_derive = { git = "https://github.com/sigp/ethereum_ssz", rev = "2059c21ba52cd3a7e39a8ad537012b761812a393" }
+tree_hash = { git = "https://github.com/sigp/tree_hash", rev = "03d9fa474586c125f306dd7a00cf46284575a01f" }
+tree_hash_derive = { git = "https://github.com/sigp/tree_hash", rev = "03d9fa474586c125f306dd7a00cf46284575a01f" }

--- a/crates/common/src/chain_info.rs
+++ b/crates/common/src/chain_info.rs
@@ -25,8 +25,8 @@ pub struct ChainInfo {
 impl ChainInfo {
     pub fn new(spec: ChainSpec, genesis_validators_root: B256, genesis_time_in_secs: u64) -> Self {
         let name = spec.config_name.clone().expect("spec config name should be set");
-        let clock = new_slot_clock(genesis_time_in_secs, spec.seconds_per_slot);
-        let builder_domain = spec.get_builder_domain();
+        let clock = new_slot_clock(genesis_time_in_secs, spec.get_slot_duration());
+        let builder_domain = spec.get_builder_application_domain();
         Self { name, genesis_validators_root, spec, clock, genesis_time_in_secs, builder_domain }
     }
 
@@ -39,7 +39,7 @@ impl ChainInfo {
     }
 
     pub fn seconds_per_slot(&self) -> u64 {
-        self.spec.seconds_per_slot
+        self.spec.get_slot_duration().as_secs()
     }
 
     pub fn slots_per_epoch(&self) -> u64 {

--- a/crates/relay/src/api/proposer/header_stream.rs
+++ b/crates/relay/src/api/proposer/header_stream.rs
@@ -270,6 +270,7 @@ fn fork_byte(fork: ForkName) -> u8 {
         ForkName::Electra => 5,
         ForkName::Fulu => 6,
         ForkName::Gloas => 7,
+        ForkName::Heze => 8,
     }
 }
 

--- a/crates/relay/src/auctioneer/get_payload.rs
+++ b/crates/relay/src/auctioneer/get_payload.rs
@@ -158,7 +158,8 @@ impl<B: BidAdjustor> Context<B> {
             SignedBlindedBeaconBlock::Capella(_) |
             SignedBlindedBeaconBlock::Deneb(_) |
             SignedBlindedBeaconBlock::Electra(_) |
-            SignedBlindedBeaconBlock::Gloas(_) => {
+            SignedBlindedBeaconBlock::Gloas(_) |
+            SignedBlindedBeaconBlock::Heze(_) => {
                 Err(ProposerApiError::UnsupportedBeaconChainVersion)
             }
             SignedBlindedBeaconBlock::Fulu(blinded_block) => {

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -23,10 +23,10 @@ lh-bls.workspace = true
 lh-eth2 = { workspace = true, features = ["events"] }
 lh-kzg.workspace = true
 lh-slot-clock.workspace = true
-lh-test-random.workspace = true
 lh-types.workspace = true
 libp2p.workspace = true
 rand.workspace = true
+rand_xorshift.workspace = true
 rustc-hash.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/types/src/bid_submission.rs
+++ b/crates/types/src/bid_submission.rs
@@ -6,7 +6,7 @@ use alloy_rpc_types::{
     engine::ExecutionPayloadV3,
 };
 use flux_profiler::timed;
-use lh_types::{ForkName, SignedRoot, Slot, test_utils::TestRandom};
+use lh_types::{ForkName, SignedRoot, Slot};
 use serde::{Deserialize, Serialize};
 use ssz::{Decode, DecodeError};
 use ssz_derive::{Decode, Encode};
@@ -17,7 +17,8 @@ use tree_hash_derive::TreeHash;
 use crate::{
     BlobsBundle, BlobsError, Bloom, BlsPublicKey, BlsPublicKeyBytes, BlsSignature,
     BlsSignatureBytes, DehydratedBidSubmission, ExecutionPayload, ExtraData, PayloadAndBlobs,
-    SszError, bid_adjustment_data::BidAdjustmentData, error::SigError, fields::ExecutionRequests,
+    SszError, TestRandom, bid_adjustment_data::BidAdjustmentData, error::SigError,
+    fields::ExecutionRequests,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Encode, Decode, TreeHash)]

--- a/crates/types/src/blobs.rs
+++ b/crates/types/src/blobs.rs
@@ -1,14 +1,14 @@
 use std::sync::Arc;
 
 use alloy_eips::eip7594::CELLS_PER_EXT_BLOB;
-use lh_types::{ForkName, ForkVersionDecode, test_utils::TestRandom};
+use lh_types::{ForkName, ForkVersionDecode};
 use rand::Rng;
 use serde::{Deserialize, Serialize};
 use ssz::DecodeError;
 use ssz_derive::{Decode, Encode};
 
 use crate::{
-    BlobsError, BlockValidationError, ExecutionPayload, SignedBeaconBlock,
+    BlobsError, BlockValidationError, ExecutionPayload, SignedBeaconBlock, TestRandom,
     fields::{KzgCommitment, KzgCommitments, KzgProof, KzgProofs},
 };
 
@@ -203,15 +203,13 @@ pub struct SignedBlockContents {
 #[cfg(test)]
 mod tests {
     use lh_eth2::types::BlobsBundle as LhBlobsBundle;
-    use lh_types::{
-        KzgCommitment as LhKzgCommitment, KzgProof as LhKzgProof, MainnetEthSpec,
-        test_utils::{TestRandom, XorShiftRng},
-    };
+    use lh_types::{KzgCommitment as LhKzgCommitment, KzgProof as LhKzgProof, MainnetEthSpec};
     use rand::SeedableRng;
+    use rand_xorshift::XorShiftRng;
     use ssz::Encode;
 
     use super::*;
-    use crate::{SignedBidSubmission, test_encode_decode_json};
+    use crate::{SignedBidSubmission, TestRandom, test_encode_decode_json};
 
     #[test]
     fn test_blobs_bundle_() {

--- a/crates/types/src/block_merging.rs
+++ b/crates/types/src/block_merging.rs
@@ -2,8 +2,6 @@ use std::collections::HashMap;
 
 use alloy_primitives::{Address, B256, U256};
 use bitflags::bitflags;
-use lh_test_random::TestRandom;
-use lh_types::test_utils::TestRandom;
 use rand::Rng;
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
@@ -11,7 +9,7 @@ use ssz::{Decode, Encode};
 use ssz_derive::{Decode, Encode};
 
 use crate::{
-    Blob, SignedBidSubmission,
+    Blob, SignedBidSubmission, TestRandom,
     fields::{KzgCommitment, KzgProof},
 };
 
@@ -47,7 +45,7 @@ impl TestRandom for Order {
 /// Vector of transaction indices. Aliased for easier use.
 pub type TxIndices = SmallVec<[usize; 8]>;
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, Encode, Decode, TestRandom, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Encode, Decode, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct TransactionOrder {
     /// Index into block.transactions
@@ -56,7 +54,13 @@ pub struct TransactionOrder {
     pub can_revert: bool,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Encode, Decode, TestRandom, PartialEq, Eq)]
+impl TestRandom for TransactionOrder {
+    fn random_for_test(rng: &mut impl rand::RngCore) -> Self {
+        Self { index: usize::random_for_test(rng), can_revert: bool::random_for_test(rng) }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Encode, Decode, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 /// References a bundle of transactions via their indices.
 /// All indices are for the block the transactions come from.
@@ -72,7 +76,17 @@ pub struct BundleOrder {
     pub dropping_txs: TxIndices,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Encode, Decode, TestRandom, PartialEq, Eq)]
+impl TestRandom for BundleOrder {
+    fn random_for_test(rng: &mut impl rand::RngCore) -> Self {
+        Self {
+            txs: TxIndices::random_for_test(rng),
+            reverting_txs: TxIndices::random_for_test(rng),
+            dropping_txs: TxIndices::random_for_test(rng),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Encode, Decode, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 /// Same as [`BundleOrder`], with the addition of `flags`. See [`Order::BundleV2`] for why
 /// this is a separate type rather than a field on `BundleOrder`.
@@ -139,6 +153,17 @@ impl Decode for MergeOrderFlags {
     }
 }
 
+impl TestRandom for BundleOrderV2 {
+    fn random_for_test(rng: &mut impl rand::RngCore) -> Self {
+        Self {
+            txs: TxIndices::random_for_test(rng),
+            reverting_txs: TxIndices::random_for_test(rng),
+            dropping_txs: TxIndices::random_for_test(rng),
+            flags: MergeOrderFlags::random_for_test(rng),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 pub struct InvalidTxIndex;
 
@@ -164,14 +189,22 @@ impl BundleOrderV2 {
     }
 }
 
-#[derive(
-    Debug, Default, Clone, Serialize, Deserialize, Encode, Decode, TestRandom, PartialEq, Eq,
-)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize, Encode, Decode, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct BlockMergingData {
     pub allow_appending: bool,
     pub builder_address: Address,
     pub merge_orders: Vec<Order>,
+}
+
+impl TestRandom for BlockMergingData {
+    fn random_for_test(rng: &mut impl rand::RngCore) -> Self {
+        Self {
+            allow_appending: bool::random_for_test(rng),
+            builder_address: Address::random_for_test(rng),
+            merge_orders: Vec::random_for_test(rng),
+        }
+    }
 }
 
 impl BlockMergingData {

--- a/crates/types/src/builder_bid.rs
+++ b/crates/types/src/builder_bid.rs
@@ -1,13 +1,13 @@
 use std::sync::Arc;
 
 use alloy_primitives::U256;
-use lh_types::{SignedRoot, test_utils::TestRandom};
+use lh_types::SignedRoot;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
 use tree_hash_derive::TreeHash;
 
 use crate::{
-    BlsPublicKeyBytes, BlsSignatureBytes, ExecutionPayloadHeader,
+    BlsPublicKeyBytes, BlsSignatureBytes, ExecutionPayloadHeader, TestRandom,
     fields::{ExecutionRequests, KzgCommitments},
 };
 

--- a/crates/types/src/clock.rs
+++ b/crates/types/src/clock.rs
@@ -6,12 +6,8 @@ use crate::Slot;
 
 pub const MAINNET_GENESIS_TIME: u64 = 1606824023;
 
-pub fn new_slot_clock(genesis_time: u64, seconds_per_slot: u64) -> SlotClock {
-    SlotClock::new(
-        0u64.into(),
-        Duration::from_secs(genesis_time),
-        Duration::from_secs(seconds_per_slot),
-    )
+pub fn new_slot_clock(genesis_time: u64, slot_duration: Duration) -> SlotClock {
+    SlotClock::new(0u64.into(), Duration::from_secs(genesis_time), slot_duration)
 }
 
 pub fn duration_into_slot(clock: &SlotClock, slot: Slot) -> Option<Duration> {
@@ -28,7 +24,7 @@ mod tests {
 
     #[test]
     fn test_duration_into_slot() {
-        let clock = new_slot_clock(MAINNET_GENESIS_TIME, 12);
+        let clock = new_slot_clock(MAINNET_GENESIS_TIME, Duration::from_secs(12));
 
         for _ in 0..100 {
             let slot = clock.now().unwrap();

--- a/crates/types/src/execution_payload.rs
+++ b/crates/types/src/execution_payload.rs
@@ -1,5 +1,5 @@
 use alloy_primitives::{Address, B256, U256};
-use lh_types::{EthSpec, ForkName, ForkVersionDecode, MainnetEthSpec, test_utils::TestRandom};
+use lh_types::{EthSpec, ForkName, ForkVersionDecode, MainnetEthSpec};
 use serde::{Deserialize, Serialize};
 use ssz::Decode;
 use ssz_derive::{Decode, Encode};
@@ -7,7 +7,7 @@ use tree_hash::TreeHash;
 use tree_hash_derive::TreeHash;
 
 use crate::{
-    BlockValidationError, SszError, convert_bloom_to_lighthouse,
+    BlockValidationError, SszError, TestRandom, convert_bloom_to_lighthouse,
     convert_transactions_to_lighthouse,
     fields::{Bloom, ExtraData, Transactions, Withdrawals},
 };
@@ -167,7 +167,8 @@ impl ForkVersionDecode for ExecutionPayload {
             ForkName::Capella |
             ForkName::Deneb |
             ForkName::Electra |
-            ForkName::Gloas => {
+            ForkName::Gloas |
+            ForkName::Heze => {
                 return Err(ssz::DecodeError::BytesInvalid(format!(
                     "unsupported fork for ExecutionPayloadHeader: {fork_name}",
                 )));

--- a/crates/types/src/fields.rs
+++ b/crates/types/src/fields.rs
@@ -1,13 +1,18 @@
 use alloy_primitives::FixedBytes;
-use lh_types::{EthSpec, MainnetEthSpec, test_utils::TestRandom};
+use lh_types::{EthSpec, MainnetEthSpec};
 use rand::Rng;
 use ssz_types::{FixedVector, VariableList};
 
-use crate::{SszError, ssz_bytes_wrapper};
+use crate::{SszError, TestRandom, ssz_bytes_wrapper};
 
 pub type Withdrawal = lh_types::Withdrawal;
 pub type Withdrawals = lh_types::Withdrawals<MainnetEthSpec>;
-pub type ExecutionRequests = lh_types::ExecutionRequests<MainnetEthSpec>;
+// `ExecutionRequests` is a fork-versioned superstruct as of Gloas (which adds
+// `builder_deposits`/`builder_exits`, EIP-8282). helix's active fork is still pre-Gloas, so --
+// mirroring how `ExecutionPayload` is pinned to a flat, non-fork-versioned shape elsewhere in
+// this crate -- we pin to the Electra shape here too. Revisit once helix actually needs to
+// serve Gloas submissions.
+pub type ExecutionRequests = lh_types::ExecutionRequestsElectra<MainnetEthSpec>;
 pub type KzgCommitment = alloy_consensus::Bytes48;
 pub type KzgCommitments =
     VariableList<KzgCommitment, <MainnetEthSpec as EthSpec>::MaxBlobCommitmentsPerBlock>;

--- a/crates/types/src/hydration.rs
+++ b/crates/types/src/hydration.rs
@@ -2,7 +2,7 @@ use std::{hash::Hasher, sync::Arc};
 
 use alloy_primitives::{Address, B256, U256};
 use flux_profiler::timed;
-use lh_types::{ForkName, ForkVersionDecode, test_utils::TestRandom};
+use lh_types::{ForkName, ForkVersionDecode};
 use rustc_hash::{FxHashMap, FxHasher};
 use serde::{Deserialize, Serialize};
 use ssz::{Decode, DecodeError};
@@ -12,7 +12,7 @@ use tree_hash::TreeHash;
 
 use crate::{
     BidTrace, Blob, BlobsBundle, BlockMergingData, BlockValidationError, BlsPublicKeyBytes,
-    BlsSignatureBytes, ExecutionPayload, SignedBidSubmission,
+    BlsSignatureBytes, ExecutionPayload, SignedBidSubmission, TestRandom,
     bid_adjustment_data::BidAdjustmentData,
     bid_submission,
     fields::{ExecutionRequests, KzgCommitment, KzgProof, Transaction},
@@ -34,7 +34,8 @@ impl ForkVersionDecode for DehydratedBidSubmission {
             ForkName::Capella |
             ForkName::Deneb |
             ForkName::Electra |
-            ForkName::Gloas => Err(DecodeError::NoMatchingVariant),
+            ForkName::Gloas |
+            ForkName::Heze => Err(DecodeError::NoMatchingVariant),
             ForkName::Fulu => DehydratedBidSubmissionFulu::from_ssz_bytes(bytes)
                 .map(DehydratedBidSubmission::Fulu),
         }
@@ -212,6 +213,7 @@ impl ForkVersionDecode for DehydratedBidSubmissionFuluWithAdjustments {
             ForkName::Capella |
             ForkName::Deneb |
             ForkName::Gloas |
+            ForkName::Heze |
             ForkName::Electra => Err(DecodeError::NoMatchingVariant),
             ForkName::Fulu => DehydratedBidSubmissionFuluWithAdjustments::from_ssz_bytes(bytes),
         }
@@ -254,6 +256,7 @@ impl ForkVersionDecode for DehydratedBidSubmissionFuluWithMergingData {
             ForkName::Capella |
             ForkName::Deneb |
             ForkName::Gloas |
+            ForkName::Heze |
             ForkName::Electra => Err(DecodeError::NoMatchingVariant),
             ForkName::Fulu => DehydratedBidSubmissionFuluWithMergingData::from_ssz_bytes(bytes),
         }

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -10,6 +10,7 @@ mod execution_payload;
 mod fields;
 mod hydration;
 mod operator;
+mod test_random_compat;
 mod test_utils;
 mod utils;
 mod validator;
@@ -29,14 +30,14 @@ pub use fields::*;
 pub use helix_tcp_types::{Compression, MergeType};
 pub use hydration::*;
 pub use lh_kzg::{KzgCommitment, KzgProof};
-pub use lh_test_random::TestRandom;
 pub use lh_types::{
     Config as LhConfig, EthSpec, ExecPayload, ForkName, ForkVersionDecode, MainnetEthSpec,
-    SignedRoot, test_utils::TestRandom,
+    SignedRoot,
 };
 pub use operator::*;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
+pub use test_random_compat::TestRandom;
 pub use test_utils::*;
 pub use validator::*;
 

--- a/crates/types/src/test_random_compat.rs
+++ b/crates/types/src/test_random_compat.rs
@@ -1,0 +1,257 @@
+//! `TestRandom` used to be provided by lighthouse (`test_random_derive` +
+//! `lh_types::test_utils::TestRandom`), but was removed upstream in favor of
+//! `arbitrary`-based generation (lighthouse PR #9006). helix's own types still want a cheap
+//! "give me a random instance" helper for round-trip tests, so this vendors the removed trait
+//! and its blanket impls (unchanged from lighthouse's last version) rather than touching the
+//! ~12 call sites across the crate. Impls for lighthouse's own types (`Epoch`, `Slot`) are
+//! added here too, since those no longer come from upstream either.
+
+use std::sync::Arc;
+
+use alloy_primitives::{Address, B256, U256};
+use lh_bls::{
+    AggregateSignature, PUBLIC_KEY_BYTES_LEN, PublicKey, PublicKeyBytes, SIGNATURE_BYTES_LEN,
+    SecretKey, Signature, SignatureBytes,
+};
+use lh_kzg::{BYTES_PER_COMMITMENT, KzgCommitment, KzgProof};
+use lh_types::{
+    ConsolidationRequest, DepositRequest, Epoch, EthSpec, ExecutionRequestsElectra, Slot,
+    Withdrawal, WithdrawalRequest,
+};
+use rand::RngCore;
+use ssz_types::{FixedVector, VariableList, typenum::Unsigned};
+
+pub trait TestRandom {
+    fn random_for_test(rng: &mut impl RngCore) -> Self;
+}
+
+impl TestRandom for bool {
+    fn random_for_test(rng: &mut impl RngCore) -> Self {
+        (rng.next_u32() % 2) == 1
+    }
+}
+
+impl TestRandom for u8 {
+    fn random_for_test(rng: &mut impl RngCore) -> Self {
+        rng.next_u32().to_be_bytes()[0]
+    }
+}
+
+impl TestRandom for u32 {
+    fn random_for_test(rng: &mut impl RngCore) -> Self {
+        rng.next_u32()
+    }
+}
+
+impl TestRandom for u64 {
+    fn random_for_test(rng: &mut impl RngCore) -> Self {
+        rng.next_u64()
+    }
+}
+
+impl TestRandom for usize {
+    fn random_for_test(rng: &mut impl RngCore) -> Self {
+        rng.next_u32() as usize
+    }
+}
+
+impl<U: TestRandom> TestRandom for Vec<U> {
+    fn random_for_test(rng: &mut impl RngCore) -> Self {
+        (0..(usize::random_for_test(rng) % 4)).map(|_| U::random_for_test(rng)).collect()
+    }
+}
+
+impl<U: TestRandom> TestRandom for Arc<U> {
+    fn random_for_test(rng: &mut impl RngCore) -> Self {
+        Arc::new(U::random_for_test(rng))
+    }
+}
+
+impl<U: TestRandom, const N: usize> TestRandom for smallvec::SmallVec<[U; N]> {
+    fn random_for_test(rng: &mut impl RngCore) -> Self {
+        (0..(usize::random_for_test(rng) % 4)).map(|_| U::random_for_test(rng)).collect()
+    }
+}
+
+macro_rules! impl_test_random_for_u8_array {
+    ($len:expr) => {
+        impl TestRandom for [u8; $len] {
+            fn random_for_test(rng: &mut impl RngCore) -> Self {
+                let mut bytes = [0; $len];
+                rng.fill_bytes(&mut bytes);
+                bytes
+            }
+        }
+    };
+}
+
+impl_test_random_for_u8_array!(3);
+impl_test_random_for_u8_array!(4);
+impl_test_random_for_u8_array!(32);
+impl_test_random_for_u8_array!(48);
+impl_test_random_for_u8_array!(96);
+
+impl<T: TestRandom, N: Unsigned> TestRandom for FixedVector<T, N> {
+    fn random_for_test(rng: &mut impl RngCore) -> Self {
+        Self::new((0..N::to_usize()).map(|_| T::random_for_test(rng)).collect())
+            .expect("N items provided")
+    }
+}
+
+impl<T: TestRandom, N: Unsigned> TestRandom for VariableList<T, N> {
+    fn random_for_test(rng: &mut impl RngCore) -> Self {
+        let len =
+            if N::to_usize() == 0 { 0 } else { usize::random_for_test(rng) % 4.min(N::to_usize()) };
+        (0..len).map(|_| T::random_for_test(rng)).collect::<Vec<_>>().try_into().unwrap()
+    }
+}
+
+impl TestRandom for Address {
+    fn random_for_test(rng: &mut impl RngCore) -> Self {
+        let mut bytes = [0; 20];
+        rng.fill_bytes(&mut bytes);
+        Address::from(bytes)
+    }
+}
+
+impl TestRandom for B256 {
+    fn random_for_test(rng: &mut impl RngCore) -> Self {
+        let mut bytes = [0; 32];
+        rng.fill_bytes(&mut bytes);
+        B256::from(bytes)
+    }
+}
+
+impl TestRandom for U256 {
+    fn random_for_test(rng: &mut impl RngCore) -> Self {
+        let mut bytes = [0; 32];
+        rng.fill_bytes(&mut bytes);
+        U256::from_le_slice(&bytes)
+    }
+}
+
+impl TestRandom for Epoch {
+    fn random_for_test(rng: &mut impl RngCore) -> Self {
+        Epoch::new(u64::random_for_test(rng))
+    }
+}
+
+impl TestRandom for Slot {
+    fn random_for_test(rng: &mut impl RngCore) -> Self {
+        Slot::new(u64::random_for_test(rng))
+    }
+}
+
+impl TestRandom for Withdrawal {
+    fn random_for_test(rng: &mut impl RngCore) -> Self {
+        Self {
+            index: u64::random_for_test(rng),
+            validator_index: u64::random_for_test(rng),
+            address: Address::random_for_test(rng),
+            amount: u64::random_for_test(rng),
+        }
+    }
+}
+
+impl TestRandom for DepositRequest {
+    fn random_for_test(rng: &mut impl RngCore) -> Self {
+        Self {
+            pubkey: PublicKeyBytes::random_for_test(rng),
+            withdrawal_credentials: B256::random_for_test(rng),
+            amount: u64::random_for_test(rng),
+            signature: SignatureBytes::random_for_test(rng),
+            index: u64::random_for_test(rng),
+        }
+    }
+}
+
+impl TestRandom for WithdrawalRequest {
+    fn random_for_test(rng: &mut impl RngCore) -> Self {
+        Self {
+            source_address: Address::random_for_test(rng),
+            validator_pubkey: PublicKeyBytes::random_for_test(rng),
+            amount: u64::random_for_test(rng),
+        }
+    }
+}
+
+impl TestRandom for ConsolidationRequest {
+    fn random_for_test(rng: &mut impl RngCore) -> Self {
+        Self {
+            source_address: Address::random_for_test(rng),
+            source_pubkey: PublicKeyBytes::random_for_test(rng),
+            target_pubkey: PublicKeyBytes::random_for_test(rng),
+        }
+    }
+}
+
+impl<E: EthSpec> TestRandom for ExecutionRequestsElectra<E> {
+    fn random_for_test(rng: &mut impl RngCore) -> Self {
+        Self {
+            deposits: TestRandom::random_for_test(rng),
+            withdrawals: TestRandom::random_for_test(rng),
+            consolidations: TestRandom::random_for_test(rng),
+        }
+    }
+}
+
+impl TestRandom for SecretKey {
+    fn random_for_test(_rng: &mut impl RngCore) -> Self {
+        SecretKey::random()
+    }
+}
+
+impl TestRandom for PublicKey {
+    fn random_for_test(rng: &mut impl RngCore) -> Self {
+        SecretKey::random_for_test(rng).public_key()
+    }
+}
+
+impl TestRandom for PublicKeyBytes {
+    fn random_for_test(rng: &mut impl RngCore) -> Self {
+        if bool::random_for_test(rng) {
+            PublicKeyBytes::from(PublicKey::random_for_test(rng))
+        } else {
+            PublicKeyBytes::deserialize(&<[u8; PUBLIC_KEY_BYTES_LEN]>::random_for_test(rng))
+                .unwrap()
+        }
+    }
+}
+
+impl TestRandom for Signature {
+    fn random_for_test(_rng: &mut impl RngCore) -> Self {
+        Signature::infinity().expect("infinity signature is valid")
+    }
+}
+
+impl TestRandom for SignatureBytes {
+    fn random_for_test(rng: &mut impl RngCore) -> Self {
+        if bool::random_for_test(rng) {
+            SignatureBytes::from(Signature::random_for_test(rng))
+        } else {
+            SignatureBytes::deserialize(&<[u8; SIGNATURE_BYTES_LEN]>::random_for_test(rng)).unwrap()
+        }
+    }
+}
+
+impl TestRandom for AggregateSignature {
+    fn random_for_test(rng: &mut impl RngCore) -> Self {
+        let mut aggregate = AggregateSignature::infinity();
+        aggregate.add_assign(&Signature::random_for_test(rng));
+        aggregate
+    }
+}
+
+impl TestRandom for KzgCommitment {
+    fn random_for_test(rng: &mut impl RngCore) -> Self {
+        KzgCommitment(<[u8; 48]>::random_for_test(rng))
+    }
+}
+
+impl TestRandom for KzgProof {
+    fn random_for_test(rng: &mut impl RngCore) -> Self {
+        let mut bytes = [0; BYTES_PER_COMMITMENT];
+        rng.fill_bytes(&mut bytes);
+        Self(bytes)
+    }
+}

--- a/crates/types/src/test_utils.rs
+++ b/crates/types/src/test_utils.rs
@@ -1,10 +1,10 @@
 use alloy_primitives::{B256, b256};
-use lh_types::test_utils::{TestRandom, XorShiftRng};
 use rand::SeedableRng;
+use rand_xorshift::XorShiftRng;
 use serde_json::Value;
 use ssz::{Decode, Encode};
 
-use crate::{BlsPublicKey, BlsPublicKeyBytes, BlsSecretKey};
+use crate::{BlsPublicKey, BlsPublicKeyBytes, BlsSecretKey, TestRandom};
 
 /// Test that the encoding and decoding works, returns the decoded struct
 pub fn test_encode_decode_json<T: serde::Serialize + serde::de::DeserializeOwned>(d: &str) -> T {

--- a/crates/types/src/validator.rs
+++ b/crates/types/src/validator.rs
@@ -1,11 +1,12 @@
 use alloy_primitives::{Address, B256};
-use lh_types::{Epoch, SignedRoot, test_utils::TestRandom};
+use lh_types::{Epoch, SignedRoot};
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
 use tree_hash_derive::TreeHash;
 
 use crate::{
-    BlsPublicKey, BlsPublicKeyBytes, BlsSignature, BlsSignatureBytes, SigError, TestRandomSeed,
+    BlsPublicKey, BlsPublicKeyBytes, BlsSignature, BlsSignatureBytes, SigError, TestRandom,
+    TestRandomSeed,
 };
 
 /// From Lighthouse, replacing PublicKeyBytes with PublicKey

--- a/crates/website/src/website_service.rs
+++ b/crates/website/src/website_service.rs
@@ -203,7 +203,11 @@ impl WebsiteService {
             genesis_validators_root: alloy_primitives::hex::encode(
                 state.chain_info.genesis_validators_root.as_ref() as &[u8],
             ),
-            builder_signing_domain: state.chain_info.spec.get_builder_domain().to_string(),
+            builder_signing_domain: state
+                .chain_info
+                .spec
+                .get_builder_application_domain()
+                .to_string(),
         })
     }
 }


### PR DESCRIPTION
Issue: #489 (step 0 of 6)

## What this PR does
Pins the lighthouse dependencies to a Gloas (ePBS)-supporting devnet revision and fixes the resulting compile breakage: lighthouse's removal of `test_random_derive`/`TestRandom` (vendored locally in `test_random_compat.rs`), `ExecutionRequests` becoming fork-versioned, a new `ForkName::Heze` variant, and a `ChainSpec` API rename (`get_slot_duration`, `get_builder_application_domain`).

## What this PR deliberately does not do
No new Gloas types or endpoints. That's step 1.

## Tests
No behavior change; existing test suite (`cargo test -p helix-types -p helix-relay --all-features`) passes unchanged, including the pre-existing `#[ignore]`d tests tracked by #485/#486.

## Reviewer checklist
- [ ] CI (`lint`, `unit-test`) is green
- [ ] Matches the linked issue/step
- [ ] No unexplained scope creep or unrelated files touched