### PR TITLE
Document stacking step PRs instead of waiting on merge order

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,10 @@ as work proceeds.
 Scope each PR to one step of one issue. Use
 [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md).
 
+Stack a step's PR on the previous step's branch rather than waiting for
+it to merge. Note the base branch in the PR description, and retarget to
+the base branch (`develop`/`main`) once the step below merges.
+
 ## Verification bar
 
 Before merging:


### PR DESCRIPTION
## What this PR does
Adds a line to CONTRIBUTING.md's pull requests section: stack a step's PR on the previous step's branch instead of waiting for it to merge, noting the base branch in the description.

## What this PR deliberately does not do
No other workflow changes.

## Tests
Docs only, no tests.

## Reviewer checklist
- [ ] CI (`lint`, `unit-test`) is green
- [ ] Matches the linked issue/step
- [ ] No unexplained scope creep or unrelated files touched