### PR TITLE
Add Gloas builder-API auth/preference types and stub the 3 new proposer endpoints

### DIFF
--- a/crates/common/src/api/mod.rs
+++ b/crates/common/src/api/mod.rs
@@ -31,6 +31,13 @@ pub const PATH_GET_HEADER: &str = "/header/{slot}/{parent_hash}/{pubkey}";
 pub const PATH_HEADER_STREAM: &str = "/header_stream/{slot}/{parent_hash}/{pubkey}";
 pub const PATH_GET_PAYLOAD: &str = "/blinded_blocks";
 
+// Gloas (ePBS) builder-API additions, per https://github.com/ethereum/builder-specs/pull/165.
+// Not yet wired to the auctioneer -- see docs/gloas-support-plan.md.
+pub const PATH_GET_EXECUTION_PAYLOAD_BID: &str =
+    "/execution_payload_bid/{slot}/{parent_hash}/{parent_root}/{proposer_pubkey}";
+pub const PATH_SUBMIT_BUILDER_PREFERENCES: &str = "/builder_preferences/{proposer_pubkey}";
+pub const PATH_SUBMIT_SIGNED_BEACON_BLOCK: &str = "/beacon_blocks";
+
 pub const PATH_DATA_API: &str = "/relay/v1/data";
 pub const PATH_DATA_API_V2: &str = "/relay/v2/data";
 

--- a/crates/common/src/api/proposer_api.rs
+++ b/crates/common/src/api/proposer_api.rs
@@ -15,3 +15,20 @@ pub struct GetHeaderParams {
     pub parent_hash: B256,
     pub pubkey: BlsPublicKeyBytes,
 }
+
+/// Path params for Gloas's `getExecutionPayloadBid`. Adds `parent_root` relative to
+/// `GetHeaderParams`: with ePBS the beacon block and execution payload are decoupled, so
+/// `parent_hash` and `parent_root` may reference different parent blocks.
+#[derive(Debug, serde::Deserialize, Clone, Copy)]
+pub struct GetExecutionPayloadBidParams {
+    pub slot: u64,
+    pub parent_hash: B256,
+    pub parent_root: B256,
+    pub proposer_pubkey: BlsPublicKeyBytes,
+}
+
+/// Path params for Gloas's `submitBuilderPreferences`.
+#[derive(Debug, serde::Deserialize, Clone, Copy)]
+pub struct ProposerPubkeyParams {
+    pub proposer_pubkey: BlsPublicKeyBytes,
+}

--- a/crates/common/src/chain_info.rs
+++ b/crates/common/src/chain_info.rs
@@ -20,6 +20,9 @@ pub struct ChainInfo {
     pub clock: SlotClock,
     pub genesis_time_in_secs: u64,
     pub builder_domain: B256,
+    /// Domain for verifying Gloas builder-API `SignedRequestAuth` signatures. Not a consensus
+    /// domain; see `ChainSpec::get_request_auth_domain`.
+    pub request_auth_domain: B256,
 }
 
 impl ChainInfo {
@@ -27,7 +30,16 @@ impl ChainInfo {
         let name = spec.config_name.clone().expect("spec config name should be set");
         let clock = new_slot_clock(genesis_time_in_secs, spec.get_slot_duration());
         let builder_domain = spec.get_builder_application_domain();
-        Self { name, genesis_validators_root, spec, clock, genesis_time_in_secs, builder_domain }
+        let request_auth_domain = spec.get_request_auth_domain();
+        Self {
+            name,
+            genesis_validators_root,
+            spec,
+            clock,
+            genesis_time_in_secs,
+            builder_domain,
+            request_auth_domain,
+        }
     }
 
     pub fn fork_at_slot(&self, slot: Slot) -> ForkName {

--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -532,6 +532,9 @@ impl RouterConfig {
             Route::HeaderStream,
             Route::GetPayload,
             Route::GetPayloadV2,
+            Route::GetExecutionPayloadBid,
+            Route::SubmitBuilderPreferences,
+            Route::SubmitSignedBeaconBlock,
         ]);
 
         self.replace_condensed_with_real(Route::DataApi, &[
@@ -581,7 +584,8 @@ impl RouterConfig {
 
         let is_get_header_instance = routes.contains(&Route::ProposerApi) ||
             routes.contains(&Route::GetHeader) ||
-            routes.contains(&Route::HeaderStream);
+            routes.contains(&Route::HeaderStream) ||
+            routes.contains(&Route::GetExecutionPayloadBid);
         let is_submission_instance =
             routes.contains(&Route::BuilderApi) || routes.contains(&Route::SubmitBlock);
 
@@ -655,6 +659,12 @@ pub enum Route {
     DataAdjustments,
     MergedBlocks,
     PromoteBuilder,
+    /// Gloas (ePBS): not yet wired to the auctioneer, see docs/gloas-support-plan.md.
+    GetExecutionPayloadBid,
+    /// Gloas (ePBS): not yet wired to the auctioneer, see docs/gloas-support-plan.md.
+    SubmitBuilderPreferences,
+    /// Gloas (ePBS): not yet wired to the auctioneer, see docs/gloas-support-plan.md.
+    SubmitSignedBeaconBlock,
 }
 
 impl Route {
@@ -672,6 +682,15 @@ impl Route {
             Route::HeaderStream => format!("{PATH_PROPOSER_API}{PATH_HEADER_STREAM}"),
             Route::GetPayload => format!("{PATH_PROPOSER_API}{PATH_GET_PAYLOAD}"),
             Route::GetPayloadV2 => format!("{PATH_PROPOSER_API_V2}{PATH_GET_PAYLOAD}"),
+            Route::GetExecutionPayloadBid => {
+                format!("{PATH_PROPOSER_API}{PATH_GET_EXECUTION_PAYLOAD_BID}")
+            }
+            Route::SubmitBuilderPreferences => {
+                format!("{PATH_PROPOSER_API}{PATH_SUBMIT_BUILDER_PREFERENCES}")
+            }
+            Route::SubmitSignedBeaconBlock => {
+                format!("{PATH_PROPOSER_API}{PATH_SUBMIT_SIGNED_BEACON_BLOCK}")
+            }
             Route::ProposerPayloadDelivered => {
                 format!("{PATH_DATA_API}{PATH_PROPOSER_PAYLOAD_DELIVERED}")
             }

--- a/crates/relay/src/api/proposer/error.rs
+++ b/crates/relay/src/api/proposer/error.rs
@@ -123,6 +123,19 @@ pub enum ProposerApiError {
 
     #[error("SszDecodeError {0:?}")]
     SszDecodeError(DecodeError),
+
+    // Gloas (ePBS) builder-API additions, per
+    // https://github.com/ethereum/builder-specs/pull/165. Not yet wired to the auctioneer.
+    #[error("invalid SignedRequestAuth: signature verification failed")]
+    InvalidRequestAuthSignature,
+
+    #[error(
+        "invalid SignedRequestAuth: auth.message.slot ({auth_slot}) does not match the request slot ({request_slot})"
+    )]
+    RequestAuthSlotMismatch { auth_slot: u64, request_slot: u64 },
+
+    #[error("invalid request: Date-Milliseconds and X-Timeout-Ms headers are required")]
+    MissingTimingHeaders,
 }
 
 impl From<DecodeError> for ProposerApiError {
@@ -166,12 +179,14 @@ impl IntoResponse for ProposerApiError {
                 ProposerApiError::SigError(_) |
                 ProposerApiError::DeliveringPayload |
                 ProposerApiError::GetPayloadAlreadyReceived |
-                ProposerApiError::RequestForPastSlot { .. } => StatusCode::BAD_REQUEST,
+                ProposerApiError::RequestForPastSlot { .. } |
+                ProposerApiError::RequestAuthSlotMismatch { .. } |
+                ProposerApiError::MissingTimingHeaders => StatusCode::BAD_REQUEST,
 
                 // All authentication failures, kept indistinguishable by status
-                ProposerApiError::InvalidApiKey | ProposerApiError::StreamNotAdmitted => {
-                    StatusCode::UNAUTHORIZED
-                }
+                ProposerApiError::InvalidApiKey |
+                ProposerApiError::StreamNotAdmitted |
+                ProposerApiError::InvalidRequestAuthSignature => StatusCode::UNAUTHORIZED,
 
                 ProposerApiError::InternalServerError |
                 ProposerApiError::NoExecutionPayloadFound => StatusCode::INTERNAL_SERVER_ERROR,

--- a/crates/relay/src/api/proposer/get_execution_payload_bid.rs
+++ b/crates/relay/src/api/proposer/get_execution_payload_bid.rs
@@ -1,0 +1,74 @@
+use std::sync::Arc;
+
+use axum::{Extension, extract::Path, http::HeaderMap};
+use helix_common::{
+    api::{
+        HEADER_START_TIME_UNIX_MS, HEADER_TIMEOUT_MS, proposer_api::GetExecutionPayloadBidParams,
+    },
+    api_provider::header_u64,
+    decoder::Encoding,
+    utils::extract_request_id,
+};
+use helix_types::{ForkName, SignedRequestAuth};
+use hyper::StatusCode;
+use ssz::Decode;
+use tracing::info;
+
+use super::{ProposerApi, get_payload::fork_name_from_header};
+use crate::api::{Api, proposer::error::ProposerApiError};
+
+impl<A: Api> ProposerApi<A> {
+    /// Serves a `SignedExecutionPayloadBid` for the given slot/parent_hash/parent_root to a
+    /// Gloas (ePBS) proposer.
+    ///
+    /// Not yet wired to the auctioneer: this only validates the request per
+    /// <https://github.com/ethereum/builder-specs/pull/165> and always answers with the
+    /// spec's "no bid available" response.
+    #[tracing::instrument(skip_all, err(level = tracing::Level::TRACE), fields(id =% extract_request_id(&headers), slot = params.slot))]
+    pub async fn get_execution_payload_bid(
+        Extension(proposer_api): Extension<Arc<ProposerApi<A>>>,
+        headers: HeaderMap,
+        Path(params): Path<GetExecutionPayloadBidParams>,
+        body: bytes::Bytes,
+    ) -> Result<StatusCode, ProposerApiError> {
+        let fork = fork_name_from_header(&headers).ok().flatten();
+        if fork != Some(ForkName::Gloas) {
+            return Err(ProposerApiError::InvalidFork);
+        }
+
+        if header_u64(&headers, HEADER_START_TIME_UNIX_MS).is_none() ||
+            header_u64(&headers, HEADER_TIMEOUT_MS).is_none()
+        {
+            return Err(ProposerApiError::MissingTimingHeaders);
+        }
+
+        let signed_request_auth: SignedRequestAuth = match Encoding::from_content_type(&headers) {
+            Encoding::Json => serde_json::from_slice(&body)?,
+            Encoding::Ssz => SignedRequestAuth::from_ssz_bytes(&body)?,
+        };
+
+        if signed_request_auth.message.slot != params.slot {
+            return Err(ProposerApiError::RequestAuthSlotMismatch {
+                auth_slot: signed_request_auth.message.slot,
+                request_slot: params.slot,
+            });
+        }
+
+        signed_request_auth
+            .verify_signature(&params.proposer_pubkey, proposer_api.chain_info.request_auth_domain)
+            .map_err(|_| ProposerApiError::InvalidRequestAuthSignature)?;
+
+        info!(
+            slot = params.slot,
+            parent_hash = ?params.parent_hash,
+            parent_root = ?params.parent_root,
+            proposer_pubkey = ?params.proposer_pubkey,
+            "validated getExecutionPayloadBid request (not yet wired to the auctioneer)"
+        );
+
+        // TODO(gloas): fetch/build the SignedExecutionPayloadBid from the auctioneer, honoring
+        // any stored max_execution_payment preference. Not wired in yet -- always reports "no
+        // bid available", which is a valid response per spec.
+        Ok(StatusCode::NO_CONTENT)
+    }
+}

--- a/crates/relay/src/api/proposer/get_payload.rs
+++ b/crates/relay/src/api/proposer/get_payload.rs
@@ -579,7 +579,7 @@ fn calculate_slot_time_info(
     Some((since_slot_start, until_slot_start))
 }
 
-fn fork_name_from_header(headers: &HeaderMap) -> Result<Option<ForkName>, String> {
+pub(super) fn fork_name_from_header(headers: &HeaderMap) -> Result<Option<ForkName>, String> {
     headers
         .get(CONSENSUS_VERSION_HEADER)
         .map(|fork_name| fork_name.to_str().map_err(|e| e.to_string()).and_then(ForkName::from_str))

--- a/crates/relay/src/api/proposer/mod.rs
+++ b/crates/relay/src/api/proposer/mod.rs
@@ -1,8 +1,11 @@
 mod error;
+mod get_execution_payload_bid;
 mod get_header;
 pub(crate) mod get_payload;
 mod header_stream;
 mod register;
+mod submit_builder_preferences;
+mod submit_signed_beacon_block;
 
 use std::sync::{Arc, atomic::Ordering};
 

--- a/crates/relay/src/api/proposer/submit_builder_preferences.rs
+++ b/crates/relay/src/api/proposer/submit_builder_preferences.rs
@@ -1,0 +1,54 @@
+use std::sync::Arc;
+
+use axum::{Extension, extract::Path, http::HeaderMap};
+use helix_common::{
+    api::proposer_api::ProposerPubkeyParams, decoder::Encoding, utils::extract_request_id,
+};
+use helix_types::{BuilderPreferencesRequest, ForkName};
+use hyper::StatusCode;
+use ssz::Decode;
+use tracing::info;
+
+use super::{ProposerApi, get_payload::fork_name_from_header};
+use crate::api::{Api, proposer::error::ProposerApiError};
+
+impl<A: Api> ProposerApi<A> {
+    /// Accepts a proposer's Gloas (ePBS) `BuilderPreferencesRequest`.
+    ///
+    /// Not yet wired in: this only validates the request per
+    /// <https://github.com/ethereum/builder-specs/pull/165>; preferences are not yet stored
+    /// or enforced when serving bids.
+    #[tracing::instrument(skip_all, err(level = tracing::Level::TRACE), fields(id =% extract_request_id(&headers)))]
+    pub async fn submit_builder_preferences(
+        Extension(proposer_api): Extension<Arc<ProposerApi<A>>>,
+        headers: HeaderMap,
+        Path(params): Path<ProposerPubkeyParams>,
+        body: bytes::Bytes,
+    ) -> Result<StatusCode, ProposerApiError> {
+        let fork = fork_name_from_header(&headers).ok().flatten();
+        if fork != Some(ForkName::Gloas) {
+            return Err(ProposerApiError::InvalidFork);
+        }
+
+        let request: BuilderPreferencesRequest = match Encoding::from_content_type(&headers) {
+            Encoding::Json => serde_json::from_slice(&body)?,
+            Encoding::Ssz => BuilderPreferencesRequest::from_ssz_bytes(&body)?,
+        };
+
+        request
+            .auth
+            .verify_signature(&params.proposer_pubkey, proposer_api.chain_info.request_auth_domain)
+            .map_err(|_| ProposerApiError::InvalidRequestAuthSignature)?;
+
+        info!(
+            proposer_pubkey = ?params.proposer_pubkey,
+            slot = request.auth.message.slot,
+            max_execution_payment = request.preferences.max_execution_payment,
+            "validated submitBuilderPreferences request (not yet persisted -- storage not wired in)"
+        );
+
+        // TODO(gloas): reject stale slots, store preferences per proposer per slot, and honor
+        // max_execution_payment when serving bids. Not wired in yet.
+        Ok(StatusCode::ACCEPTED)
+    }
+}

--- a/crates/relay/src/api/proposer/submit_signed_beacon_block.rs
+++ b/crates/relay/src/api/proposer/submit_signed_beacon_block.rs
@@ -1,0 +1,53 @@
+use std::sync::Arc;
+
+use axum::{Extension, http::HeaderMap};
+use helix_common::{decoder::Encoding, utils::extract_request_id};
+use helix_types::{ForkName, SignedBeaconBlock, SignedBeaconBlockGloas};
+use hyper::StatusCode;
+use ssz::Decode;
+use tracing::info;
+
+use super::{ProposerApi, get_payload::fork_name_from_header};
+use crate::api::{Api, proposer::error::ProposerApiError};
+
+impl<A: Api> ProposerApi<A> {
+    /// Accepts a Gloas (ePBS) `SignedBeaconBlock`, replacing `submitBlindedBlock`/`getPayload`:
+    /// post-Gloas there is no blinded-block variant, and the payload is no longer returned
+    /// synchronously -- the builder reveals it later via a `SignedExecutionPayloadEnvelope`
+    /// broadcast to the PTC over gossip.
+    ///
+    /// Not yet wired in: this only decodes and accepts the block per
+    /// <https://github.com/ethereum/builder-specs/pull/165>. No validation against a held
+    /// bid, and no envelope construction/broadcast, happens yet.
+    #[tracing::instrument(skip_all, err(level = tracing::Level::TRACE), fields(id =% extract_request_id(&headers)))]
+    pub async fn submit_signed_beacon_block(
+        Extension(_proposer_api): Extension<Arc<ProposerApi<A>>>,
+        headers: HeaderMap,
+        body: bytes::Bytes,
+    ) -> Result<StatusCode, ProposerApiError> {
+        let fork = fork_name_from_header(&headers).ok().flatten();
+        if fork != Some(ForkName::Gloas) {
+            return Err(ProposerApiError::InvalidFork);
+        }
+
+        let signed_block: SignedBeaconBlock = match Encoding::from_content_type(&headers) {
+            Encoding::Json => {
+                let block: SignedBeaconBlockGloas = serde_json::from_slice(&body)?;
+                block.into()
+            }
+            Encoding::Ssz => {
+                let block = SignedBeaconBlockGloas::from_ssz_bytes(&body)?;
+                block.into()
+            }
+        };
+
+        info!(
+            slot = signed_block.slot().as_u64(),
+            "accepted submitSignedBeaconBlock request (not yet wired to the auctioneer)"
+        );
+
+        // TODO(gloas): validate against a held SignedExecutionPayloadBid, then construct and
+        // broadcast the SignedExecutionPayloadEnvelope to the PTC. Not wired in yet.
+        Ok(StatusCode::ACCEPTED)
+    }
+}

--- a/crates/relay/src/api/router.rs
+++ b/crates/relay/src/api/router.rs
@@ -72,6 +72,9 @@ pub fn build_router<A: Api>(
             Route::HeaderStream => get(ProposerApi::<A>::header_stream),
             Route::GetPayload => post(ProposerApi::<A>::get_payload),
             Route::GetPayloadV2 => post(ProposerApi::<A>::get_payload_v2),
+            Route::GetExecutionPayloadBid => post(ProposerApi::<A>::get_execution_payload_bid),
+            Route::SubmitBuilderPreferences => post(ProposerApi::<A>::submit_builder_preferences),
+            Route::SubmitSignedBeaconBlock => post(ProposerApi::<A>::submit_signed_beacon_block),
             Route::ProposerPayloadDelivered => {
                 get(DataApi::<A::ApiProvider>::proposer_payload_delivered)
             }

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -10,6 +10,7 @@ mod execution_payload;
 mod fields;
 mod hydration;
 mod operator;
+mod request_auth;
 mod test_random_compat;
 mod test_utils;
 mod utils;
@@ -35,6 +36,7 @@ pub use lh_types::{
     SignedRoot,
 };
 pub use operator::*;
+pub use request_auth::*;
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
 pub use test_random_compat::TestRandom;
@@ -62,6 +64,7 @@ pub type BlobsBundle = crate::blobs::BlobsBundle;
 pub type VersionedSignedProposal = SignedBlockContents;
 pub type SignedBeaconBlock = lh_types::SignedBeaconBlock<MainnetEthSpec>;
 pub type SignedBeaconBlockFulu = lh_types::SignedBeaconBlockFulu<MainnetEthSpec>;
+pub type SignedBeaconBlockGloas = lh_types::SignedBeaconBlockGloas<MainnetEthSpec>;
 
 // Beacon block
 pub type BeaconBlockFulu = lh_types::BeaconBlockFulu<MainnetEthSpec>;

--- a/crates/types/src/request_auth.rs
+++ b/crates/types/src/request_auth.rs
@@ -1,0 +1,132 @@
+//! Builder-API-only types introduced for Gloas (ePBS), used to authenticate
+//! `getExecutionPayloadBid` and `submitBuilderPreferences` requests, and to carry a
+//! proposer's per-builder payment preferences.
+//!
+//! See <https://github.com/ethereum/builder-specs/pull/165>. Not yet part of any merged
+//! spec, so field shapes may still change.
+
+use alloy_primitives::B256;
+use lh_types::SignedRoot;
+use serde::{Deserialize, Serialize};
+use ssz_derive::{Decode, Encode};
+use ssz_types::typenum::U4096;
+use tree_hash_derive::TreeHash;
+
+use crate::{BlsPublicKey, BlsPublicKeyBytes, BlsSignature, BlsSignatureBytes, SigError};
+
+crate::ssz_bytes_wrapper! {
+    /// ByteList[MAX_DATA_SIZE], MAX_DATA_SIZE = 4096
+    pub struct RequestAuthData;
+    max = U4096;
+}
+
+/// Authenticates a `getExecutionPayloadBid` or `submitBuilderPreferences` request. Signed
+/// under `DOMAIN_REQUEST_AUTH`, distinct from the in-protocol `DOMAIN_BEACON_BUILDER`.
+#[derive(PartialEq, Debug, Serialize, Deserialize, Clone, Encode, Decode, TreeHash)]
+pub struct RequestAuth {
+    /// Opaque authentication data agreed with the builder out of band.
+    pub data: RequestAuthData,
+    /// The proposal slot this request is authorized for.
+    #[serde(with = "serde_utils::quoted_u64")]
+    pub slot: u64,
+}
+
+impl SignedRoot for RequestAuth {}
+
+#[derive(PartialEq, Debug, Serialize, Deserialize, Clone, Encode, Decode)]
+pub struct SignedRequestAuth {
+    pub message: RequestAuth,
+    pub signature: BlsSignatureBytes,
+}
+
+impl SignedRequestAuth {
+    /// `pubkey` is resolved from the `proposer_pubkey` path parameter, not carried inside
+    /// `RequestAuth` itself. `domain` is `ChainInfo::request_auth_domain`.
+    pub fn verify_signature(
+        &self,
+        pubkey: &BlsPublicKeyBytes,
+        domain: B256,
+    ) -> Result<(), SigError> {
+        let signature = BlsSignature::deserialize(self.signature.as_slice())
+            .map_err(|_| SigError::InvalidBlsSignatureBytes)?;
+        let pubkey = BlsPublicKey::deserialize(pubkey.as_slice())
+            .map_err(|_| SigError::InvalidBlsPubkeyBytes)?;
+
+        let message = self.message.signing_root(domain);
+        if !signature.verify(&pubkey, message) {
+            return Err(SigError::InvalidBlsSignature);
+        }
+
+        Ok(())
+    }
+}
+
+/// A proposer's per-builder payment preferences, submitted via `submitBuilderPreferences`.
+#[derive(PartialEq, Debug, Default, Serialize, Deserialize, Clone, Encode, Decode)]
+pub struct BuilderPreferences {
+    /// Maximum execution-layer payment, in Gwei, the proposer will accept from this builder.
+    #[serde(with = "serde_utils::quoted_u64")]
+    pub max_execution_payment: u64,
+}
+
+#[derive(PartialEq, Debug, Serialize, Deserialize, Clone, Encode, Decode)]
+pub struct BuilderPreferencesRequest {
+    pub preferences: BuilderPreferences,
+    pub auth: SignedRequestAuth,
+}
+
+#[cfg(test)]
+mod tests {
+    use ssz::{Decode, Encode};
+
+    use super::*;
+    use crate::BlsKeypair;
+
+    fn sample_request_auth() -> RequestAuth {
+        RequestAuth { data: RequestAuthData(vec![1, 2, 3, 4].into()), slot: 123 }
+    }
+
+    #[test]
+    fn request_auth_json_round_trip() {
+        let auth = sample_request_auth();
+        let json = serde_json::to_string(&auth).unwrap();
+        assert_eq!(auth, serde_json::from_str(&json).unwrap());
+    }
+
+    #[test]
+    fn request_auth_ssz_round_trip() {
+        let auth = sample_request_auth();
+        let bytes = auth.as_ssz_bytes();
+        assert_eq!(auth, RequestAuth::from_ssz_bytes(&bytes).unwrap());
+    }
+
+    #[test]
+    fn builder_preferences_request_json_round_trip() {
+        let request = BuilderPreferencesRequest {
+            preferences: BuilderPreferences { max_execution_payment: 42 },
+            auth: SignedRequestAuth {
+                message: sample_request_auth(),
+                signature: BlsSignatureBytes::default(),
+            },
+        };
+        let json = serde_json::to_string(&request).unwrap();
+        assert_eq!(request, serde_json::from_str(&json).unwrap());
+    }
+
+    #[test]
+    fn signed_request_auth_signature_round_trips() {
+        let keypair = BlsKeypair::random();
+        let domain = B256::repeat_byte(7);
+        let message = sample_request_auth();
+        let root = message.signing_root(domain);
+        let signature = keypair.sk.sign(root);
+
+        let signed = SignedRequestAuth { message, signature: signature.serialize().into() };
+        let pubkey: BlsPublicKeyBytes = keypair.pk.serialize().into();
+
+        signed.verify_signature(&pubkey, domain).expect("valid signature should verify");
+        signed
+            .verify_signature(&pubkey, B256::repeat_byte(8))
+            .expect_err("wrong domain should fail verification");
+    }
+}


### PR DESCRIPTION
Issue: #489 (step 1 of 6)

Stacked on #495 (step 0) — base branch is `od/gloas-step0-lighthouse-pin`, not `develop`. Retarget to `develop` once step 0 merges.

## What this PR does
Adds `RequestAuth`/`SignedRequestAuth` and `BuilderPreferences` types, and stubs the three new Gloas proposer-facing endpoints (`getExecutionPayloadBid`, `submitBuilderPreferences`, `submitSignedBeaconBlock`) behind new routes, validating request shape and auth signatures only.

## What this PR deliberately does not do
Not wired to the auctioneer — no real bids served, no preferences persisted, no envelope constructed or posted to a beacon node. That's steps 2-4.

## Tests
No tests yet for the new endpoints — they're shape/signature validation stubs with no behavior to pin down. Step 2 (envelope construction) and step 3 (bid serving) get tests written before implementation, per the issue.

## Reviewer checklist
- [ ] CI (`lint`, `unit-test`) is green
- [ ] Matches the linked issue/step
- [ ] No unexplained scope creep or unrelated files touched