### PR TITLE
chore: remove package rename

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,9 +66,9 @@ flate2 = "1.0"
 flux = { git = "https://github.com/gattaca-com/flux", rev = "ce40087" }
 flux-network = { package = "flux-network", git = "https://github.com/gattaca-com/flux", rev = "ce40087" }
 flux-profiler = { package = "flux-profiler", git = "https://github.com/gattaca-com/flux", rev = "ce40087" }
-flux-type-hash = { package = "type-hash", git = "https://github.com/gattaca-com/flux", rev = "ce40087" }
-flux-type-hash-derive = { package = "type-hash-derive", git = "https://github.com/gattaca-com/flux", rev = "ce40087" }
 flux-utils = { package = "flux-utils", git = "https://github.com/gattaca-com/flux", rev = "ce40087" }
+type-hash = { git = "https://github.com/gattaca-com/flux", rev = "ce40087" }
+type-hash-derive = { git = "https://github.com/gattaca-com/flux", rev = "ce40087" }
 
 futures = "0.3"
 futures-util = { version = "0.3", features = ["compat"] }

--- a/crates/tcp-types/Cargo.toml
+++ b/crates/tcp-types/Cargo.toml
@@ -12,13 +12,13 @@ alloy-rpc-types.workspace = true
 bitflags.workspace = true
 bytes.workspace = true
 ethereum_ssz.workspace = true
-flux-type-hash.workspace = true
-flux-type-hash-derive.workspace = true
 ethereum_ssz_derive.workspace = true
 serde.workspace = true
 strum.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
+type-hash.workspace = true
+type-hash-derive.workspace = true
 uuid.workspace = true
 
 [dev-dependencies]

--- a/crates/tcp-types/src/lib.rs
+++ b/crates/tcp-types/src/lib.rs
@@ -3,9 +3,9 @@ pub mod merging;
 use std::fmt::{self, Display};
 
 use bytes::Bytes;
-use flux_type_hash_derive::TypeHash;
 use serde::{Deserialize, Serialize};
 use strum::{AsRefStr, EnumString};
+use type_hash_derive::TypeHash;
 
 #[repr(u8)]
 #[derive(


### PR DESCRIPTION
this is needed for helix-tcp-types to be consumable as a publishable crate downstream https://github.com/gattaca-com/helix/tree/develop/crates/tcp-types