### PR TITLE
Add SimRequest::ValidateMerged and dispatch merged blocks through the simulator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6635,6 +6635,7 @@ dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
+ "alloy-rpc-types",
  "askama",
  "async-trait",
  "aws-sdk-s3",

--- a/crates/relay/Cargo.toml
+++ b/crates/relay/Cargo.toml
@@ -84,6 +84,7 @@ uuid.workspace = true
 zstd.workspace = true
 
 [dev-dependencies]
+alloy-rpc-types.workspace = true
 tracing-subscriber.workspace = true
 criterion.workspace = true
 

--- a/crates/relay/src/api/admin_service.rs
+++ b/crates/relay/src/api/admin_service.rs
@@ -1,4 +1,10 @@
-use std::{net::SocketAddr, sync::Arc};
+use std::{
+    net::SocketAddr,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+};
 
 use axum::{
     Extension, Json, Router,
@@ -18,6 +24,10 @@ pub async fn run_admin_service(
     auctioneer: Arc<LocalCache>,
     db: Arc<PostgresDatabaseService>,
     admin_token: String,
+    // Bare Arc<AtomicBool>: the router's only extension of this exact type today.
+    // A second one would silently collide (axum keys extensions by type) — wrap
+    // both in distinct newtypes if that's ever added.
+    block_merging_enabled: Arc<AtomicBool>,
 ) {
     let router = Router::new()
         .route("/admin/v1/status", get(status))
@@ -26,11 +36,13 @@ pub async fn run_admin_service(
             "/admin/v1/merged-headers",
             post(enable_merged_headers).delete(disable_merged_headers),
         )
+        .route("/admin/v1/block-merging", post(enable_block_merging).delete(disable_block_merging))
         .route("/admin/v1/builders/{pubkey}/demote", post(demote_builder))
         .route("/admin/v1/builders/{pubkey}/promote", post(promote_builder))
         .route("/admin/v1/adjustments/disable", post(disable_adjustments))
         .layer(Extension(auctioneer))
         .layer(Extension(db))
+        .layer(Extension(block_merging_enabled))
         .layer(ValidateRequestHeaderLayer::bearer(&admin_token));
 
     let listener = tokio::net::TcpListener::bind("0.0.0.0:4050").await.unwrap();
@@ -42,8 +54,12 @@ pub async fn run_admin_service(
 
 async fn status(
     Extension(auctioneer): Extension<Arc<LocalCache>>,
+    Extension(block_merging_enabled): Extension<Arc<AtomicBool>>,
 ) -> Result<impl IntoResponse, StatusCode> {
-    Ok(Json(serde_json::json!({ "kill_switch_enabled": auctioneer.kill_switch_enabled() })))
+    Ok(Json(serde_json::json!({
+        "kill_switch_enabled": auctioneer.kill_switch_enabled(),
+        "block_merging_enabled": block_merging_enabled.load(Ordering::Relaxed),
+    })))
 }
 
 async fn enable_kill_switch(
@@ -75,6 +91,22 @@ async fn disable_merged_headers(
 ) -> Result<impl IntoResponse, StatusCode> {
     auctioneer.disable_merged_headers();
     info!("Merged header serving disabled");
+    Ok((StatusCode::NO_CONTENT, ()))
+}
+
+async fn enable_block_merging(
+    Extension(block_merging_enabled): Extension<Arc<AtomicBool>>,
+) -> Result<impl IntoResponse, StatusCode> {
+    block_merging_enabled.store(true, Ordering::Relaxed);
+    info!("Block merging enabled");
+    Ok((StatusCode::NO_CONTENT, ()))
+}
+
+async fn disable_block_merging(
+    Extension(block_merging_enabled): Extension<Arc<AtomicBool>>,
+) -> Result<impl IntoResponse, StatusCode> {
+    block_merging_enabled.store(false, Ordering::Relaxed);
+    info!("Block merging disabled");
     Ok((StatusCode::NO_CONTENT, ()))
 }
 
@@ -143,7 +175,10 @@ async fn disable_adjustments(
 #[cfg(test)]
 #[allow(clippy::field_reassign_with_default)]
 mod test {
-    use std::sync::Arc;
+    use std::sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    };
 
     use helix_common::local_cache::LocalCache;
     use helix_database::postgres::postgres_db_service::PostgresDatabaseService;
@@ -156,9 +191,10 @@ mod test {
     async fn test_admin_service() {
         let auctioneer = Arc::new(LocalCache::new());
         let db = Arc::new(PostgresDatabaseService::default());
+        let block_merging_enabled = Arc::new(AtomicBool::new(true));
 
         let admin_token = "test_token".into();
-        tokio::spawn(run_admin_service(auctioneer.clone(), db, admin_token));
+        tokio::spawn(run_admin_service(auctioneer.clone(), db, admin_token, block_merging_enabled));
         tokio::time::sleep(std::time::Duration::from_secs(1)).await; // wait for server to start
         let client = reqwest::Client::new();
 
@@ -201,10 +237,11 @@ mod test {
     async fn test_admin_service_merged_headers() {
         let auctioneer = Arc::new(LocalCache::new());
         let db = Arc::new(PostgresDatabaseService::default());
+        let block_merging_enabled = Arc::new(AtomicBool::new(true));
         assert!(auctioneer.merged_headers_enabled(), "should be enabled by default");
 
         let admin_token = "test_token".into();
-        tokio::spawn(run_admin_service(auctioneer.clone(), db, admin_token));
+        tokio::spawn(run_admin_service(auctioneer.clone(), db, admin_token, block_merging_enabled));
         tokio::time::sleep(std::time::Duration::from_secs(1)).await; // wait for server to start
         let client = reqwest::Client::new();
 
@@ -232,9 +269,10 @@ mod test {
     async fn test_admin_service_unauthorized() {
         let auctioneer = Arc::new(LocalCache::new());
         let db = Arc::new(PostgresDatabaseService::default());
+        let block_merging_enabled = Arc::new(AtomicBool::new(true));
 
         let admin_token = "test_token".into();
-        tokio::spawn(run_admin_service(auctioneer.clone(), db, admin_token));
+        tokio::spawn(run_admin_service(auctioneer.clone(), db, admin_token, block_merging_enabled));
         tokio::time::sleep(std::time::Duration::from_secs(1)).await; // wait for server to start
         let client = reqwest::Client::new();
 
@@ -247,5 +285,45 @@ mod test {
             client.get("http://localhost:4050/admin/v1/killswitch/disable").send().await.unwrap();
         assert_eq!(response.status(), 401);
         assert!(!auctioneer.kill_switch_enabled());
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_admin_service_block_merging() {
+        let auctioneer = Arc::new(LocalCache::new());
+        let db = Arc::new(PostgresDatabaseService::default());
+        let block_merging_enabled = Arc::new(AtomicBool::new(true));
+
+        let admin_token = "test_token".into();
+        tokio::spawn(run_admin_service(auctioneer, db, admin_token, block_merging_enabled.clone()));
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await; // wait for server to start
+        let client = reqwest::Client::new();
+
+        let response = client
+            .delete("http://localhost:4050/admin/v1/block-merging")
+            .bearer_auth("test_token")
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(response.status(), 204);
+        assert!(!block_merging_enabled.load(Ordering::Relaxed));
+
+        let response = client
+            .get("http://localhost:4050/admin/v1/status")
+            .bearer_auth("test_token")
+            .send()
+            .await
+            .unwrap();
+        let status: serde_json::Value = response.json().await.unwrap();
+        assert_eq!(status["block_merging_enabled"], false);
+
+        let response = client
+            .post("http://localhost:4050/admin/v1/block-merging")
+            .bearer_auth("test_token")
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(response.status(), 204);
+        assert!(block_merging_enabled.load(Ordering::Relaxed));
     }
 }

--- a/crates/relay/src/api/mod.rs
+++ b/crates/relay/src/api/mod.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::too_many_arguments)]
 
-use std::sync::Arc;
+use std::sync::{Arc, atomic::AtomicBool};
 
 use helix_common::{api_provider::ApiProvider, local_cache::LocalCache};
 pub use helix_data_api::{
@@ -27,8 +27,14 @@ pub fn start_admin_service(
     auctioneer: Arc<LocalCache>,
     db: Arc<PostgresDatabaseService>,
     admin_token: String,
+    block_merging_enabled: Arc<AtomicBool>,
 ) {
-    tokio::spawn(admin_service::run_admin_service(auctioneer, db, admin_token));
+    tokio::spawn(admin_service::run_admin_service(
+        auctioneer,
+        db,
+        admin_token,
+        block_merging_enabled,
+    ));
 }
 
 pub trait Api: Clone + Send + Sync + 'static {

--- a/crates/relay/src/auctioneer/mod.rs
+++ b/crates/relay/src/auctioneer/mod.rs
@@ -143,7 +143,7 @@ impl<B: BidAdjustor> Tile<HelixSpine> for Auctioneer<B> {
                 tracing::error!(?msg, "sim outbound payload not found");
                 return;
             };
-            let SimResult::Validate(sim_result) = payload.as_ref();
+            let SimResult::Validate(sim_result) = payload.as_ref() else { return };
             let event = Event::SimResult(sim_result.clone());
             self.state.step(event, &mut self.ctx, &mut self.tel, producers);
         });

--- a/crates/relay/src/block_merging/tile.rs
+++ b/crates/relay/src/block_merging/tile.rs
@@ -1,4 +1,10 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::HashMap,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+};
 
 use alloy_primitives::{Address, B256, Bytes, U256, keccak256};
 use flux::{
@@ -194,6 +200,11 @@ pub struct BlockMergingTile {
     decoded: Arc<SharedVector<SubmissionDataWithSpan>>,
     slot_events: Arc<SharedVector<SlotUpdate>>,
     merged_blocks: Arc<SharedVector<BlockMergeResponse>>,
+    /// Admin-toggled kill switch for the merge builder connection. While
+    /// `false`, the tile neither dials nor completes a handshake, and
+    /// force-disconnects any active connection. Only an admin can set this
+    /// back to `true` (never automatic).
+    block_merging_enabled: Arc<AtomicBool>,
 
     // Buffered during `poll_with` (the connector is exclusively borrowed
     // there), drained right after.
@@ -237,6 +248,17 @@ impl Tile<HelixSpine> for BlockMergingTile {
     fn name(&self) -> flux::tile::TileName {
         flux_utils::short_typename::<Self>()
     }
+}
+
+/// Whether the tile should attempt to dial the merge builder.
+fn should_dial(enabled: bool, has_token: bool) -> bool {
+    enabled && !has_token
+}
+
+/// Whether the tile should force-disconnect its current connection to the
+/// merge builder.
+fn should_force_disconnect(enabled: bool, has_token: bool) -> bool {
+    !enabled && has_token
 }
 
 /// order_id -> order_hash for every `latest_only` bundle in this submission.
@@ -283,6 +305,7 @@ impl BlockMergingTile {
         slot_events: Arc<SharedVector<SlotUpdate>>,
         merged_blocks: Arc<SharedVector<BlockMergeResponse>>,
         chain_info: ChainInfo,
+        block_merging_enabled: Arc<AtomicBool>,
     ) -> Self {
         let relay_config_msg = RelayConfigV1 {
             relay_fee_recipient: config.relay_fee_recipient,
@@ -339,6 +362,7 @@ impl BlockMergingTile {
             decoded,
             slot_events,
             merged_blocks,
+            block_merging_enabled,
             to_disconnect: Vec::new(),
             to_register: Vec::new(),
             handshaken: Vec::new(),
@@ -354,7 +378,8 @@ impl BlockMergingTile {
     /// is not retried by the connector (unlike an established conn, which
     /// auto-reconnects), so this runs on a repeater.
     fn dial_endpoint(&mut self) {
-        if self.token.is_some() {
+        let enabled = self.block_merging_enabled.load(Ordering::Relaxed);
+        if !should_dial(enabled, self.token.is_some()) {
             return;
         }
         let addr = self.endpoint.addr;
@@ -408,6 +433,8 @@ impl BlockMergingTile {
     }
 
     fn poll_sockets(&mut self) {
+        let enabled = self.block_merging_enabled.load(Ordering::Relaxed);
+
         // Split borrows: the connector is exclusively borrowed for the whole
         // poll, all reactions are buffered.
         let Self {
@@ -434,8 +461,12 @@ impl BlockMergingTile {
             PollEvent::Reconnect { token } => {
                 info!(?token, "reconnected to merging builder");
                 if *my_token == Some(token) {
-                    conn.reset();
-                    to_register.push(token);
+                    if should_force_disconnect(enabled, true) {
+                        to_disconnect.push(token);
+                    } else {
+                        conn.reset();
+                        to_register.push(token);
+                    }
                 }
             }
             PollEvent::Disconnect { token } => {
@@ -615,6 +646,15 @@ impl BlockMergingTile {
             self.connector.write_or_enqueue_with(SendBehavior::Single(token), |buf| {
                 append_frame(buf, MergingMsgId::PongV1, &PongV1 { nonce });
             });
+        }
+
+        // Catches an already-active connection the tick after the flag
+        // flips to disabled; a no-op once the token is no longer in the
+        // connector's active set.
+        if let Some(token) = self.token &&
+            should_force_disconnect(enabled, true)
+        {
+            self.connector.disconnect(token);
         }
     }
 
@@ -1122,5 +1162,21 @@ mod tests {
             find_unbundled_txs(&filtered_final_txs, &orders, &mut Vec::new(), &mut Vec::new()),
             Vec::<B256>::new(),
         );
+    }
+
+    #[test]
+    fn should_dial_only_when_enabled_and_disconnected() {
+        assert!(should_dial(true, false));
+        assert!(!should_dial(true, true));
+        assert!(!should_dial(false, false));
+        assert!(!should_dial(false, true));
+    }
+
+    #[test]
+    fn should_force_disconnect_only_when_disabled_and_connected() {
+        assert!(should_force_disconnect(false, true));
+        assert!(!should_force_disconnect(false, false));
+        assert!(!should_force_disconnect(true, true));
+        assert!(!should_force_disconnect(true, false));
     }
 }

--- a/crates/relay/src/block_merging/tile.rs
+++ b/crates/relay/src/block_merging/tile.rs
@@ -200,10 +200,11 @@ pub struct BlockMergingTile {
     decoded: Arc<SharedVector<SubmissionDataWithSpan>>,
     slot_events: Arc<SharedVector<SlotUpdate>>,
     merged_blocks: Arc<SharedVector<BlockMergeResponse>>,
-    /// Admin-toggled kill switch for the merge builder connection. While
-    /// `false`, the tile neither dials nor completes a handshake, and
-    /// force-disconnects any active connection. Only an admin can set this
-    /// back to `true` (never automatic).
+    /// Admin-toggled kill switch. The connection itself (dial, handshake,
+    /// ping/pong) is unaffected — only an admin can set this back to `true`
+    /// (never automatic). While `false`, the tile stops forwarding
+    /// mergeable blocks and top-bid activations, and silently drops any
+    /// merged blocks it receives.
     block_merging_enabled: Arc<AtomicBool>,
 
     // Buffered during `poll_with` (the connector is exclusively borrowed
@@ -250,15 +251,85 @@ impl Tile<HelixSpine> for BlockMergingTile {
     }
 }
 
-/// Whether the tile should attempt to dial the merge builder.
-fn should_dial(enabled: bool, has_token: bool) -> bool {
-    enabled && !has_token
-}
-
-/// Whether the tile should force-disconnect its current connection to the
-/// merge builder.
-fn should_force_disconnect(enabled: bool, has_token: bool) -> bool {
-    !enabled && has_token
+/// Validates and converts an incoming `MergedBlockV1` into a response to
+/// forward to the auctioneer, or `None` if it's dropped (disabled, stale,
+/// regressed, missing a blob sidecar, or unbundled by the builder).
+/// Extracted from `poll_sockets` so this compute is unit-testable without a
+/// real connection: `enabled` is checked first, before any state mutation,
+/// so a disabled tile silently drops every merged block it receives.
+#[allow(clippy::too_many_arguments)]
+fn handle_merged_block(
+    enabled: bool,
+    token: Token,
+    merged: MergedBlockV1,
+    slot: &mut SlotState,
+    stats: &mut SlotStats,
+    blob_sidecars: &FxHashMap<B256, BlobWithMetadata>,
+    tx_hash_cache: &mut FxHashMap<Bytes, B256>,
+    unbundled_scratch_bundled: &mut Vec<bool>,
+    unbundled_scratch_covered: &mut Vec<bool>,
+) -> Option<BlockMergeResponse> {
+    if !enabled {
+        return None;
+    }
+    if merged.slot != slot.bid_slot || !slot.appendable.contains(&merged.base_block_hash) {
+        stats.merged_stale += 1;
+        debug!(
+            ?token,
+            slot = merged.slot,
+            bid_slot = slot.bid_slot,
+            "stale or unknown merged block"
+        );
+        return None;
+    }
+    // Builders only guarantee monotonicity within a connection; filter
+    // so the stored merged bid never regresses.
+    if slot
+        .best_merged
+        .get(&merged.base_block_hash)
+        .is_some_and(|floor| merged.proposer_value <= floor.value)
+    {
+        stats.merged_regressed += 1;
+        return None;
+    }
+    slot.best_merged.insert(merged.base_block_hash, BestMergedFloor {
+        value: merged.proposer_value,
+        order_ids: merged.included_order_ids.iter().copied().collect(),
+    });
+    let Some(response) = merged_block_to_response(merged, blob_sidecars) else {
+        stats.merged_blob_missing += 1;
+        warn!(
+            ?token,
+            "could not build merge response (missing blob sidecar or invalid payload), dropping \
+             merged block"
+        );
+        return None;
+    };
+    let appended = appended_tx_hashes(&response.builder_inclusions);
+    let appended_txs: Vec<B256> = response
+        .execution_payload
+        .transactions
+        .iter()
+        .map(|tx| *tx_hash_cache.entry(tx.0.clone()).or_insert_with(|| keccak256(tx.as_ref())))
+        .filter(|hash| appended.contains(hash))
+        .collect();
+    let unbundled = find_unbundled_txs(
+        &appended_txs,
+        &slot.order_txs,
+        unbundled_scratch_bundled,
+        unbundled_scratch_covered,
+    );
+    if !unbundled.is_empty() {
+        stats.merged_unbundled += 1;
+        warn!(
+            ?token,
+            count = unbundled.len(),
+            "merge builder unbundled an order, dropping merged block"
+        );
+        return None;
+    }
+    stats.merged_blocks += 1;
+    Some(response)
 }
 
 /// order_id -> order_hash for every `latest_only` bundle in this submission.
@@ -378,8 +449,7 @@ impl BlockMergingTile {
     /// is not retried by the connector (unlike an established conn, which
     /// auto-reconnects), so this runs on a repeater.
     fn dial_endpoint(&mut self) {
-        let enabled = self.block_merging_enabled.load(Ordering::Relaxed);
-        if !should_dial(enabled, self.token.is_some()) {
+        if self.token.is_some() {
             return;
         }
         let addr = self.endpoint.addr;
@@ -461,12 +531,8 @@ impl BlockMergingTile {
             PollEvent::Reconnect { token } => {
                 info!(?token, "reconnected to merging builder");
                 if *my_token == Some(token) {
-                    if should_force_disconnect(enabled, true) {
-                        to_disconnect.push(token);
-                    } else {
-                        conn.reset();
-                        to_register.push(token);
-                    }
+                    conn.reset();
+                    to_register.push(token);
                 }
             }
             PollEvent::Disconnect { token } => {
@@ -532,71 +598,20 @@ impl BlockMergingTile {
                             warn!(?token, "undecodable merged block");
                             return;
                         };
-                        if merged.slot != slot.bid_slot ||
-                            !slot.appendable.contains(&merged.base_block_hash)
-                        {
-                            stats.merged_stale += 1;
-                            debug!(
-                                ?token,
-                                slot = merged.slot,
-                                bid_slot = slot.bid_slot,
-                                "stale or unknown merged block"
-                            );
-                            return;
-                        }
-                        // Builders only guarantee monotonicity within a connection; filter
-                        // so the stored merged bid never regresses.
-                        if slot
-                            .best_merged
-                            .get(&merged.base_block_hash)
-                            .is_some_and(|floor| merged.proposer_value <= floor.value)
-                        {
-                            stats.merged_regressed += 1;
-                            return;
-                        }
-                        slot.best_merged.insert(merged.base_block_hash, BestMergedFloor {
-                            value: merged.proposer_value,
-                            order_ids: merged.included_order_ids.iter().copied().collect(),
-                        });
-                        let Some(response) = merged_block_to_response(merged, blob_sidecars) else {
-                            stats.merged_blob_missing += 1;
-                            warn!(
-                                ?token,
-                                "could not build merge response (missing blob sidecar or invalid \
-                                 payload), dropping merged block"
-                            );
-                            return;
-                        };
-                        let appended = appended_tx_hashes(&response.builder_inclusions);
-                        let appended_txs: Vec<B256> = response
-                            .execution_payload
-                            .transactions
-                            .iter()
-                            .map(|tx| {
-                                *tx_hash_cache
-                                    .entry(tx.0.clone())
-                                    .or_insert_with(|| keccak256(tx.as_ref()))
-                            })
-                            .filter(|hash| appended.contains(hash))
-                            .collect();
-                        let unbundled = find_unbundled_txs(
-                            &appended_txs,
-                            &slot.order_txs,
+                        if let Some(response) = handle_merged_block(
+                            enabled,
+                            token,
+                            merged,
+                            slot,
+                            stats,
+                            blob_sidecars,
+                            tx_hash_cache,
                             unbundled_scratch_bundled,
                             unbundled_scratch_covered,
-                        );
-                        if !unbundled.is_empty() {
-                            stats.merged_unbundled += 1;
-                            warn!(
-                                ?token,
-                                count = unbundled.len(),
-                                "merge builder unbundled an order, dropping merged block"
-                            );
-                            return;
+                        ) {
+                            let ix = merged_blocks.push(response);
+                            merged_ixs.push(ix);
                         }
-                        stats.merged_blocks += 1;
-                        let ix = merged_blocks.push(response);
-                        merged_ixs.push(ix);
                     }
                     MergingMsgId::RejectV1 => {
                         if let Ok(reject) = RejectV1::from_ssz_bytes(body) {
@@ -646,15 +661,6 @@ impl BlockMergingTile {
             self.connector.write_or_enqueue_with(SendBehavior::Single(token), |buf| {
                 append_frame(buf, MergingMsgId::PongV1, &PongV1 { nonce });
             });
-        }
-
-        // Catches an already-active connection the tick after the flag
-        // flips to disabled; a no-op once the token is no longer in the
-        // connector's active set.
-        if let Some(token) = self.token &&
-            should_force_disconnect(enabled, true)
-        {
-            self.connector.disconnect(token);
         }
     }
 
@@ -758,8 +764,12 @@ impl BlockMergingTile {
     }
 
     /// Forwards the decoded submission at `ix` as a `MergeableBlockV1`, or
-    /// replays it to `only` on re-handshake.
+    /// replays it to `only` on re-handshake. A no-op while block merging is
+    /// administratively disabled.
     fn forward_decoded(&mut self, ix: usize, only: Option<Token>) {
+        if !self.block_merging_enabled.load(Ordering::Relaxed) {
+            return;
+        }
         let is_replay = only.is_some();
         if is_replay {
             self.stats.replayed += 1;
@@ -986,6 +996,9 @@ impl BlockMergingTile {
         }
         self.stats.last_top_bid_ns = top_bid.timestamp;
 
+        if !self.block_merging_enabled.load(Ordering::Relaxed) {
+            return;
+        }
         if !self.slot.appendable.contains(&top_bid.block_hash) {
             return;
         }
@@ -1033,9 +1046,30 @@ impl BlockMergingTile {
 
 #[cfg(test)]
 mod tests {
-    use helix_tcp_types::merging::order::{BundleOrderRef, TxOrderRef};
+    use alloy_primitives::{Address, Bloom};
+    use alloy_rpc_types::{
+        beacon::{BlsPublicKey, requests::ExecutionRequestsV4},
+        engine::{ExecutionPayloadV1, ExecutionPayloadV2, ExecutionPayloadV3},
+    };
+    use flux::timing::Nanos;
+    use helix_common::{
+        MergingBuilderCollateral, MergingBuilderEndpoint, SubmissionTrace,
+        decoder::{Encoding, SubmissionDecoderParams},
+    };
+    use helix_tcp_types::{
+        MergeType,
+        merging::{
+            builder_to_relay::MergeTraceV1,
+            order::{BundleOrderRef, TxOrderRef},
+        },
+    };
+    use helix_types::{
+        BlockMergingData, Compression, ForkName, SignedBidSubmission, SubmissionVersion,
+        TestRandomSeed,
+    };
 
     use super::*;
+    use crate::{SubmissionRef, auctioneer::SubmissionData};
 
     fn bundle(latest_only: bool) -> MergeOrderRef {
         MergeOrderRef::Bundle(BundleOrderRef {
@@ -1164,19 +1198,234 @@ mod tests {
         );
     }
 
-    #[test]
-    fn should_dial_only_when_enabled_and_disconnected() {
-        assert!(should_dial(true, false));
-        assert!(!should_dial(true, true));
-        assert!(!should_dial(false, false));
-        assert!(!should_dial(false, true));
+    fn test_tile(enabled: bool) -> BlockMergingTile {
+        let config = BlockMergingTcpConfig {
+            builder: MergingBuilderEndpoint {
+                addr: "127.0.0.1:1".parse().unwrap(),
+                api_key: Uuid::nil().to_string(),
+            },
+            relay_fee_recipient: Address::ZERO,
+            multisend_contract: Address::ZERO,
+            relay_bps: 0,
+            merged_builder_bps: 0,
+            winning_builder_bps: 0,
+            distribution_gas_limit: 140_000,
+            builder_collaterals: vec![MergingBuilderCollateral {
+                builder_coinbase: Address::ZERO,
+                collateral_safe: Address::ZERO,
+            }],
+        };
+        BlockMergingTile::new(
+            config,
+            "test-relay".to_string(),
+            Arc::new(SharedVector::default()),
+            Arc::new(SharedVector::default()),
+            Arc::new(SharedVector::default()),
+            ChainInfo::default(),
+            Arc::new(AtomicBool::new(enabled)),
+        )
+    }
+
+    /// A decoded submission carrying merging data for `bid_slot`/`block_hash`, with no merge
+    /// orders — the per-slot order-budget/unbundling logic isn't under test here.
+    fn test_submission(
+        bid_slot: u64,
+        block_hash: B256,
+        allow_appending: bool,
+    ) -> SubmissionDataWithSpan {
+        let mut signed = SignedBidSubmission::test_random();
+        signed.message.slot = bid_slot;
+        signed.message.block_hash = block_hash;
+        // `TestRandom` for `BlobsBundle` doesn't respect the
+        // proofs/blobs/commitments length invariant (see the #[ignore]d
+        // `fulu_bid_submission*` tests in helix-types) and panics on use;
+        // this submission carries no blobs so it isn't touched.
+        signed.blobs_bundle = Arc::new(Default::default());
+        let submission_data = SubmissionData {
+            submission_ref: SubmissionRef::Internal,
+            submission: Submission::Full(signed),
+            merging_data: Some(BlockMergingData {
+                allow_appending,
+                builder_address: Address::ZERO,
+                merge_orders: vec![],
+            }),
+            bid_adjustment_data: None,
+            version: SubmissionVersion::new(0, None),
+            withdrawals_root: B256::ZERO,
+            trace: SubmissionTrace::default(),
+            decoder_params: SubmissionDecoderParams {
+                compression: Compression::None,
+                encoding: Encoding::Ssz,
+                merge_type: MergeType::default(),
+                is_dehydrated: false,
+                with_mergeable_data: true,
+                with_adjustments: false,
+                mark_all_txs_mergeable: false,
+                fork_name: ForkName::Deneb,
+            },
+            is_pessimistic: false,
+        };
+        SubmissionDataWithSpan { submission_data, span: tracing::Span::none(), sent_at: Nanos(0) }
     }
 
     #[test]
-    fn should_force_disconnect_only_when_disabled_and_connected() {
-        assert!(should_force_disconnect(false, true));
-        assert!(!should_force_disconnect(false, false));
-        assert!(!should_force_disconnect(true, true));
-        assert!(!should_force_disconnect(true, false));
+    fn forward_decoded_noop_when_disabled() {
+        let mut tile = test_tile(false);
+        tile.slot.bid_slot = 5;
+        tile.slot.slot_start = Some(SlotStartV1 {
+            slot: 5,
+            parent_hash: B256::ZERO,
+            proposer_fee_recipient: Address::ZERO,
+            parent_beacon_block_root: B256::ZERO,
+        });
+        let block_hash = B256::repeat_byte(7);
+        let ix = tile.decoded.push(test_submission(5, block_hash, true));
+
+        tile.forward_decoded(ix, None);
+
+        assert!(tile.slot.appendable.is_empty());
+        assert!(tile.slot.replay_log.is_empty());
+    }
+
+    #[test]
+    fn forward_decoded_tracks_when_enabled() {
+        let mut tile = test_tile(true);
+        tile.slot.bid_slot = 5;
+        tile.slot.slot_start = Some(SlotStartV1 {
+            slot: 5,
+            parent_hash: B256::ZERO,
+            proposer_fee_recipient: Address::ZERO,
+            parent_beacon_block_root: B256::ZERO,
+        });
+        let block_hash = B256::repeat_byte(7);
+        let ix = tile.decoded.push(test_submission(5, block_hash, true));
+
+        tile.forward_decoded(ix, None);
+
+        assert!(tile.slot.appendable.contains(&block_hash));
+        assert_eq!(tile.slot.replay_log.len(), 1);
+    }
+
+    #[test]
+    fn on_top_bid_skips_activation_when_disabled() {
+        let mut tile = test_tile(false);
+        let block_hash = B256::repeat_byte(3);
+        tile.slot.bid_slot = 5;
+        tile.slot.appendable.insert(block_hash);
+        tile.conn.forwarded.insert(block_hash);
+        tile.conn.active = true;
+        // Never touched: the disabled gate returns before the connector is reached.
+        tile.token = Some(Token(0));
+
+        tile.on_top_bid(TopBidUpdate {
+            timestamp: 1,
+            slot: 5,
+            block_number: 0,
+            block_hash,
+            parent_hash: B256::ZERO,
+            builder_pubkey: BlsPublicKeyBytes::default(),
+            fee_recipient: Address::ZERO,
+            value: U256::ZERO,
+        });
+
+        assert!(tile.conn.activated.is_none());
+        assert_eq!(tile.stats.activations_sent, 0);
+    }
+
+    fn test_merged_block(bid_slot: u64, base_block_hash: B256) -> MergedBlockV1 {
+        let execution_payload = ExecutionPayloadV3 {
+            payload_inner: ExecutionPayloadV2 {
+                payload_inner: ExecutionPayloadV1 {
+                    parent_hash: B256::ZERO,
+                    fee_recipient: Address::ZERO,
+                    state_root: B256::ZERO,
+                    receipts_root: B256::ZERO,
+                    logs_bloom: Bloom::default(),
+                    prev_randao: B256::ZERO,
+                    block_number: 1,
+                    gas_limit: 30_000_000,
+                    gas_used: 0,
+                    timestamp: 0,
+                    extra_data: Default::default(),
+                    base_fee_per_gas: U256::from(1),
+                    block_hash: base_block_hash,
+                    transactions: vec![],
+                },
+                withdrawals: vec![],
+            },
+            blob_gas_used: 0,
+            excess_blob_gas: 0,
+        };
+        MergedBlockV1 {
+            slot: bid_slot,
+            response_id: 0,
+            base_block_hash,
+            base_builder_pubkey: BlsPublicKey::default(),
+            execution_payload,
+            execution_requests: ExecutionRequestsV4::default(),
+            appended_blobs: vec![],
+            proposer_value: U256::from(1),
+            base_builder_revenue: U256::ZERO,
+            relay_revenue: U256::ZERO,
+            builder_inclusions: vec![],
+            included_order_ids: vec![],
+            trace: MergeTraceV1::default(),
+        }
+    }
+
+    #[test]
+    fn handle_merged_block_dropped_when_disabled() {
+        let base_block_hash = B256::repeat_byte(9);
+        let mut slot = SlotState { bid_slot: 5, ..Default::default() };
+        slot.appendable.insert(base_block_hash);
+        let mut stats = SlotStats::default();
+        let blob_sidecars = FxHashMap::default();
+        let mut tx_hash_cache = FxHashMap::default();
+        let mut bundled_scratch = Vec::new();
+        let mut covered_scratch = Vec::new();
+
+        let result = handle_merged_block(
+            false,
+            Token(0),
+            test_merged_block(5, base_block_hash),
+            &mut slot,
+            &mut stats,
+            &blob_sidecars,
+            &mut tx_hash_cache,
+            &mut bundled_scratch,
+            &mut covered_scratch,
+        );
+
+        assert!(result.is_none());
+        assert!(slot.best_merged.is_empty());
+        assert_eq!(stats.merged_blocks, 0);
+    }
+
+    #[test]
+    fn handle_merged_block_accepted_when_enabled() {
+        let base_block_hash = B256::repeat_byte(9);
+        let mut slot = SlotState { bid_slot: 5, ..Default::default() };
+        slot.appendable.insert(base_block_hash);
+        let mut stats = SlotStats::default();
+        let blob_sidecars = FxHashMap::default();
+        let mut tx_hash_cache = FxHashMap::default();
+        let mut bundled_scratch = Vec::new();
+        let mut covered_scratch = Vec::new();
+
+        let result = handle_merged_block(
+            true,
+            Token(0),
+            test_merged_block(5, base_block_hash),
+            &mut slot,
+            &mut stats,
+            &blob_sidecars,
+            &mut tx_hash_cache,
+            &mut bundled_scratch,
+            &mut covered_scratch,
+        );
+
+        assert!(result.is_some());
+        assert!(slot.best_merged.contains_key(&base_block_hash));
+        assert_eq!(stats.merged_blocks, 1);
     }
 }

--- a/crates/relay/src/main.rs
+++ b/crates/relay/src/main.rs
@@ -340,20 +340,20 @@ async fn run(
                 Arc::new(SharedVector::<SimRequest>::with_capacity(MAX_SUBMISSIONS_PER_SLOT));
             let sim_results =
                 Arc::new(SharedVector::<SimResult>::with_capacity(MAX_SUBMISSIONS_PER_SLOT));
+            let merged_blocks = Arc::new(SharedVector::<BlockMergeResponse>::with_capacity(1024));
 
             let (accept_optimistic, failsafe_triggered, sim_tile) = SimulatorTile::create(
                 config.simulators.clone(),
                 sim_requests.clone(),
                 sim_results.clone(),
                 decoded.clone(),
+                merged_blocks.clone(),
                 chain_info.as_ref().clone(),
                 failsafe_triggered,
             );
 
             let sim_core = config.cores.simulator;
             attach_tile(sim_tile, spine, TileConfig::new(sim_core, ThreadPriority::OSDefault));
-
-            let merged_blocks = Arc::new(SharedVector::<BlockMergeResponse>::with_capacity(1024));
 
             if config.block_merging_config.is_enabled &&
                 let Some(merging_tcp) = config.block_merging_config.tcp.clone()

--- a/crates/relay/src/main.rs
+++ b/crates/relay/src/main.rs
@@ -185,6 +185,7 @@ async fn run(
 
     let alert_manager = Arc::new(AlertManager::from_relay_config(&config));
     let failsafe_triggered = Arc::new(AtomicBool::new(false));
+    let block_merging_enabled = Arc::new(AtomicBool::new(config.block_merging_config.is_enabled));
     let (gossip_sender, gossip_receiver) = tokio::sync::mpsc::channel(10_000);
 
     let operator_api = config.operator_config.as_ref().map(|operator_config| {
@@ -214,7 +215,12 @@ async fn run(
     });
 
     spine.start(None, Some(termination_grace_period), |spine| {
-        start_admin_service(local_cache.clone(), db.clone(), expect_env_var(ADMIN_TOKEN_ENV_VAR));
+        start_admin_service(
+            local_cache.clone(),
+            db.clone(),
+            expect_env_var(ADMIN_TOKEN_ENV_VAR),
+            block_merging_enabled.clone(),
+        );
 
         let auctioneer_handle = AuctioneerHandle::new(event_tx.clone());
         let registrations_handle = RegWorkerHandle::new(reg_worker_tx);
@@ -359,6 +365,7 @@ async fn run(
                     slot_events.clone(),
                     merged_blocks.clone(),
                     chain_info.as_ref().clone(),
+                    block_merging_enabled.clone(),
                 );
                 attach_tile(
                     merging_tile,

--- a/crates/relay/src/simulator/mod.rs
+++ b/crates/relay/src/simulator/mod.rs
@@ -9,7 +9,10 @@ use helix_types::{
     BlobWithMetadata, BuilderInclusionResult, ExecutionPayload, ExecutionRequests, MergedBlockTrace,
 };
 
-use crate::{SubmissionRef, simulator::tile::ValidationResult};
+use crate::{
+    SubmissionRef,
+    simulator::tile::{MergedSimulationResult, ValidationResult},
+};
 
 pub mod client;
 pub mod tile;
@@ -31,6 +34,24 @@ pub struct ValidationRequest {
 
 pub type MergeResult = (usize, Result<BlockMergeResponse, BlockSimError>);
 
+/// Simulation of an incoming merged block from the merge builder. Unlike `ValidationRequest`,
+/// there's no decoded bid submission to look up: the block itself lives in `merged_blocks`,
+/// indexed by `merged_block_ix`.
+#[derive(Debug, Clone)]
+pub struct MergedValidationRequest {
+    pub merged_block_ix: usize,
+    /// Kept alongside the index for `PendingMergeRequests`' eviction key, avoiding a
+    /// `merged_blocks` lookup at queue time.
+    pub base_block_hash: B256,
+    pub slot: u64,
+    pub parent_beacon_block_root: B256,
+    pub proposer_fee_recipient: Address,
+    pub registered_gas_limit: u64,
+    pub apply_blacklist: bool,
+    pub inclusion_list: InclusionListWithMetadata,
+    pub receive_ns: u64,
+}
+
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct BlockMergeResponse {
     pub base_block_hash: B256,
@@ -50,6 +71,7 @@ pub struct BlockMergeResponse {
 /// Large payload stored in `SharedVector` for auctioneer → sim tile transfer.
 pub enum SimRequest {
     Validate { req: Box<ValidationRequest>, fast_track: bool },
+    ValidateMerged(Box<MergedValidationRequest>),
 }
 
 /// Large payload stored in `SharedVector` for sim tile → auctioneer transfer.
@@ -57,6 +79,7 @@ pub enum SimRequest {
 #[allow(clippy::large_enum_variant)]
 pub enum SimResult {
     Validate(ValidationResult),
+    ValidateMerged(MergedSimulationResult),
 }
 
 impl ValidationRequest {

--- a/crates/relay/src/simulator/tile.rs
+++ b/crates/relay/src/simulator/tile.rs
@@ -528,7 +528,23 @@ impl SimulatorTile {
                 http: sim.client.client.clone(),
             }
         } else {
-            let (builder, method) = sim.client.sim_request_builder(submission.fork_name());
+            let fork = submission.fork_name();
+            let Some((builder, method)) = sim.client.sim_request_builder(fork) else {
+                warn!(%fork, "no validation RPC method for fork, dropping merged block");
+                sim.pending += 1;
+                let inner = MergedSimulationResultInner {
+                    merged_block_ix: req.merged_block_ix,
+                    result: Err(BlockSimError::UnsupportedFork(fork)),
+                };
+                let result_ix = self.sim_results.push(SimResult::ValidateMerged((id, Some(inner))));
+                let _ = self.task_tx.try_send(SimTileInternalEvent::TaskDone {
+                    id,
+                    paused_until: None,
+                    result_ix,
+                    elapsed: None,
+                });
+                return;
+            };
             SimDispatch::Json { to_send: builder, method: method.to_owned() }
         };
         sim.pending += 1;

--- a/crates/relay/src/simulator/tile.rs
+++ b/crates/relay/src/simulator/tile.rs
@@ -7,6 +7,7 @@ use std::{
     time::{Duration, Instant},
 };
 
+use alloy_primitives::B256;
 use flux::{
     spine::SpineProducers as _,
     tile::{Tile, TileName},
@@ -16,6 +17,7 @@ use flux_profiler::timed;
 use flux_utils::SharedVector;
 use helix_common::{
     SimulatorConfig, SubmissionTrace,
+    api::builder_api::InclusionListWithMetadata,
     bid_submission::OptimisticVersion,
     chain_info::ChainInfo,
     is_local_dev,
@@ -26,7 +28,10 @@ use helix_common::{
     utils::avg_duration,
     validator_preferences::{Filtering, ValidatorPreferences},
 };
-use helix_types::{BlsPublicKeyBytes, SignedBidSubmission, SimHydrationCache, Submission};
+use helix_types::{
+    BidTrace, BlobWithMetadata, BlobsBundle, BlsPublicKeyBytes, BlsSignatureBytes, KzgCommitments,
+    SignedBidSubmission, SimHydrationCache, Submission,
+};
 use ssz::Encode as _;
 use tracing::{debug, error, info, warn};
 
@@ -34,7 +39,7 @@ use crate::{
     HelixSpine, SimRequest, ValidationRequest,
     auctioneer::Bid,
     bid_decoder::SubmissionDataWithSpan,
-    simulator::{SimResult, client::SimulatorClient},
+    simulator::{BlockMergeResponse, MergedValidationRequest, SimResult, client::SimulatorClient},
     spine::{
         HelixSpineProducers,
         messages::{FromSimMsg, ToSimKind, ToSimMsg},
@@ -47,6 +52,7 @@ pub struct SimulatorTile {
     ssz_sim_indices: Vec<usize>,
     requests: PendingRequests,
     priority_requests: PendingRequests,
+    merge_requests: PendingMergeRequests,
     last_bid_slot: u64,
     local_telemetry: LocalTelemetry,
     /// Per-simulator counters for the current slot, indexed like `simulators`.
@@ -57,6 +63,7 @@ pub struct SimulatorTile {
     sim_requests: Arc<SharedVector<SimRequest>>,
     sim_results: Arc<SharedVector<SimResult>>,
     decoded: Arc<SharedVector<SubmissionDataWithSpan>>,
+    merged_blocks: Arc<SharedVector<BlockMergeResponse>>,
     hydration_cache: SimHydrationCache,
     chain_info: ChainInfo,
     /// If we have any synced simulator
@@ -94,6 +101,9 @@ impl Tile<HelixSpine> for SimulatorTile {
                     SimRequest::Validate { req, fast_track } => {
                         self.handle_sim_request((**req).clone(), *fast_track, producers);
                     }
+                    SimRequest::ValidateMerged(req) => {
+                        self.handle_merge_sim_request((**req).clone(), producers);
+                    }
                 },
                 None => error!(?msg, "sim inbound payload not found"),
             },
@@ -114,6 +124,7 @@ impl SimulatorTile {
         sim_requests: Arc<SharedVector<SimRequest>>,
         sim_results: Arc<SharedVector<SimResult>>,
         decoded: Arc<SharedVector<SubmissionDataWithSpan>>,
+        merged_blocks: Arc<SharedVector<BlockMergeResponse>>,
         chain_info: ChainInfo,
         failsafe_triggered: Arc<AtomicBool>,
     ) -> (Arc<AtomicBool>, Arc<AtomicBool>, Self) {
@@ -129,6 +140,7 @@ impl SimulatorTile {
 
         let requests = PendingRequests::with_capacity(200);
         let priority_requests = PendingRequests::with_capacity(30);
+        let merge_requests = PendingMergeRequests::with_capacity(30);
 
         if !is_local_dev() {
             let clients: Vec<SimulatorClient> =
@@ -170,6 +182,7 @@ impl SimulatorTile {
             ssz_sim_indices,
             requests,
             priority_requests,
+            merge_requests,
             last_bid_slot: 0,
             local_telemetry: LocalTelemetry::default(),
             sim_slot_stats,
@@ -178,6 +191,7 @@ impl SimulatorTile {
             sim_requests,
             sim_results,
             decoded,
+            merged_blocks,
             hydration_cache: SimHydrationCache::new(),
             chain_info,
             accept_optimistic: accept_optimistic.clone(),
@@ -240,6 +254,32 @@ impl SimulatorTile {
         }
     }
 
+    #[timed]
+    fn handle_merge_sim_request(
+        &mut self,
+        req: MergedValidationRequest,
+        producers: &mut HelixSpineProducers,
+    ) {
+        if self.merged_blocks.get(req.merged_block_ix).is_none() {
+            error!(ix = req.merged_block_ix, "merged block not found in ring");
+            let result_ix = self
+                .sim_results
+                .push(SimResult::ValidateMerged((0, Some(infra_merge_error(&req)))));
+            producers.produce(FromSimMsg { ix: result_ix });
+            return;
+        }
+
+        self.local_telemetry.sims_reqs += 1;
+
+        if let Some(id) = self.next_client(|s| s.can_simulate()) {
+            self.local_telemetry.sims_sent_immediately += 1;
+            self.spawn_merge_sim(id, req);
+        } else {
+            self.local_telemetry.queued += 1;
+            self.merge_requests.store(req);
+        }
+    }
+
     fn handle_task_response(
         &mut self,
         id: usize,
@@ -260,18 +300,18 @@ impl SimulatorTile {
 
         producers.produce(FromSimMsg { ix: result_ix });
 
-        if let Some(id) = self.next_client(|s| s.can_simulate()) &&
-            let Some(req) = self.priority_requests.next_req().or(self.requests.next_req())
-        {
-            self.local_telemetry.sims_sent_from_queue += 1;
-            self.spawn_sim(id, req);
+        if let Some(id) = self.next_client(|s| s.can_simulate()) {
+            if let Some(req) = self.priority_requests.next_req().or(self.requests.next_req()) {
+                self.local_telemetry.sims_sent_from_queue += 1;
+                self.spawn_sim(id, req);
+            } else if let Some(req) = self.merge_requests.next_req() {
+                self.spawn_merge_sim(id, req);
+            }
         }
     }
 
     #[timed]
     fn spawn_sim(&mut self, id: usize, req: ValidationRequest) {
-        const PAUSE_DURATION: Duration = Duration::from_secs(60);
-
         let Some(decoded_data) = self.decoded.get(req.decoded_ix) else {
             error!(ix = req.decoded_ix, "decoded submission not found in ring");
             // Balance pending so handle_task_response can route the next request.
@@ -442,6 +482,121 @@ impl SimulatorTile {
         });
     }
 
+    #[timed]
+    fn spawn_merge_sim(&mut self, id: usize, req: MergedValidationRequest) {
+        let Some(response) = self.merged_blocks.get(req.merged_block_ix) else {
+            error!(ix = req.merged_block_ix, "merged block not found in ring");
+            let sim = &mut self.simulators[id];
+            sim.pending += 1;
+            let result_ix = self
+                .sim_results
+                .push(SimResult::ValidateMerged((id, Some(infra_merge_error(&req)))));
+            let _ = self.task_tx.try_send(SimTileInternalEvent::TaskDone {
+                id,
+                paused_until: None,
+                result_ix,
+                elapsed: None,
+            });
+            return;
+        };
+
+        let submission = match merged_block_to_submission(&response, &req) {
+            Ok(submission) => submission,
+            Err(err) => {
+                let sim = &mut self.simulators[id];
+                sim.pending += 1;
+                let inner = MergedSimulationResultInner {
+                    merged_block_ix: req.merged_block_ix,
+                    result: Err(err),
+                };
+                let result_ix = self.sim_results.push(SimResult::ValidateMerged((id, Some(inner))));
+                let _ = self.task_tx.try_send(SimTileInternalEvent::TaskDone {
+                    id,
+                    paused_until: None,
+                    result_ix,
+                    elapsed: None,
+                });
+                return;
+            }
+        };
+
+        let sim = &mut self.simulators[id];
+        let dispatch = if let Some(url) = &sim.client.ssz_url {
+            SimDispatch::Ssz {
+                to_send: sim.client.client.post(format!("{url}/validate")),
+                ssz_url: url.clone(),
+                http: sim.client.client.clone(),
+            }
+        } else {
+            let (builder, method) = sim.client.sim_request_builder(submission.fork_name());
+            SimDispatch::Json { to_send: builder, method: method.to_owned() }
+        };
+        sim.pending += 1;
+
+        self.local_telemetry.max_in_flight = self.local_telemetry.max_in_flight.max(sim.pending);
+        let timer = SimulatorMetrics::timer(sim.client.endpoint());
+        let task_tx = self.task_tx.clone();
+        let sim_results = self.sim_results.clone();
+        let merged_block_ix = req.merged_block_ix;
+        let apply_blacklist = req.apply_blacklist;
+        let registered_gas_limit = req.registered_gas_limit;
+        let parent_beacon_block_root = req.parent_beacon_block_root;
+        let inclusion_list = req.inclusion_list.clone();
+        spawn_tracked!(async move {
+            let start_sim = Nanos::now();
+            let block_hash = submission.execution_payload.block_hash;
+            debug!(%block_hash, "sending merged block simulation request");
+
+            SimulatorMetrics::sim_count(false);
+            let res = match dispatch {
+                SimDispatch::Ssz { to_send, .. } => {
+                    let request = ssz_request(
+                        apply_blacklist,
+                        registered_gas_limit,
+                        parent_beacon_block_root,
+                        inclusion_list,
+                        &submission,
+                    );
+                    SimulatorClient::do_sim_request(&request, false, to_send).await
+                }
+                SimDispatch::Json { to_send, method } => {
+                    let filtering =
+                        if apply_blacklist { Filtering::Regional } else { Filtering::Global };
+                    let json_req = JsonValidationRequest::new(
+                        registered_gas_limit,
+                        &submission,
+                        ValidatorPreferences { filtering, ..Default::default() },
+                        Some(parent_beacon_block_root),
+                        Some(inclusion_list),
+                    );
+                    SimulatorClient::do_json_sim_request(&json_req, false, &method, to_send).await
+                }
+            };
+
+            let time = timer.stop_and_record();
+            debug!(%block_hash, time_secs = time, ?res, "merged block simulation completed");
+
+            let paused_until = if let Err(err) = res.as_ref() {
+                SimulatorMetrics::sim_status(false);
+                if err.is_temporary() { Some(Instant::now() + PAUSE_DURATION) } else { None }
+            } else {
+                SimulatorMetrics::sim_status(true);
+                None
+            };
+
+            record_submission_step("merge_simulation", start_sim.elapsed());
+
+            let inner = MergedSimulationResultInner { merged_block_ix, result: res };
+            let result_ix = sim_results.push(SimResult::ValidateMerged((id, Some(inner))));
+            let _ = task_tx.try_send(SimTileInternalEvent::TaskDone {
+                id,
+                paused_until,
+                result_ix,
+                elapsed: Some(Duration::from_secs_f64(time)),
+            });
+        });
+    }
+
     /// Selection priority:
     /// 1. Sticky sim with SSZ endpoint (state locality + binary protocol)
     /// 2. Any SSZ-capable sim, least pending (binary protocol)
@@ -484,6 +639,7 @@ impl SimulatorTile {
         self.last_bid_slot = bid_slot;
         self.requests.clear();
         self.priority_requests.clear();
+        self.merge_requests.clear();
         self.hydration_cache.clear();
         let now = Instant::now();
         for s in self.simulators.iter_mut() {
@@ -561,6 +717,10 @@ impl SimEntry {
 
 pub(crate) const SIMULATOR_REQUEST_TIMEOUT: Duration = Duration::from_secs(20);
 
+/// How long a simulator is paused after a temporary error, for both submission and
+/// merged-block simulations.
+const PAUSE_DURATION: Duration = Duration::from_secs(60);
+
 #[derive(Default)]
 struct LocalTelemetry {
     sims_reqs: usize,
@@ -590,6 +750,14 @@ pub struct SimulationResultInner {
     pub bid: Option<Bid>,
     /// Ok carries the trace; Err carries the simulation failure.
     pub result: Result<SubmissionTrace, BlockSimError>,
+}
+
+pub type MergedSimulationResult = (usize, Option<MergedSimulationResultInner>);
+#[derive(Clone)]
+pub struct MergedSimulationResultInner {
+    pub merged_block_ix: usize,
+    /// Ok on a valid merged block; Err carries the simulation failure.
+    pub result: Result<(), BlockSimError>,
 }
 
 enum SimDispatch {
@@ -685,6 +853,40 @@ impl PendingRequests {
     }
 }
 
+/// Pending merged-block requests. There's exactly one merge builder connection, so unlike
+/// `PendingRequests` (keyed per-builder) we only keep the last request per base block.
+struct PendingMergeRequests {
+    reqs: Vec<MergedValidationRequest>,
+}
+
+impl PendingMergeRequests {
+    fn with_capacity(capacity: usize) -> Self {
+        Self { reqs: Vec::with_capacity(capacity) }
+    }
+
+    /// Returns the evicted request if a newer one replaced it.
+    fn store(&mut self, req: MergedValidationRequest) -> Option<MergedValidationRequest> {
+        if let Some(i) = self.reqs.iter().position(|r| r.base_block_hash == req.base_block_hash) {
+            if req.receive_ns > self.reqs[i].receive_ns {
+                return Some(std::mem::replace(&mut self.reqs[i], req));
+            }
+            return None;
+        }
+        self.reqs.push(req);
+        None
+    }
+
+    fn next_req(&mut self) -> Option<MergedValidationRequest> {
+        let i = self.reqs.iter().enumerate().max_by_key(|(_, r)| r.receive_ns).map(|(i, _)| i)?;
+        Some(self.reqs.swap_remove(i))
+    }
+
+    /// Clear backlog of simulations from the previous bid slot.
+    fn clear(&mut self) {
+        self.reqs.clear();
+    }
+}
+
 fn infra_error(req: &ValidationRequest) -> SimulationResultInner {
     SimulationResultInner {
         submission_ref: req.submission_ref,
@@ -694,16 +896,205 @@ fn infra_error(req: &ValidationRequest) -> SimulationResultInner {
     }
 }
 
+fn infra_merge_error(req: &MergedValidationRequest) -> MergedSimulationResultInner {
+    MergedSimulationResultInner {
+        merged_block_ix: req.merged_block_ix,
+        result: Err(BlockSimError::RpcError),
+    }
+}
+
+/// Converts a merged block into a synthetic `SignedBidSubmission` so it can be simulated
+/// through the same SSZ/JSON dispatch the simulator already exposes for bid submissions.
+/// `builder_pubkey`/`proposer_pubkey`/`signature` are zeroed: the simulator never checks the
+/// BLS signature, and these fields are otherwise cosmetic (only `tx_sink` logging reads them).
+fn merged_block_to_submission(
+    response: &BlockMergeResponse,
+    req: &MergedValidationRequest,
+) -> Result<SignedBidSubmission, BlockSimError> {
+    let payload = &response.execution_payload;
+    let message = BidTrace {
+        slot: req.slot,
+        parent_hash: payload.parent_hash,
+        block_hash: payload.block_hash,
+        builder_pubkey: BlsPublicKeyBytes::default(),
+        proposer_pubkey: BlsPublicKeyBytes::default(),
+        proposer_fee_recipient: req.proposer_fee_recipient,
+        gas_limit: payload.gas_limit,
+        gas_used: payload.gas_used,
+        value: response.proposer_value,
+    };
+    Ok(SignedBidSubmission {
+        message,
+        execution_payload: Arc::new(payload.clone()),
+        blobs_bundle: Arc::new(blobs_bundle_from_appended(&response.appended_blobs)?),
+        execution_requests: Arc::new(response.execution_requests.clone()),
+        signature: BlsSignatureBytes::default(),
+    })
+}
+
+fn blobs_bundle_from_appended(appended: &[BlobWithMetadata]) -> Result<BlobsBundle, BlockSimError> {
+    let mut commitments = Vec::with_capacity(appended.len());
+    let mut proofs = Vec::new();
+    let mut blobs = Vec::with_capacity(appended.len());
+    for b in appended {
+        commitments.push(b.commitment);
+        proofs.extend(b.proofs.iter().copied());
+        blobs.push(b.blob.clone());
+    }
+    let commitments = KzgCommitments::new(commitments)
+        .map_err(|_| BlockSimError::BlockValidationFailed("too many appended blobs".to_owned()))?;
+    Ok(BlobsBundle { commitments, proofs, blobs })
+}
+
 fn create_ssz_request(
     req: &ValidationRequest,
     submission: &SignedBidSubmission,
 ) -> SszValidationRequest {
+    ssz_request(
+        req.apply_blacklist,
+        req.registered_gas_limit,
+        req.parent_beacon_block_root,
+        req.inclusion_list.clone(),
+        submission,
+    )
+}
+
+fn ssz_request(
+    apply_blacklist: bool,
+    registered_gas_limit: u64,
+    parent_beacon_block_root: B256,
+    inclusion_list: InclusionListWithMetadata,
+    submission: &SignedBidSubmission,
+) -> SszValidationRequest {
     SszValidationRequest {
-        apply_blacklist: req.apply_blacklist,
-        registered_gas_limit: req.registered_gas_limit,
-        parent_beacon_block_root: req.parent_beacon_block_root,
-        inclusion_list: req.inclusion_list.clone(),
+        apply_blacklist,
+        registered_gas_limit,
+        parent_beacon_block_root,
+        inclusion_list,
         decoder_params: None,
         signed_bid_submission: submission.as_ssz_bytes(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{Address, U256};
+    use helix_types::{ExecutionPayload, ExecutionRequests, MergedBlockTrace, TestRandom};
+    use rand::{SeedableRng, rngs::SmallRng};
+
+    use super::*;
+
+    fn merge_response(
+        payload: ExecutionPayload,
+        proposer_value: U256,
+        blobs: Vec<BlobWithMetadata>,
+    ) -> BlockMergeResponse {
+        BlockMergeResponse {
+            base_block_hash: payload.parent_hash,
+            execution_payload: payload,
+            execution_requests: ExecutionRequests::default(),
+            appended_blobs: blobs,
+            proposer_value,
+            base_builder_revenue: U256::ZERO,
+            relay_revenue: U256::ZERO,
+            builder_inclusions: Default::default(),
+            trace: MergedBlockTrace::default(),
+        }
+    }
+
+    fn merge_request(base_block_hash: B256, receive_ns: u64) -> MergedValidationRequest {
+        MergedValidationRequest {
+            merged_block_ix: 0,
+            base_block_hash,
+            slot: 123,
+            parent_beacon_block_root: B256::repeat_byte(9),
+            proposer_fee_recipient: Address::repeat_byte(7),
+            registered_gas_limit: 30_000_000,
+            apply_blacklist: true,
+            inclusion_list: InclusionListWithMetadata::default(),
+            receive_ns,
+        }
+    }
+
+    #[test]
+    fn merged_block_to_submission_derives_bid_trace_from_payload_and_context() {
+        let mut rng = SmallRng::seed_from_u64(1);
+        let payload = ExecutionPayload::random_for_test(&mut rng);
+        let response = merge_response(payload.clone(), U256::from(42u64), vec![]);
+        let req = merge_request(response.base_block_hash, 0);
+
+        let submission = merged_block_to_submission(&response, &req).unwrap();
+
+        assert_eq!(submission.message.slot, req.slot);
+        assert_eq!(submission.message.parent_hash, payload.parent_hash);
+        assert_eq!(submission.message.block_hash, payload.block_hash);
+        assert_eq!(submission.message.gas_limit, payload.gas_limit);
+        assert_eq!(submission.message.gas_used, payload.gas_used);
+        assert_eq!(submission.message.value, response.proposer_value);
+        assert_eq!(submission.message.proposer_fee_recipient, req.proposer_fee_recipient);
+        assert_eq!(submission.message.builder_pubkey, BlsPublicKeyBytes::default());
+        assert_eq!(submission.message.proposer_pubkey, BlsPublicKeyBytes::default());
+        assert_eq!(submission.signature, BlsSignatureBytes::default());
+    }
+
+    #[test]
+    fn merged_block_to_submission_converts_appended_blobs_to_blobs_bundle() {
+        let mut rng = SmallRng::seed_from_u64(2);
+        let payload = ExecutionPayload::random_for_test(&mut rng);
+        let blob = BlobWithMetadata {
+            commitment: Default::default(),
+            proofs: vec![Default::default(); 128],
+            blob: Default::default(),
+        };
+        let response = merge_response(payload, U256::ZERO, vec![blob.clone()]);
+        let req = merge_request(response.base_block_hash, 0);
+
+        let submission = merged_block_to_submission(&response, &req).unwrap();
+
+        assert_eq!(submission.blobs_bundle.commitments.len(), 1);
+        assert_eq!(submission.blobs_bundle.commitments[0], blob.commitment);
+        assert_eq!(submission.blobs_bundle.proofs, blob.proofs);
+        assert_eq!(submission.blobs_bundle.blobs.len(), 1);
+    }
+
+    #[test]
+    fn pending_merge_requests_evicts_older_same_base_block() {
+        let mut pending = PendingMergeRequests::with_capacity(4);
+        let base = B256::repeat_byte(1);
+        assert!(pending.store(merge_request(base, 10)).is_none());
+
+        let evicted = pending.store(merge_request(base, 20));
+        assert_eq!(evicted.map(|r| r.receive_ns), Some(10));
+    }
+
+    #[test]
+    fn pending_merge_requests_keeps_existing_if_new_is_older() {
+        let mut pending = PendingMergeRequests::with_capacity(4);
+        let base = B256::repeat_byte(1);
+        pending.store(merge_request(base, 20));
+
+        let evicted = pending.store(merge_request(base, 10));
+        assert!(evicted.is_none());
+        assert_eq!(pending.next_req().map(|r| r.receive_ns), Some(20));
+    }
+
+    #[test]
+    fn pending_merge_requests_next_req_returns_and_removes() {
+        let mut pending = PendingMergeRequests::with_capacity(4);
+        pending.store(merge_request(B256::repeat_byte(1), 5));
+        pending.store(merge_request(B256::repeat_byte(2), 15));
+
+        let next = pending.next_req().unwrap();
+        assert_eq!(next.receive_ns, 15);
+        assert_eq!(pending.next_req().unwrap().receive_ns, 5);
+        assert!(pending.next_req().is_none());
+    }
+
+    #[test]
+    fn pending_merge_requests_clear_empties_queue() {
+        let mut pending = PendingMergeRequests::with_capacity(4);
+        pending.store(merge_request(B256::repeat_byte(1), 5));
+        pending.clear();
+        assert!(pending.next_req().is_none());
     }
 }


### PR DESCRIPTION
Issue: #500 (step 2 of 4)

Base branch: `od/merged_block_sim` (step 1, #502) -- stacked per CONTRIBUTING.md, not yet merged. Diff will shrink once #502 merges and this retargets to `develop`.

## What this PR does
Adds `SimRequest::ValidateMerged`/`SimResult::ValidateMerged` so a merged block from the merge builder can be simulated through the existing `SimulatorTile` machinery. A merged block is converted into a synthetic `SignedBidSubmission` (`BidTrace.block_hash`/`parent_hash`/`gas_limit`/`gas_used` derived from the execution payload, `value` from `proposer_value`, `proposer_fee_recipient` from the request, `builder_pubkey`/`proposer_pubkey`/`signature` zeroed -- the simulator never checks the BLS signature and these fields are otherwise cosmetic), so it reuses the same SSZ/JSON dispatch already used for ordinary bid submissions. A new `PendingMergeRequests` queue (keyed by `base_block_hash`, since there's exactly one merge builder connection rather than many builder pubkeys) gives merged-block requests the same load-shedding behavior under simulator capacity pressure as ordinary submissions get from `PendingRequests`.

`SimulatorTile` gains read access to `merged_blocks` (main.rs reordered so it's constructed before `SimulatorTile::create` instead of after). The auctioneer's `FromSimMsg` consumer, which previously did an irrefutable `let SimResult::Validate(..) = ..`, now ignores `SimResult::ValidateMerged` results with an `else { return }` -- it doesn't act on them in this step.

## What this PR deliberately does not do
Nothing sends a `ValidateMerged` request yet, and nothing consumes `SimResult::ValidateMerged`. `BlockMergingTile` isn't wired up to dispatch requests or read results back, and there's no builder-attribution/disable-switch/Discord-alert logic. That's step 3.

## Tests
Written first, reviewed, then implemented against. A live end-to-end HTTP dispatch test isn't feasible here: `spawn_sim`/`spawn_merge_sim` dispatch via `spawn_tracked!`, which panics unless a process-global `RUNTIME` was already set up via `init_runtime(&RelayConfig)` -- a one-time, real-core-pinning init meant for actual process startup, and `spawn_sim` itself has no existing test either. So tests target the new, genuinely error-prone synchronous logic:
- `merged_block_to_submission_derives_bid_trace_from_payload_and_context` / `merged_block_to_submission_converts_appended_blobs_to_blobs_bundle`: the merged-block -> synthetic-submission conversion.
- `pending_merge_requests_evicts_older_same_base_block` / `pending_merge_requests_keeps_existing_if_new_is_older` / `pending_merge_requests_next_req_returns_and_removes` / `pending_merge_requests_clear_empties_queue`: the new queue's eviction/ordering.

`just fmt-check`, `cargo clippy --all-features --no-deps -- -D warnings`, and `just test` (full workspace) all pass.

## Reviewer checklist
- [ ] CI (`lint`, `unit-test`) is green
- [ ] Matches the linked issue/step
- [ ] No unexplained scope creep or unrelated files touched