### PR TITLE
move from floodsub to gossipsub for operator p2p

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3778,17 +3778,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cuckoofilter"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b810a8449931679f64cd7eef1bbd0fa315801b6d5d9cdc1ace2804d6529eee18"
-dependencies = [
- "byteorder",
- "fnv",
- "rand 0.7.3",
-]
-
-[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6040,17 +6029,6 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
@@ -6316,6 +6294,9 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "hashbrown"
@@ -6359,6 +6340,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2bca93b15ea5a746f220e56587f71e73c6165eab783df9e26590069953e3c30"
 dependencies = [
  "fxhash",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -6898,6 +6888,12 @@ dependencies = [
  "outref",
  "vsimd",
 ]
+
+[[package]]
+name = "hex_fmt"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b07f60793ff0a4d9cef0f18e63b5357e06209987153a64648c972c1e5aff336f"
 
 [[package]]
 name = "hickory-net"
@@ -8483,7 +8479,7 @@ dependencies = [
  "libp2p-connection-limits",
  "libp2p-core",
  "libp2p-dns",
- "libp2p-floodsub",
+ "libp2p-gossipsub",
  "libp2p-identity",
  "libp2p-mdns",
  "libp2p-metrics",
@@ -8562,25 +8558,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "libp2p-floodsub"
-version = "0.47.0"
+name = "libp2p-gossipsub"
+version = "0.49.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0914997f56315c83bc64ffb721cd4e764ad819370582db287232c5791469697"
+checksum = "3573f3d8e30bd62cda336df5c7c1041a1caa40a648376b8e1e274d585c0ed25c"
 dependencies = [
+ "async-channel 2.5.0",
  "asynchronous-codec",
+ "base64 0.22.1",
+ "byteorder",
  "bytes",
- "cuckoofilter",
+ "either",
  "fnv",
  "futures",
+ "futures-timer",
+ "getrandom 0.2.17",
+ "hashlink 0.9.1",
+ "hex_fmt",
  "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm",
  "quick-protobuf",
  "quick-protobuf-codec",
  "rand 0.8.7",
- "smallvec",
- "thiserror 2.0.20",
+ "regex",
+ "sha2 0.10.9",
  "tracing",
+ "web-time",
 ]
 
 [[package]]
@@ -8630,6 +8634,7 @@ checksum = "805a555148522cb3414493a5153451910cb1a146c53ffbf4385708349baf62b7"
 dependencies = [
  "futures",
  "libp2p-core",
+ "libp2p-gossipsub",
  "libp2p-identity",
  "libp2p-ping",
  "libp2p-swarm",
@@ -11475,19 +11480,6 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
@@ -11522,16 +11514,6 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
@@ -11548,15 +11530,6 @@ checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.16",
 ]
 
 [[package]]
@@ -11583,15 +11556,6 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
-]
 
 [[package]]
 name = "rand_pcg"
@@ -18196,12 +18160,6 @@ checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
  "try-lock",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,7 @@ lh-eth2 = { package = "eth2", git = "https://github.com/sigp/lighthouse", rev = 
 lh-kzg = { package = "kzg", git = "https://github.com/sigp/lighthouse", rev = "f064e9e061997c41658c3544da47627c6db92bc9" }
 lh-slot-clock = { package = "slot_clock", git = "https://github.com/sigp/lighthouse", rev = "f064e9e061997c41658c3544da47627c6db92bc9" }
 lh-types = { package = "types", git = "https://github.com/sigp/lighthouse", rev = "f064e9e061997c41658c3544da47627c6db92bc9" }
-libp2p = { version = "0.56", features = ["macros", "ping", "quic", "floodsub", "secp256k1", "tokio"] }
+libp2p = { version = "0.56", features = ["macros", "ping", "quic", "gossipsub", "secp256k1", "tokio"] }
 metrics = "0.24.0"
 mime_guess = "2"
 mockito = "1.1.1"

--- a/crates/operator/src/lib.rs
+++ b/crates/operator/src/lib.rs
@@ -16,7 +16,7 @@ use helix_common::{
 };
 use helix_database::{PostgresDatabaseService, handle::DbHandle};
 use helix_types::{BuilderCollateral, Operator, OperatorMessage, Payload};
-use libp2p::{BehaviourBuilderError, TransportError, identity::Keypair, multiaddr};
+use libp2p::{BehaviourBuilderError, TransportError, gossipsub, identity::Keypair, multiaddr};
 use thiserror::Error;
 use tokio::task::AbortHandle;
 
@@ -33,6 +33,9 @@ pub enum OperatorError {
     MultiaddrParseError(#[from] multiaddr::Error),
     SwarmNetworkError(#[from] TransportError<std::io::Error>),
     SwarmBuildError(#[from] BehaviourBuilderError),
+    GossipsubConfigError(#[from] gossipsub::ConfigBuilderError),
+    GossipsubBehaviourError(&'static str),
+    GossipsubSubscriptionError(#[from] gossipsub::SubscriptionError),
     MessageSendError(#[from] SendError<(Option<String>, OperatorMessage)>),
     MessageTrySendError(#[from] TrySendError<(Option<String>, OperatorMessage)>),
     MessageRecvError(#[from] RecvError),
@@ -270,7 +273,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
+    use std::{str::FromStr, time::Duration};
 
     use alloy_primitives::B256;
     use helix_types::{BlsPublicKeyBytes, Demotion, OperatorMessage, Promotion};
@@ -303,12 +306,17 @@ mod tests {
             vec![operator_b],
             helix_common::OperatorP2pMode::On,
         );
+        // Ensure A is listening before B initiates its dial.
+        tokio::time::sleep(Duration::from_millis(100)).await;
         let op_b = OperatorPubSub::new(
             32023,
             keypair_b,
             vec![operator_a],
             helix_common::OperatorP2pMode::On,
         );
+        // Wait for the gossipsub subscription exchange before publishing. Messages are
+        // intentionally best-effort and are not queued for peers that have not subscribed yet.
+        tokio::time::sleep(Duration::from_millis(500)).await;
 
         let builder_pubkey = BlsPublicKeyBytes::random();
         let demotion = Demotion {
@@ -316,15 +324,24 @@ mod tests {
             slot: 1,
             builder_pubkey,
             block_hash: B256::random(),
-            reason_msg: "fail".as_bytes().to_vec(),
+            // Exercise a message larger than floodsub's former 2 KiB frame limit.
+            reason_msg: vec![42; 4 * 1024],
         };
         let promotion = Promotion { ts_ms: 2, slot: 2, builder_pubkey };
         op_a.send(None, helix_types::OperatorMessage::Demotion(demotion)).await.unwrap();
-        let (_, msg) = op_b.recv().await.unwrap();
-        assert!(matches!(msg, OperatorMessage::Demotion(_)));
+        let (_, msg) = tokio::time::timeout(Duration::from_secs(5), op_b.recv())
+            .await
+            .expect("timed out waiting for demotion")
+            .unwrap();
+        assert!(
+            matches!(msg, OperatorMessage::Demotion(demotion) if demotion.reason_msg.len() == 4 * 1024)
+        );
 
         op_b.send(None, OperatorMessage::Promotion(promotion)).await.unwrap();
-        let (_, msg) = op_a.recv().await.unwrap();
+        let (_, msg) = tokio::time::timeout(Duration::from_secs(5), op_a.recv())
+            .await
+            .expect("timed out waiting for promotion")
+            .unwrap();
         assert!(matches!(msg, OperatorMessage::Promotion(_)));
     }
 }

--- a/crates/operator/src/pubsub.rs
+++ b/crates/operator/src/pubsub.rs
@@ -6,8 +6,8 @@ use helix_types::{BuilderCollateral, OperatorMessage};
 use libp2p::{
     PeerId, SwarmBuilder,
     allow_block_list::{self, AllowedPeers},
-    floodsub::{self, Event, FloodsubMessage},
     futures::StreamExt,
+    gossipsub::{self, Event, IdentTopic, MessageAcceptance, MessageAuthenticity, ValidationMode},
     identity::Keypair,
     ping,
     swarm::{NetworkBehaviour, SwarmEvent},
@@ -17,11 +17,33 @@ use ssz::{Decode, Encode};
 use super::{Operator, OperatorError};
 use crate::utils::{PromotionState, PromotionStates};
 
+const MAX_OPERATOR_MESSAGE_SIZE: usize = 16 * 1024 * 1024;
+
 #[derive(NetworkBehaviour)]
 struct NetBehaviour {
     allow_list: allow_block_list::Behaviour<AllowedPeers>,
-    floodsub: floodsub::Behaviour,
+    gossipsub: gossipsub::Behaviour,
     ping: ping::Behaviour,
+}
+
+fn publish_operator_message(
+    behaviour: &mut gossipsub::Behaviour,
+    topic: &IdentTopic,
+    data: Vec<u8>,
+) {
+    let message_size = data.len();
+    if let Err(error) = behaviour.publish(topic.clone(), data) {
+        tracing::warn!(?error, message_size, "failed to publish operator message");
+    }
+}
+
+fn operator_gossipsub_config() -> Result<gossipsub::Config, gossipsub::ConfigBuilderError> {
+    gossipsub::ConfigBuilder::default()
+        .flood_publish(true)
+        .validate_messages()
+        .validation_mode(ValidationMode::Strict)
+        .max_transmit_size(MAX_OPERATOR_MESSAGE_SIZE)
+        .build()
 }
 
 fn record_builder_collateral(
@@ -47,8 +69,11 @@ pub(super) async fn run_operator_connection(
     incoming: Sender<(Operator, OperatorMessage)>,
     mode: OperatorP2pMode,
 ) -> Result<(), OperatorError> {
-    let floodsub_topic = floodsub::Topic::new("operator");
-    let local_peer_id = PeerId::from_public_key(&keypair.public());
+    let operator_topic = IdentTopic::new("operator");
+    let gossipsub_config = operator_gossipsub_config()?;
+    let gossipsub =
+        gossipsub::Behaviour::new(MessageAuthenticity::Signed(keypair.clone()), gossipsub_config)
+            .map_err(OperatorError::GossipsubBehaviourError)?;
 
     let mut allow_list = allow_block_list::Behaviour::default();
     for op in &operators {
@@ -59,17 +84,13 @@ pub(super) async fn run_operator_connection(
         .with_tokio()
         .with_quic()
         .with_behaviour(|_key| {
-            Ok(NetBehaviour {
-                allow_list,
-                floodsub: floodsub::Behaviour::new(local_peer_id),
-                ping: ping::Behaviour::default(),
-            })
+            Ok(NetBehaviour { allow_list, gossipsub, ping: ping::Behaviour::default() })
         })?
         .with_swarm_config(|cfg| cfg.with_idle_connection_timeout(Duration::from_secs(u64::MAX)))
         .build();
 
     // Subscribe to operator topic.
-    swarm.behaviour_mut().floodsub.subscribe(floodsub_topic.clone());
+    swarm.behaviour_mut().gossipsub.subscribe(&operator_topic)?;
 
     // Listen for incoming connections.
     swarm.listen_on(format!("/ip4/0.0.0.0/udp/{quic_port}/quic-v1").parse()?)?;
@@ -82,7 +103,7 @@ pub(super) async fn run_operator_connection(
 
     for (peer_id, operator) in &peers {
         // Dial other operators.
-        swarm.behaviour_mut().floodsub.add_node_to_partial_view(*peer_id);
+        swarm.behaviour_mut().gossipsub.add_explicit_peer(peer_id);
         if let Err(e) = swarm.dial(operator.multiaddr.clone()) {
             tracing::warn!(?operator, ?e, "failed to dial operator");
         }
@@ -116,20 +137,37 @@ pub(super) async fn run_operator_connection(
                         _ => true,
                     };
                     if transmit && connected_peers > 0 {
-                        swarm.behaviour_mut().floodsub.publish(floodsub_topic.clone(), msg.as_ssz_bytes());
+                        publish_operator_message(
+                            &mut swarm.behaviour_mut().gossipsub,
+                            &operator_topic,
+                            msg.as_ssz_bytes(),
+                        );
                     }
                 }
                 Err(_) => break, // channel closed
             },
             event = swarm.select_next_some() => match event {
                 SwarmEvent::Behaviour(b_event) => match b_event {
-                    NetBehaviourEvent::Floodsub(f_event) => match f_event {
-                        Event::Message(msg) => {
-                            let FloodsubMessage { source, data, .. } = msg;
+                    NetBehaviourEvent::Gossipsub(g_event) => match g_event {
+                        Event::Message { propagation_source, message_id, message } => {
+                            // Operator messages are pushed directly to every subscribed peer. Mark
+                            // them as ignored by gossipsub after local delivery so they are never
+                            // forwarded to another peer.
+                            let _ = swarm.behaviour_mut().gossipsub.report_message_validation_result(
+                                &message_id,
+                                &propagation_source,
+                                MessageAcceptance::Ignore,
+                            );
+
+                            let Some(source) = message.source else {
+                                tracing::warn!(?propagation_source, "received operator message without a source");
+                                let _ = swarm.disconnect_peer_id(propagation_source);
+                                continue;
+                            };
 
                             match peers.get(&source) {
                                 Some(operator) => {
-                                    let operator_msg = match OperatorMessage::from_ssz_bytes(&data) {
+                                    let operator_msg = match OperatorMessage::from_ssz_bytes(&message.data) {
                                         Ok(msg) => msg,
                                         Err(e) => {
                                             tracing::error!(?e, operator=operator.name, "failed to decode operator message");
@@ -153,13 +191,13 @@ pub(super) async fn run_operator_connection(
                                     }
                                 }
                                 None => {
-                                    tracing::warn!(?source, "received operator message from unknown peer");
-                                    let _ = swarm.disconnect_peer_id(source);
+                                    tracing::warn!(?source, ?propagation_source, "received operator message from unknown peer");
+                                    let _ = swarm.disconnect_peer_id(propagation_source);
                                 }
                             }
                         }
                         Event::Subscribed { peer_id, topic } => {
-                            if peers.contains_key(&peer_id) && topic == floodsub_topic {
+                            if peers.contains_key(&peer_id) && topic == operator_topic.hash() {
                                 // Send current demotion and collateral state.
                                 for state in demotions.iter() {
                                     let msg = match state {
@@ -170,10 +208,18 @@ pub(super) async fn run_operator_connection(
                                             OperatorMessage::Promotion(promotion.clone()).as_ssz_bytes()
                                         }
                                     };
-                                    swarm.behaviour_mut().floodsub.publish(floodsub_topic.clone(), msg);
+                                    publish_operator_message(
+                                        &mut swarm.behaviour_mut().gossipsub,
+                                        &operator_topic,
+                                        msg,
+                                    );
                                 }
                                 for (_, collateral) in &builder_collateral {
-                                    swarm.behaviour_mut().floodsub.publish(floodsub_topic.clone(), OperatorMessage::Collateral(collateral.clone()).as_ssz_bytes());
+                                    publish_operator_message(
+                                        &mut swarm.behaviour_mut().gossipsub,
+                                        &operator_topic,
+                                        OperatorMessage::Collateral(collateral.clone()).as_ssz_bytes(),
+                                    );
                                 }
                             } else {
                                 let _ = swarm.disconnect_peer_id(peer_id);
@@ -206,6 +252,16 @@ mod tests {
     use helix_types::BlsPublicKeyBytes;
 
     use super::*;
+
+    #[test]
+    fn gossipsub_is_configured_for_direct_16_mib_messages() {
+        let config = operator_gossipsub_config().unwrap();
+
+        assert_eq!(config.max_transmit_size(), MAX_OPERATOR_MESSAGE_SIZE);
+        assert!(config.flood_publish());
+        assert!(config.validate_messages());
+        assert!(matches!(config.validation_mode(), ValidationMode::Strict));
+    }
 
     #[test]
     fn first_builder_collateral_message_is_recorded_for_publish_and_replay() {


### PR DESCRIPTION
floodsub has hard-coded message size limits which make it unusable for payload sharing - this PR moves to gossips and configures a max message size of 16MB. 