### PR TITLE
Wire block-merging re-enable into the admin portal

### DIFF
--- a/crates/admin/frontend/src/lib/api.ts
+++ b/crates/admin/frontend/src/lib/api.ts
@@ -53,6 +53,7 @@ async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
 export interface Overview {
   adjustments_enabled: boolean;
   kill_switch_enabled: boolean | null;
+  block_merging_enabled: boolean | null;
   builders_pending_promotion: number;
 }
 
@@ -107,6 +108,8 @@ export const api = {
 
   setKillSwitch: (enabled: boolean) =>
     apiFetch<void>("/api/v1/actions/killswitch", { method: enabled ? "POST" : "DELETE" }),
+  setBlockMerging: (enabled: boolean) =>
+    apiFetch<void>("/api/v1/actions/block-merging", { method: enabled ? "POST" : "DELETE" }),
   demoteBuilder: (pubkey: string, reason: string) =>
     apiFetch<void>(`/api/v1/actions/builders/${pubkey}/demote`, {
       method: "POST",

--- a/crates/admin/frontend/src/pages/Overview.tsx
+++ b/crates/admin/frontend/src/pages/Overview.tsx
@@ -78,6 +78,13 @@ export default function Overview() {
           unknown={data.kill_switch_enabled === null}
         />
         <StatusTile
+          label="Block merging"
+          ok={data.block_merging_enabled !== false}
+          okText="Enabled"
+          badText="Disabled"
+          unknown={data.block_merging_enabled === null}
+        />
+        <StatusTile
           label="Bid adjustments"
           ok={data.adjustments_enabled}
           okText="Enabled"

--- a/crates/admin/frontend/src/pages/Settings.tsx
+++ b/crates/admin/frontend/src/pages/Settings.tsx
@@ -3,7 +3,12 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { api } from "../lib/api";
 import ConfirmDialog from "../components/ConfirmDialog";
 
-type Action = "engage-kill-switch" | "disarm-kill-switch" | "disable-adjustments";
+type Action =
+  | "engage-kill-switch"
+  | "disarm-kill-switch"
+  | "disable-block-merging"
+  | "enable-block-merging"
+  | "disable-adjustments";
 
 export default function Settings() {
   const queryClient = useQueryClient();
@@ -20,6 +25,8 @@ export default function Settings() {
     mutationFn: async (action: Action) => {
       if (action === "engage-kill-switch") await api.setKillSwitch(true);
       else if (action === "disarm-kill-switch") await api.setKillSwitch(false);
+      else if (action === "disable-block-merging") await api.setBlockMerging(false);
+      else if (action === "enable-block-merging") await api.setBlockMerging(true);
       else await api.disableAdjustments();
     },
     onSuccess: () => {
@@ -31,6 +38,7 @@ export default function Settings() {
   });
 
   const killSwitchOn = overview?.kill_switch_enabled === true;
+  const blockMergingOn = overview?.block_merging_enabled === true;
 
   return (
     <div>
@@ -68,6 +76,34 @@ export default function Settings() {
               className="shrink-0 rounded-md bg-status-critical px-3 py-1.5 text-sm font-medium text-white hover:brightness-110"
             >
               Engage kill switch
+            </button>
+          )}
+        </div>
+
+        <div className="mt-4 flex items-center justify-between gap-4 border-b border-neutral-100 pb-4 dark:border-neutral-800">
+          <div>
+            <div className="font-medium">Block merging</div>
+            <p className="text-sm text-neutral-500 dark:text-neutral-400">
+              {overview?.block_merging_enabled === null
+                ? "Relay admin API unreachable — state unknown."
+                : blockMergingOn
+                  ? "Enabled. The relay is connected to the merge builder."
+                  : "Disabled. The relay is not dialing the merge builder."}
+            </p>
+          </div>
+          {blockMergingOn ? (
+            <button
+              onClick={() => setPending("disable-block-merging")}
+              className="shrink-0 rounded-md bg-status-critical px-3 py-1.5 text-sm font-medium text-white hover:brightness-110"
+            >
+              Disable block merging
+            </button>
+          ) : (
+            <button
+              onClick={() => setPending("enable-block-merging")}
+              className="shrink-0 rounded-md border border-neutral-300 px-3 py-1.5 text-sm font-medium hover:bg-neutral-100 dark:border-neutral-700 dark:hover:bg-neutral-800"
+            >
+              Enable block merging
             </button>
           )}
         </div>
@@ -113,6 +149,32 @@ export default function Settings() {
           onCancel={() => setPending(null)}
         >
           The relay will resume accepting bids.
+        </ConfirmDialog>
+      )}
+      {pending === "disable-block-merging" && (
+        <ConfirmDialog
+          title="Disable block merging"
+          confirmLabel="Disable"
+          destructive
+          typeToConfirm="disable"
+          pending={mutation.isPending}
+          onConfirm={() => mutation.mutate(pending)}
+          onCancel={() => setPending(null)}
+        >
+          The relay will disconnect from the merge builder and stop dialing it. Re-enabling
+          requires this action again.
+        </ConfirmDialog>
+      )}
+      {pending === "enable-block-merging" && (
+        <ConfirmDialog
+          title="Enable block merging"
+          confirmLabel="Enable"
+          pending={mutation.isPending}
+          onConfirm={() => mutation.mutate(pending)}
+          onCancel={() => setPending(null)}
+        >
+          The relay will resume dialing the merge builder. Only do this after confirming the
+          reason block merging was disabled is resolved.
         </ConfirmDialog>
       )}
       {pending === "disable-adjustments" && (

--- a/crates/admin/src/handlers.rs
+++ b/crates/admin/src/handlers.rs
@@ -43,17 +43,18 @@ pub async fn overview(
     let adjustments_enabled = db.check_adjustments_enabled().await?;
     let builders_pending_promotion = db.count_builders_pending_promotion().await?;
 
-    let kill_switch_enabled = match relay.status().await {
-        Ok(status) => Some(status.kill_switch_enabled),
+    let (kill_switch_enabled, block_merging_enabled) = match relay.status().await {
+        Ok(status) => (Some(status.kill_switch_enabled), Some(status.block_merging_enabled)),
         Err(err) => {
-            warn!(%err, "relay admin API unreachable, omitting kill switch state");
-            None
+            warn!(%err, "relay admin API unreachable, omitting kill switch/block merging state");
+            (None, None)
         }
     };
 
     Ok(Json(OverviewResponse {
         adjustments_enabled,
         kill_switch_enabled,
+        block_merging_enabled,
         builders_pending_promotion,
     }))
 }
@@ -191,6 +192,22 @@ pub async fn disable_kill_switch(
 ) -> Result<impl IntoResponse, AdminApiError> {
     relay.set_kill_switch(false).await?;
     info!("kill switch disabled via admin website");
+    Ok(StatusCode::NO_CONTENT)
+}
+
+pub async fn enable_block_merging(
+    Extension(relay): Extension<RelayAdminClient>,
+) -> Result<impl IntoResponse, AdminApiError> {
+    relay.set_block_merging(true).await?;
+    info!("block merging enabled via admin website");
+    Ok(StatusCode::NO_CONTENT)
+}
+
+pub async fn disable_block_merging(
+    Extension(relay): Extension<RelayAdminClient>,
+) -> Result<impl IntoResponse, AdminApiError> {
+    relay.set_block_merging(false).await?;
+    info!("block merging disabled via admin website");
     Ok(StatusCode::NO_CONTENT)
 }
 

--- a/crates/admin/src/models.rs
+++ b/crates/admin/src/models.rs
@@ -61,5 +61,7 @@ pub struct OverviewResponse {
     pub adjustments_enabled: bool,
     /// `None` when the relay admin API is unreachable.
     pub kill_switch_enabled: Option<bool>,
+    /// `None` when the relay admin API is unreachable.
+    pub block_merging_enabled: Option<bool>,
     pub builders_pending_promotion: i64,
 }

--- a/crates/admin/src/relay_client.rs
+++ b/crates/admin/src/relay_client.rs
@@ -9,6 +9,7 @@ use crate::error::AdminApiError;
 #[derive(Deserialize, Serialize, Clone, Copy)]
 pub struct RelayAdminStatus {
     pub kill_switch_enabled: bool,
+    pub block_merging_enabled: bool,
 }
 
 #[derive(Serialize)]
@@ -44,6 +45,13 @@ impl RelayAdminClient {
 
     pub async fn set_kill_switch(&self, enabled: bool) -> Result<(), AdminApiError> {
         let url = format!("{}/admin/v1/killswitch", self.base);
+        let request = if enabled { self.client.post(url) } else { self.client.delete(url) };
+        let response = request.bearer_auth(&self.token).send().await?;
+        Self::check_status(&response)
+    }
+
+    pub async fn set_block_merging(&self, enabled: bool) -> Result<(), AdminApiError> {
+        let url = format!("{}/admin/v1/block-merging", self.base);
         let request = if enabled { self.client.post(url) } else { self.client.delete(url) };
         let response = request.bearer_auth(&self.token).send().await?;
         Self::check_status(&response)
@@ -86,5 +94,64 @@ impl RelayAdminClient {
                 StatusCode::from_u16(status.as_u16()).unwrap_or(StatusCode::BAD_GATEWAY),
             ))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    };
+
+    use axum::{
+        Extension, Json, Router,
+        routing::{get, post},
+    };
+
+    use super::*;
+
+    async fn spawn_fake_relay(block_merging_enabled: Arc<AtomicBool>) -> String {
+        async fn status(Extension(flag): Extension<Arc<AtomicBool>>) -> Json<serde_json::Value> {
+            Json(serde_json::json!({
+                "kill_switch_enabled": false,
+                "block_merging_enabled": flag.load(Ordering::Relaxed),
+            }))
+        }
+        async fn enable(Extension(flag): Extension<Arc<AtomicBool>>) -> StatusCode {
+            flag.store(true, Ordering::Relaxed);
+            StatusCode::NO_CONTENT
+        }
+        async fn disable(Extension(flag): Extension<Arc<AtomicBool>>) -> StatusCode {
+            flag.store(false, Ordering::Relaxed);
+            StatusCode::NO_CONTENT
+        }
+
+        let router = Router::new()
+            .route("/admin/v1/status", get(status))
+            .route("/admin/v1/block-merging", post(enable).delete(disable))
+            .layer(Extension(block_merging_enabled));
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, router.into_make_service()).await.unwrap();
+        });
+        format!("http://{addr}")
+    }
+
+    #[tokio::test]
+    async fn set_block_merging_toggles_and_status_reflects_it() {
+        let flag = Arc::new(AtomicBool::new(true));
+        let base = spawn_fake_relay(flag.clone()).await;
+        let client = RelayAdminClient::new(base, "unused".into());
+
+        client.set_block_merging(false).await.unwrap();
+        assert!(!flag.load(Ordering::Relaxed));
+        assert!(!client.status().await.unwrap().block_merging_enabled);
+
+        client.set_block_merging(true).await.unwrap();
+        assert!(flag.load(Ordering::Relaxed));
+        assert!(client.status().await.unwrap().block_merging_enabled);
     }
 }

--- a/crates/admin/src/service.rs
+++ b/crates/admin/src/service.rs
@@ -35,6 +35,10 @@ pub fn build_admin_router(
             "/actions/killswitch",
             post(handlers::enable_kill_switch).delete(handlers::disable_kill_switch),
         )
+        .route(
+            "/actions/block-merging",
+            post(handlers::enable_block_merging).delete(handlers::disable_block_merging),
+        )
         .route("/actions/builders/{pubkey}/demote", post(handlers::demote_builder))
         .route("/actions/builders/{pubkey}/promote", post(handlers::promote_builder))
         .route("/actions/adjustments/disable", post(handlers::disable_adjustments))

--- a/crates/common/src/simulator.rs
+++ b/crates/common/src/simulator.rs
@@ -149,6 +149,21 @@ pub struct SszValidationRequest {
     pub signed_bid_submission: Vec<u8>,
 }
 
+/// Merged-block counterpart of [`SszValidationRequest`], carrying the extra
+/// `base_payment_tx_index` a merged-block-only validation endpoint uses to recognise the
+/// base block's own payment tx directly, instead of scanning every tx in the block -- see
+/// `BlockMergeResponse::base_payment_tx_index`.
+#[derive(Debug, Clone, Encode, Decode)]
+pub struct SszMergedValidationRequest {
+    pub apply_blacklist: bool,
+    pub registered_gas_limit: u64,
+    pub parent_beacon_block_root: B256,
+    pub inclusion_list: InclusionListWithMetadata,
+    pub decoder_params: Option<SubmissionDecoderParams>,
+    pub signed_bid_submission: Vec<u8>,
+    pub base_payment_tx_index: u64,
+}
+
 // TODO: refactor this in a SignedBidSubmission + extra fields
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct JsonValidationRequest {
@@ -186,6 +201,15 @@ impl JsonValidationRequest {
             inclusion_list,
         }
     }
+}
+
+/// Merged-block counterpart of [`JsonValidationRequest`], carrying the extra
+/// `base_payment_tx_index` -- see [`SszMergedValidationRequest`].
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct MergedJsonValidationRequest {
+    #[serde(flatten)]
+    pub base: JsonValidationRequest,
+    pub base_payment_tx_index: u64,
 }
 
 #[cfg(test)]

--- a/crates/relay/src/auctioneer/block_merger.rs
+++ b/crates/relay/src/auctioneer/block_merger.rs
@@ -8,15 +8,11 @@ use alloy_primitives::{Address, B256, U256};
 use flux_profiler::timed;
 use helix_common::{
     RelayConfig,
-    chain_info::ChainInfo,
     local_cache::LocalCache,
     metrics::MERGE_TRACE_LATENCY,
     utils::{utcnow_ms, utcnow_ns},
 };
-use helix_types::{
-    BlobWithMetadata, BlobsBundle, BlsPublicKeyBytes, MergedBlock, PayloadAndBlobs, PayloadBidData,
-    Transactions,
-};
+use helix_types::{BlsPublicKeyBytes, MergedBlock, PayloadAndBlobs, PayloadBidData, Transactions};
 use rustc_hash::{FxBuildHasher, FxHashSet};
 use tracing::{debug, error, info, trace, warn};
 
@@ -30,8 +26,6 @@ pub enum PayloadMergingError {
         "merged payload value is lower or equal to original bid. original: {original}, merged: {merged}"
     )]
     MergedPayloadNotValuable { original: U256, merged: U256 },
-    #[error("reached maximum blob count for block")]
-    MaxBlobCountReached,
 }
 
 /// Stores merged blocks so they can be served via `get_header`/`get_payload`. Everything
@@ -42,7 +36,6 @@ pub enum PayloadMergingError {
 pub struct BlockMerger {
     curr_bid_slot: u64,
     config: RelayConfig,
-    chain_info: ChainInfo,
     local_cache: LocalCache,
     best_merged_blocks: HashMap<Address, BestMergedBlock>,
     /// Base block hashes for which `get_header` found that the merged bid only differed
@@ -53,16 +46,10 @@ pub struct BlockMerger {
 }
 
 impl BlockMerger {
-    pub fn new(
-        curr_bid_slot: u64,
-        chain_info: ChainInfo,
-        local_cache: LocalCache,
-        config: RelayConfig,
-    ) -> Self {
+    pub fn new(curr_bid_slot: u64, local_cache: LocalCache, config: RelayConfig) -> Self {
         Self {
             curr_bid_slot,
             config,
-            chain_info,
             local_cache,
             best_merged_blocks: HashMap::with_capacity(16),
             flagged_payment_tx_only_blocks: FxHashSet::with_capacity_and_hasher(16, FxBuildHasher),
@@ -201,7 +188,6 @@ impl BlockMerger {
         }
 
         let bid_slot = self.curr_bid_slot;
-        let max_blobs_per_block = self.chain_info.max_blobs_per_block();
 
         let original_block_hash = original_payload.execution_payload.block_hash;
         if self.flagged_payment_tx_only_blocks.remove(&original_block_hash) {
@@ -236,8 +222,7 @@ impl BlockMerger {
             original_tx_count: original_payload.execution_payload.transactions.len(),
             merged_tx_count: response.execution_payload.transactions.len(),
             original_blob_count: original_payload.blobs_bundle.blobs.len(),
-            merged_blob_count: original_payload.blobs_bundle.blobs.len() +
-                response.appended_blobs.len(),
+            merged_blob_count: response.blobs_bundle.blobs.len(),
             original_gas_used: original_payload.execution_payload.gas_used,
             merged_gas_used: response.execution_payload.gas_used,
             builder_inclusions: response.builder_inclusions,
@@ -246,18 +231,11 @@ impl BlockMerger {
 
         trace!(%block_hash, "stored merged block in local cache");
 
-        let mut merged_blobs_bundle = original_payload.blobs_bundle.as_ref().to_owned();
-        append_merged_blobs(
-            &mut merged_blobs_bundle,
-            response.appended_blobs,
-            max_blobs_per_block,
-        )?;
-
         let withdrawals_root = response.execution_payload.withdrawals_root();
 
         let payload_and_blobs = PayloadAndBlobs {
             execution_payload: Arc::new(response.execution_payload),
-            blobs_bundle: Arc::new(merged_blobs_bundle),
+            blobs_bundle: Arc::new(response.blobs_bundle),
         };
 
         let bid_data = PayloadBidData {
@@ -268,7 +246,7 @@ impl BlockMerger {
             builder_pubkey,
         };
 
-        trace!(%block_hash, %response.proposer_value, "blobs appended to merged payload");
+        trace!(%block_hash, %response.proposer_value, "merged payload ready for storage");
 
         let new_bid = PayloadEntry::new_gossip(payload_and_blobs, bid_data);
 
@@ -299,22 +277,6 @@ impl BlockMerger {
 struct BestMergedBlock {
     base_block_time_ms: u64,
     bid: PayloadEntry,
-}
-
-/// Appends the merged blobs to the original blobs bundle.
-#[timed]
-fn append_merged_blobs(
-    original_blobs_bundle: &mut BlobsBundle,
-    appended_blobs: Vec<BlobWithMetadata>,
-    max_blobs_per_block: usize,
-) -> Result<(), PayloadMergingError> {
-    for blob_data in appended_blobs {
-        original_blobs_bundle
-            .push_blob(blob_data.commitment, &blob_data.proofs, blob_data.blob, max_blobs_per_block)
-            .map_err(|_| PayloadMergingError::MaxBlobCountReached)?;
-    }
-
-    Ok(())
 }
 
 /// Checks whether the merged block kept the original builder's tx ordering completely

--- a/crates/relay/src/auctioneer/context.rs
+++ b/crates/relay/src/auctioneer/context.rs
@@ -108,7 +108,7 @@ impl<B: BidAdjustor> Context<B> {
             api_key: None,
         };
 
-        let block_merger = BlockMerger::new(0, chain_info.clone(), cache.clone(), config.clone());
+        let block_merger = BlockMerger::new(0, cache.clone(), config.clone());
 
         let slot_context = SlotContext {
             bid_slot: Slot::new(0),

--- a/crates/relay/src/block_merging/mod.rs
+++ b/crates/relay/src/block_merging/mod.rs
@@ -9,7 +9,7 @@ mod unbundling;
 use std::collections::HashMap;
 
 use alloy_consensus::{Bytes48, Transaction as _, TxEnvelope};
-use alloy_primitives::B256;
+use alloy_primitives::{Address, B256};
 use alloy_rlp::Decodable;
 use helix_tcp_types::merging::{
     MergingFrameHeader, MergingMsgId,
@@ -20,7 +20,7 @@ use helix_types::{
     BlobWithMetadata, BlobsBundle, BuilderInclusionResult, ExecutionPayload, KzgCommitment,
     MergeOrderFlags, MergedBlockTrace, Order, payload_from_v3, requests_from_v4,
 };
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use ssz::Encode;
 pub use tile::BlockMergingTile;
 // Bench-only visibility, see benches/unbundling.rs.
@@ -110,6 +110,15 @@ fn merged_block_to_response(
             })
         })
         .collect();
+    // Base txs are replayed verbatim at the front of a merged block; every appended order tx
+    // and the trailing distribution tx come after them, in that order (see
+    // `MergeSession::emit` in crates/builder/src/engine/session.rs). So the base payment tx's
+    // index is always total-appended-count minus the appended order txs minus the distribution
+    // tx. `checked_sub` guards against a malformed/adversarial wire count exceeding the actual
+    // tx list, same failure mode as this function's other validity checks.
+    let appended_order_txs = appended_tx_hashes(&builder_inclusions).len();
+    let base_payment_tx_index =
+        execution_payload.transactions.len().checked_sub(appended_order_txs + 2)?;
     Some(BlockMergeResponse {
         base_block_hash: m.base_block_hash,
         execution_payload,
@@ -119,6 +128,7 @@ fn merged_block_to_response(
         base_builder_revenue: m.base_builder_revenue,
         relay_revenue: m.relay_revenue,
         builder_inclusions,
+        base_payment_tx_index,
         trace: MergedBlockTrace {
             request_time_ns: m.trace.base_block_recv_ns,
             sim_start_time_ns: m.trace.sim_start_ns,
@@ -130,6 +140,16 @@ fn merged_block_to_response(
             top_bid: None,
         },
     })
+}
+
+/// Every tx hash contributed by a merged-in order, across all builders -- as opposed to the
+/// base block's own content or the trailing distribution tx (which isn't attributed to any
+/// builder's `revenue.txs`; see `MergeSession::emit`). Used both to filter the unbundling
+/// check to genuinely appended content and to locate the base block's own payment tx.
+fn appended_tx_hashes(
+    builder_inclusions: &HashMap<Address, BuilderInclusionResult>,
+) -> FxHashSet<B256> {
+    builder_inclusions.values().flat_map(|inclusion| inclusion.txs.iter().copied()).collect()
 }
 
 /// Resolves every blob versioned hash referenced by the merged block's own transactions --
@@ -324,7 +344,9 @@ mod tests {
                     extra_data: Default::default(),
                     base_fee_per_gas: U256::from(1),
                     block_hash: base_block_hash,
-                    transactions: vec![raw.into()],
+                    // The blob tx plus a trailing distribution tx -- every real merged block
+                    // has at least these two (see `MergeSession::emit`).
+                    transactions: vec![raw.into(), raw_plain_tx()],
                 },
                 withdrawals: vec![],
             },
@@ -450,5 +472,115 @@ mod tests {
         assert_eq!(commitments.len(), 2);
         assert!(commitments.contains(&base_commitment));
         assert!(commitments.contains(&appended_commitment));
+    }
+
+    fn raw_plain_tx() -> alloy_primitives::Bytes {
+        use alloy_consensus::{TxEip1559, TxEnvelope};
+        use alloy_primitives::Signature;
+        use alloy_rlp::Encodable;
+
+        let envelope = TxEnvelope::new_unhashed(
+            TxEip1559::default().into(),
+            Signature::new(Default::default(), Default::default(), Default::default()),
+        );
+        let mut raw = vec![];
+        envelope.encode(&mut raw);
+        raw.into()
+    }
+
+    fn merged_block_with_txs(n_txs: usize, appended: &[B256]) -> MergedBlockV1 {
+        use alloy_rpc_types::{
+            beacon::{BlsPublicKey, requests::ExecutionRequestsV4},
+            engine::{ExecutionPayloadV1, ExecutionPayloadV2, ExecutionPayloadV3},
+        };
+        use helix_tcp_types::merging::builder_to_relay::{BuilderInclusion, MergeTraceV1};
+
+        let base_block_hash = B256::repeat_byte(9);
+        let execution_payload = ExecutionPayloadV3 {
+            payload_inner: ExecutionPayloadV2 {
+                payload_inner: ExecutionPayloadV1 {
+                    parent_hash: B256::ZERO,
+                    fee_recipient: Address::ZERO,
+                    state_root: B256::ZERO,
+                    receipts_root: B256::ZERO,
+                    logs_bloom: Default::default(),
+                    prev_randao: B256::ZERO,
+                    block_number: 1,
+                    gas_limit: 30_000_000,
+                    gas_used: 0,
+                    timestamp: 0,
+                    extra_data: Default::default(),
+                    base_fee_per_gas: alloy_primitives::U256::from(1),
+                    block_hash: base_block_hash,
+                    transactions: (0..n_txs).map(|_| raw_plain_tx()).collect(),
+                },
+                withdrawals: vec![],
+            },
+            blob_gas_used: 0,
+            excess_blob_gas: 0,
+        };
+        let builder_inclusions = if appended.is_empty() {
+            vec![]
+        } else {
+            vec![BuilderInclusion {
+                builder_pubkey: BlsPublicKey::default(),
+                origin_coinbase: Address::repeat_byte(0xa),
+                contribution: alloy_primitives::U256::ZERO,
+                revenue: alloy_primitives::U256::ZERO,
+                txs: appended.to_vec(),
+            }]
+        };
+        MergedBlockV1 {
+            slot: 5,
+            response_id: 0,
+            base_block_hash,
+            base_builder_pubkey: BlsPublicKey::default(),
+            execution_payload,
+            execution_requests: ExecutionRequestsV4::default(),
+            appended_blobs: vec![],
+            proposer_value: alloy_primitives::U256::from(1),
+            base_builder_revenue: alloy_primitives::U256::ZERO,
+            relay_revenue: alloy_primitives::U256::ZERO,
+            builder_inclusions,
+            included_order_ids: vec![],
+            trace: MergeTraceV1::default(),
+        }
+    }
+
+    /// No appended orders: the base block's own trailing tx is the only
+    /// candidate, so `base_payment_tx_index` is just the second-to-last
+    /// position (the distribution tx is always last).
+    #[test]
+    fn merged_block_to_response_base_payment_tx_index_with_no_appended_orders() {
+        let merged = merged_block_with_txs(4, &[]);
+        let blob_sidecars = FxHashMap::default();
+
+        let response = merged_block_to_response(merged, &blob_sidecars, 9).unwrap();
+
+        assert_eq!(response.base_payment_tx_index, 2);
+    }
+
+    /// With appended order txs in between the base content and the
+    /// distribution tx, the base payment tx index must skip over them.
+    #[test]
+    fn merged_block_to_response_base_payment_tx_index_with_appended_orders() {
+        let appended = [B256::repeat_byte(1), B256::repeat_byte(2)];
+        let merged = merged_block_with_txs(5, &appended);
+        let blob_sidecars = FxHashMap::default();
+
+        let response = merged_block_to_response(merged, &blob_sidecars, 9).unwrap();
+
+        assert_eq!(response.base_payment_tx_index, 1);
+    }
+
+    /// A wire count of appended txs that exceeds the actual tx list is
+    /// malformed; must be rejected rather than underflow the index.
+    #[test]
+    fn merged_block_to_response_none_when_appended_count_exceeds_tx_list() {
+        let appended = [B256::repeat_byte(1), B256::repeat_byte(2), B256::repeat_byte(3)];
+        let merged = merged_block_with_txs(2, &appended);
+        let blob_sidecars = FxHashMap::default();
+
+        assert!(merged_block_to_response(merged, &blob_sidecars, 9).is_none());
     }
 }

--- a/crates/relay/src/block_merging/mod.rs
+++ b/crates/relay/src/block_merging/mod.rs
@@ -8,16 +8,17 @@ mod unbundling;
 
 use std::collections::HashMap;
 
-use alloy_consensus::Bytes48;
+use alloy_consensus::{Bytes48, Transaction as _, TxEnvelope};
 use alloy_primitives::B256;
+use alloy_rlp::Decodable;
 use helix_tcp_types::merging::{
     MergingFrameHeader, MergingMsgId,
     builder_to_relay::MergedBlockV1,
     order::{BundleOrderRef, MergeOrderRef, TxOrderRef, bundle_order_hash},
 };
 use helix_types::{
-    BlobWithMetadata, BlobsBundle, BuilderInclusionResult, KzgCommitment, MergeOrderFlags,
-    MergedBlockTrace, Order, payload_from_v3, requests_from_v4,
+    BlobWithMetadata, BlobsBundle, BuilderInclusionResult, ExecutionPayload, KzgCommitment,
+    MergeOrderFlags, MergedBlockTrace, Order, payload_from_v3, requests_from_v4,
 };
 use rustc_hash::FxHashMap;
 use ssz::Encode;
@@ -84,18 +85,19 @@ fn order_ref_hash(order_ref: &MergeOrderRef, tx_hashes: &[B256]) -> B256 {
 }
 
 /// Maps the wire message onto the simulator response type so the auctioneer reuses
-/// `handle_merge_response` unchanged. Resolves each appended blob hash from `blob_sidecars`
-/// (this tile's own cache of blob sidecars seen in submissions this slot); `None` if any
-/// hash can't be resolved, since a merged block missing a blob sidecar can't be finalized.
+/// `handle_merge_response` unchanged. Resolves the merged block's full blob set --
+/// the base block's own blob txs as well as any newly appended ones -- from
+/// `blob_sidecars` (this tile's own cache of blob sidecars seen in submissions this
+/// slot); `None` if any referenced hash can't be resolved or the resolved set is
+/// invalid, since a merged block missing a blob sidecar can't be finalized.
 fn merged_block_to_response(
     m: MergedBlockV1,
     blob_sidecars: &FxHashMap<B256, BlobWithMetadata>,
+    max_blobs_per_block: usize,
 ) -> Option<BlockMergeResponse> {
-    let appended_blobs = m
-        .appended_blobs
-        .iter()
-        .map(|h| blob_sidecars.get(h).cloned())
-        .collect::<Option<Vec<_>>>()?;
+    let execution_payload = payload_from_v3(m.execution_payload)?;
+    let blobs_bundle =
+        resolve_blobs_bundle(&execution_payload, blob_sidecars, max_blobs_per_block)?;
 
     let builder_inclusions: HashMap<_, _> = m
         .builder_inclusions
@@ -110,9 +112,9 @@ fn merged_block_to_response(
         .collect();
     Some(BlockMergeResponse {
         base_block_hash: m.base_block_hash,
-        execution_payload: payload_from_v3(m.execution_payload)?,
+        execution_payload,
         execution_requests: requests_from_v4(m.execution_requests)?,
-        appended_blobs,
+        blobs_bundle,
         proposer_value: m.proposer_value,
         base_builder_revenue: m.base_builder_revenue,
         relay_revenue: m.relay_revenue,
@@ -128,6 +130,36 @@ fn merged_block_to_response(
             top_bid: None,
         },
     })
+}
+
+/// Resolves every blob versioned hash referenced by the merged block's own transactions --
+/// base txs and newly appended txs alike -- from `blob_sidecars`. Trusting only the wire's
+/// `appended_blobs` list would drop the base block's own blob sidecars whenever it already
+/// carried blob txs, producing a merged block whose transactions reference blob hashes with
+/// no matching `blobs_bundle` entry (surfaces downstream as a blob-versioned-hash mismatch
+/// during simulation).
+fn resolve_blobs_bundle(
+    payload: &ExecutionPayload,
+    blob_sidecars: &FxHashMap<B256, BlobWithMetadata>,
+    max_blobs_per_block: usize,
+) -> Option<BlobsBundle> {
+    let mut bundle = BlobsBundle::default();
+    for tx in payload.transactions.iter() {
+        let envelope = TxEnvelope::decode(&mut tx.0.as_ref()).ok()?;
+        for hash in envelope.blob_versioned_hashes().unwrap_or_default() {
+            let sidecar = blob_sidecars.get(hash)?;
+            bundle
+                .push_blob(
+                    sidecar.commitment,
+                    &sidecar.proofs,
+                    sidecar.blob.clone(),
+                    max_blobs_per_block,
+                )
+                .ok()?;
+        }
+    }
+    bundle.validate_ssz_lengths(max_blobs_per_block).ok()?;
+    Some(bundle)
 }
 
 /// This submission's own blob sidecars, keyed by KZG versioned hash — cached so a later
@@ -244,5 +276,179 @@ mod tests {
         assert_eq!(header.msg_id, MergingMsgId::PingV1);
         let ping = PingV1::from_ssz_bytes(&buf[2..]).unwrap();
         assert_eq!(ping.nonce, 42);
+    }
+
+    /// Reproduces the RELAY-FR incident: a merge builder appends no new blob
+    /// txs (`appended_blobs` empty on the wire) to a base block that already
+    /// carries one. The resolved response must still include the base
+    /// block's own blob, or downstream simulation sees a blob tx with no
+    /// matching `blobs_bundle` entry ("expected blob versioned hashes do not
+    /// match the given transactions").
+    #[test]
+    fn merged_block_to_response_includes_base_blocks_own_blob_tx() {
+        use alloy_consensus::{TxEip4844, TxEnvelope};
+        use alloy_primitives::{Address, Bloom, Signature, U256};
+        use alloy_rlp::Encodable;
+        use alloy_rpc_types::{
+            beacon::{BlsPublicKey, requests::ExecutionRequestsV4},
+            engine::{ExecutionPayloadV1, ExecutionPayloadV2, ExecutionPayloadV3},
+        };
+        use helix_tcp_types::merging::builder_to_relay::MergeTraceV1;
+        use helix_types::Blob;
+
+        let commitment: Bytes48 = Bytes48::default();
+        let hash = calculate_versioned_hash(commitment);
+
+        let tx = TxEip4844 { blob_versioned_hashes: vec![hash], ..Default::default() };
+        let envelope = TxEnvelope::new_unhashed(
+            tx.into(),
+            Signature::new(Default::default(), Default::default(), Default::default()),
+        );
+        let mut raw = vec![];
+        envelope.encode(&mut raw);
+
+        let base_block_hash = B256::repeat_byte(9);
+        let execution_payload = ExecutionPayloadV3 {
+            payload_inner: ExecutionPayloadV2 {
+                payload_inner: ExecutionPayloadV1 {
+                    parent_hash: B256::ZERO,
+                    fee_recipient: Address::ZERO,
+                    state_root: B256::ZERO,
+                    receipts_root: B256::ZERO,
+                    logs_bloom: Bloom::default(),
+                    prev_randao: B256::ZERO,
+                    block_number: 1,
+                    gas_limit: 30_000_000,
+                    gas_used: 0,
+                    timestamp: 0,
+                    extra_data: Default::default(),
+                    base_fee_per_gas: U256::from(1),
+                    block_hash: base_block_hash,
+                    transactions: vec![raw.into()],
+                },
+                withdrawals: vec![],
+            },
+            blob_gas_used: 0,
+            excess_blob_gas: 0,
+        };
+        let merged = MergedBlockV1 {
+            slot: 5,
+            response_id: 0,
+            base_block_hash,
+            base_builder_pubkey: BlsPublicKey::default(),
+            execution_payload,
+            execution_requests: ExecutionRequestsV4::default(),
+            appended_blobs: vec![],
+            proposer_value: U256::from(1),
+            base_builder_revenue: U256::ZERO,
+            relay_revenue: U256::ZERO,
+            builder_inclusions: vec![],
+            included_order_ids: vec![],
+            trace: MergeTraceV1::default(),
+        };
+
+        let mut blob_sidecars = FxHashMap::default();
+        blob_sidecars.insert(hash, BlobWithMetadata {
+            commitment,
+            proofs: vec![Bytes48::default(); 128],
+            blob: Blob::default(),
+        });
+
+        let response =
+            merged_block_to_response(merged, &blob_sidecars, 9).expect("known blob resolves");
+
+        assert_eq!(response.blobs_bundle.blobs.len(), 1);
+        assert_eq!(response.blobs_bundle.commitments[0], commitment);
+    }
+
+    /// The base block's own blob tx and a merge builder's newly appended
+    /// blob tx must both survive resolution, not just the appended one.
+    #[test]
+    fn merged_block_to_response_includes_both_base_and_appended_blobs() {
+        use alloy_consensus::{TxEip4844, TxEnvelope};
+        use alloy_primitives::{Address, Bloom, Signature, U256};
+        use alloy_rlp::Encodable;
+        use alloy_rpc_types::{
+            beacon::{BlsPublicKey, requests::ExecutionRequestsV4},
+            engine::{ExecutionPayloadV1, ExecutionPayloadV2, ExecutionPayloadV3},
+        };
+        use helix_tcp_types::merging::builder_to_relay::MergeTraceV1;
+        use helix_types::Blob;
+
+        fn raw_blob_tx(hash: B256) -> alloy_primitives::Bytes {
+            let tx = TxEip4844 { blob_versioned_hashes: vec![hash], ..Default::default() };
+            let envelope = TxEnvelope::new_unhashed(
+                tx.into(),
+                Signature::new(Default::default(), Default::default(), Default::default()),
+            );
+            let mut raw = vec![];
+            envelope.encode(&mut raw);
+            raw.into()
+        }
+
+        let base_commitment: Bytes48 = Bytes48::default();
+        let base_hash = calculate_versioned_hash(base_commitment);
+        let appended_commitment: Bytes48 = Bytes48::repeat_byte(1);
+        let appended_hash = calculate_versioned_hash(appended_commitment);
+
+        let base_block_hash = B256::repeat_byte(9);
+        let execution_payload = ExecutionPayloadV3 {
+            payload_inner: ExecutionPayloadV2 {
+                payload_inner: ExecutionPayloadV1 {
+                    parent_hash: B256::ZERO,
+                    fee_recipient: Address::ZERO,
+                    state_root: B256::ZERO,
+                    receipts_root: B256::ZERO,
+                    logs_bloom: Bloom::default(),
+                    prev_randao: B256::ZERO,
+                    block_number: 1,
+                    gas_limit: 30_000_000,
+                    gas_used: 0,
+                    timestamp: 0,
+                    extra_data: Default::default(),
+                    base_fee_per_gas: U256::from(1),
+                    block_hash: base_block_hash,
+                    transactions: vec![raw_blob_tx(base_hash), raw_blob_tx(appended_hash)],
+                },
+                withdrawals: vec![],
+            },
+            blob_gas_used: 0,
+            excess_blob_gas: 0,
+        };
+        let merged = MergedBlockV1 {
+            slot: 5,
+            response_id: 0,
+            base_block_hash,
+            base_builder_pubkey: BlsPublicKey::default(),
+            execution_payload,
+            execution_requests: ExecutionRequestsV4::default(),
+            appended_blobs: vec![appended_hash],
+            proposer_value: U256::from(1),
+            base_builder_revenue: U256::ZERO,
+            relay_revenue: U256::ZERO,
+            builder_inclusions: vec![],
+            included_order_ids: vec![],
+            trace: MergeTraceV1::default(),
+        };
+
+        let mut blob_sidecars = FxHashMap::default();
+        blob_sidecars.insert(base_hash, BlobWithMetadata {
+            commitment: base_commitment,
+            proofs: vec![Bytes48::default(); 128],
+            blob: Blob::default(),
+        });
+        blob_sidecars.insert(appended_hash, BlobWithMetadata {
+            commitment: appended_commitment,
+            proofs: vec![Bytes48::default(); 128],
+            blob: Blob::default(),
+        });
+
+        let response =
+            merged_block_to_response(merged, &blob_sidecars, 9).expect("both blobs resolve");
+
+        let commitments: Vec<_> = response.blobs_bundle.commitments.iter().copied().collect();
+        assert_eq!(commitments.len(), 2);
+        assert!(commitments.contains(&base_commitment));
+        assert!(commitments.contains(&appended_commitment));
     }
 }

--- a/crates/relay/src/block_merging/tile.rs
+++ b/crates/relay/src/block_merging/tile.rs
@@ -289,6 +289,7 @@ fn handle_merged_block(
     tx_hash_cache: &mut FxHashMap<Bytes, B256>,
     unbundled_scratch_bundled: &mut Vec<bool>,
     unbundled_scratch_covered: &mut Vec<bool>,
+    max_blobs_per_block: usize,
 ) -> Option<BlockMergeResponse> {
     if !enabled {
         return None;
@@ -317,7 +318,8 @@ fn handle_merged_block(
         value: merged.proposer_value,
         order_ids: merged.included_order_ids.iter().copied().collect(),
     });
-    let Some(response) = merged_block_to_response(merged, blob_sidecars) else {
+    let Some(response) = merged_block_to_response(merged, blob_sidecars, max_blobs_per_block)
+    else {
         stats.merged_blob_missing += 1;
         warn!(
             ?token,
@@ -564,6 +566,7 @@ impl BlockMergingTile {
 
     fn poll_sockets(&mut self) {
         let enabled = self.block_merging_enabled.load(Ordering::Relaxed);
+        let max_blobs_per_block = self.chain_info.max_blobs_per_block();
 
         // Split borrows: the connector is exclusively borrowed for the whole
         // poll, all reactions are buffered.
@@ -670,6 +673,7 @@ impl BlockMergingTile {
                             tx_hash_cache,
                             unbundled_scratch_bundled,
                             unbundled_scratch_covered,
+                            max_blobs_per_block,
                         ) {
                             let base_block_hash = response.base_block_hash;
                             let parent_hash = response.execution_payload.parent_hash;
@@ -1182,7 +1186,7 @@ mod tests {
         },
     };
     use helix_types::{
-        BlockMergingData, Compression, ExecutionPayload, ExecutionRequests, ForkName,
+        BlobsBundle, BlockMergingData, Compression, ExecutionPayload, ExecutionRequests, ForkName,
         MergedBlockTrace, SignedBidSubmission, SubmissionVersion, TestRandom, TestRandomSeed,
     };
     use rand::{SeedableRng, rngs::SmallRng};
@@ -1204,11 +1208,15 @@ mod tests {
         proposer_value: U256,
         blobs: Vec<BlobWithMetadata>,
     ) -> BlockMergeResponse {
+        let mut blobs_bundle = BlobsBundle::default();
+        for blob in blobs {
+            blobs_bundle.push_blob(blob.commitment, &blob.proofs, blob.blob, 9).unwrap();
+        }
         BlockMergeResponse {
             base_block_hash: payload.parent_hash,
             execution_payload: payload,
             execution_requests: ExecutionRequests::default(),
-            appended_blobs: blobs,
+            blobs_bundle,
             proposer_value,
             base_builder_revenue: U256::ZERO,
             relay_revenue: U256::ZERO,
@@ -1533,6 +1541,7 @@ mod tests {
             &mut tx_hash_cache,
             &mut bundled_scratch,
             &mut covered_scratch,
+            9,
         );
 
         assert!(result.is_none());
@@ -1561,6 +1570,7 @@ mod tests {
             &mut tx_hash_cache,
             &mut bundled_scratch,
             &mut covered_scratch,
+            9,
         );
 
         assert!(result.is_some());

--- a/crates/relay/src/block_merging/tile.rs
+++ b/crates/relay/src/block_merging/tile.rs
@@ -169,6 +169,9 @@ struct SlotStats {
     merged_regressed: usize,
     /// Merged blocks dropped because an appended blob's sidecar wasn't in our cache.
     merged_blob_missing: usize,
+    /// Merged blocks whose simulation was skipped because this slot's beacon parent
+    /// root for the merged block's parent hash isn't known yet.
+    merged_root_missing: usize,
     /// Merged blocks dropped because the builder broke an order's atomicity.
     merged_unbundled: usize,
     /// TopBidUpdate messages received for the current bid slot.
@@ -353,6 +356,33 @@ fn handle_merged_block(
     }
     stats.merged_blocks += 1;
     Some(response)
+}
+
+/// Builds the simulation request for a freshly accepted merged block, resolving
+/// `parent_beacon_block_root` from this slot's cached beacon payload attributes
+/// (`slot.attrs`, keyed by the merged block's own parent hash). `None` if that root
+/// isn't known yet: EIP-4788 writes it into the beacon-roots contract during
+/// execution, so simulating with a wrong (e.g. zero-defaulted) root would produce a
+/// genuine state-root mismatch that isn't actually the merge builder's fault.
+fn merged_validation_request(
+    base_block_hash: B256,
+    parent_hash: B256,
+    slot: &SlotState,
+    merged_block_ix: usize,
+    receive_ns: u64,
+) -> Option<MergedValidationRequest> {
+    let parent_beacon_block_root = *slot.attrs.get(&parent_hash)?;
+    Some(MergedValidationRequest {
+        merged_block_ix,
+        base_block_hash,
+        slot: slot.bid_slot,
+        parent_beacon_block_root,
+        proposer_fee_recipient: slot.fee_recipient.unwrap_or_default(),
+        registered_gas_limit: slot.registered_gas_limit.unwrap_or_default(),
+        apply_blacklist: slot.apply_blacklist.unwrap_or(true),
+        inclusion_list: slot.inclusion_list.clone().unwrap_or_default(),
+        receive_ns,
+    })
 }
 
 /// Whether a merged-block simulation failure is attributable to the merge builder, as
@@ -680,24 +710,28 @@ impl BlockMergingTile {
                             let ix = merged_blocks.push(response);
                             merged_ixs.push(ix);
 
-                            let sim_req = MergedValidationRequest {
-                                merged_block_ix: ix,
+                            match merged_validation_request(
                                 base_block_hash,
-                                slot: slot.bid_slot,
-                                parent_beacon_block_root: slot
-                                    .attrs
-                                    .get(&parent_hash)
-                                    .copied()
-                                    .unwrap_or_default(),
-                                proposer_fee_recipient: slot.fee_recipient.unwrap_or_default(),
-                                registered_gas_limit: slot.registered_gas_limit.unwrap_or_default(),
-                                apply_blacklist: slot.apply_blacklist.unwrap_or(true),
-                                inclusion_list: slot.inclusion_list.clone().unwrap_or_default(),
-                                receive_ns: Nanos::now().0,
-                            };
-                            let sim_ix =
-                                sim_requests.push(SimRequest::ValidateMerged(Box::new(sim_req)));
-                            merge_sim_ixs.push(sim_ix);
+                                parent_hash,
+                                slot,
+                                ix,
+                                Nanos::now().0,
+                            ) {
+                                Some(sim_req) => {
+                                    let sim_ix = sim_requests
+                                        .push(SimRequest::ValidateMerged(Box::new(sim_req)));
+                                    merge_sim_ixs.push(sim_ix);
+                                }
+                                None => {
+                                    stats.merged_root_missing += 1;
+                                    warn!(
+                                        ?token,
+                                        %parent_hash,
+                                        "no cached beacon parent root for merged block's \
+                                         parent hash, skipping simulation"
+                                    );
+                                }
+                            }
                         }
                     }
                     MergingMsgId::RejectV1 => {
@@ -836,6 +870,7 @@ impl BlockMergingTile {
             merged_stale = stats.merged_stale,
             merged_regressed = stats.merged_regressed,
             merged_blob_missing = stats.merged_blob_missing,
+            merged_root_missing = stats.merged_root_missing,
             merged_unbundled = stats.merged_unbundled,
             appendable_blocks = self.slot.appendable.len(),
             hydration_txs = self.hydration_cache.tx_count(),
@@ -1649,5 +1684,39 @@ mod tests {
         ));
         let inner = MergedSimulationResultInner { merged_block_ix: ix, result: Ok(()) };
         assert!(merge_sim_disable_check(&inner, &merged_blocks).is_none());
+    }
+
+    /// RELAY-FR: when this slot has no cached beacon payload attributes for the merged
+    /// block's own parent hash, the request must be skipped rather than silently carry
+    /// a zero `parent_beacon_block_root`. EIP-4788 writes this value into the
+    /// beacon-roots contract during execution, so sending zero when the real root is
+    /// non-zero produces a genuine state-root mismatch downstream ("invalid merkle
+    /// root").
+    #[test]
+    fn merged_validation_request_none_when_attrs_missing() {
+        let slot = SlotState { bid_slot: 5, ..Default::default() }; // attrs empty
+        let base_block_hash = B256::repeat_byte(1);
+        let parent_hash = B256::repeat_byte(2);
+
+        let req = merged_validation_request(base_block_hash, parent_hash, &slot, 0, 0);
+
+        assert!(req.is_none(), "must not silently send a zero beacon root when it's unknown");
+    }
+
+    #[test]
+    fn merged_validation_request_uses_known_parent_beacon_block_root() {
+        let mut slot = SlotState { bid_slot: 5, ..Default::default() };
+        let base_block_hash = B256::repeat_byte(1);
+        let parent_hash = B256::repeat_byte(2);
+        let expected_root = B256::repeat_byte(3);
+        slot.attrs.insert(parent_hash, expected_root);
+
+        let req = merged_validation_request(base_block_hash, parent_hash, &slot, 7, 42)
+            .expect("known root resolves");
+
+        assert_eq!(req.parent_beacon_block_root, expected_root);
+        assert_eq!(req.base_block_hash, base_block_hash);
+        assert_eq!(req.merged_block_ix, 7);
+        assert_eq!(req.receive_ns, 42);
     }
 }

--- a/crates/relay/src/block_merging/tile.rs
+++ b/crates/relay/src/block_merging/tile.rs
@@ -1,12 +1,9 @@
-use std::{
-    collections::HashMap,
-    sync::{
-        Arc,
-        atomic::{AtomicBool, Ordering},
-    },
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
 };
 
-use alloy_primitives::{Address, B256, Bytes, U256, keccak256};
+use alloy_primitives::{B256, Bytes, U256, keccak256};
 use flux::{
     spine::SpineProducers,
     tile::Tile,
@@ -34,10 +31,7 @@ use helix_tcp_types::merging::{
     order::{MergeOrderRef, order_id},
     relay_to_builder::{ActivateBaseBlockV1, MergeableBlockV1, RevokeOrderV1, SlotStartV1},
 };
-use helix_types::{
-    BlobWithMetadata, BlsPublicKeyBytes, BuilderInclusionResult, HydrationCache, Submission,
-    payload_to_v3,
-};
+use helix_types::{BlobWithMetadata, BlsPublicKeyBytes, HydrationCache, Submission, payload_to_v3};
 use rustc_hash::{FxHashMap, FxHashSet};
 use ssz::Decode;
 use tracing::{debug, error, info, trace, warn};
@@ -46,7 +40,7 @@ use uuid::Uuid;
 use crate::{
     HelixSpine, SimRequest, SimResult, SubmissionDataWithSpan,
     block_merging::{
-        append_frame, merged_block_to_response, order_ref_hash, order_to_ref,
+        append_frame, appended_tx_hashes, merged_block_to_response, order_ref_hash, order_to_ref,
         submission_blob_sidecars,
         unbundling::{OrderTxs, find_unbundled_txs},
     },
@@ -445,18 +439,6 @@ fn revoked_ids(
 ) -> Vec<(B256, B256)> {
     let Some(prev) = prev else { return Vec::new() };
     prev.iter().filter(|(id, _)| !new.contains_key(*id)).map(|(&id, &hash)| (id, hash)).collect()
-}
-
-/// Tx hashes the merge builder actually appended onto the base block.
-/// `builder_inclusions` only ever records orders that were applied (see
-/// `record_inclusion` on the builder side), so this never includes anything
-/// from the base block's own original content — which is what the
-/// unbundling check must ignore, since orders sharing a tx hash with base
-/// content that was never touched by the merge builder aren't its concern.
-fn appended_tx_hashes(
-    builder_inclusions: &HashMap<Address, BuilderInclusionResult>,
-) -> FxHashSet<B256> {
-    builder_inclusions.values().flat_map(|inclusion| inclusion.txs.iter().copied()).collect()
 }
 
 impl BlockMergingTile {
@@ -1209,6 +1191,8 @@ impl BlockMergingTile {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
     use alloy_primitives::{Address, Bloom, U256};
     use alloy_rpc_types::{
         beacon::{BlsPublicKey, requests::ExecutionRequestsV4},
@@ -1227,8 +1211,9 @@ mod tests {
         },
     };
     use helix_types::{
-        BlobsBundle, BlockMergingData, Compression, ExecutionPayload, ExecutionRequests, ForkName,
-        MergedBlockTrace, SignedBidSubmission, SubmissionVersion, TestRandom, TestRandomSeed,
+        BlobsBundle, BlockMergingData, BuilderInclusionResult, Compression, ExecutionPayload,
+        ExecutionRequests, ForkName, MergedBlockTrace, SignedBidSubmission, SubmissionVersion,
+        TestRandom, TestRandomSeed,
     };
     use rand::{SeedableRng, rngs::SmallRng};
 
@@ -1262,6 +1247,7 @@ mod tests {
             base_builder_revenue: U256::ZERO,
             relay_revenue: U256::ZERO,
             builder_inclusions: Default::default(),
+            base_payment_tx_index: 0,
             trace: MergedBlockTrace::default(),
         }
     }
@@ -1520,6 +1506,20 @@ mod tests {
         assert_eq!(tile.stats.activations_sent, 0);
     }
 
+    fn raw_plain_tx() -> Bytes {
+        use alloy_consensus::TxEip1559;
+        use alloy_primitives::Signature;
+        use alloy_rlp::Encodable;
+
+        let envelope = alloy_consensus::TxEnvelope::new_unhashed(
+            TxEip1559::default().into(),
+            Signature::new(Default::default(), Default::default(), Default::default()),
+        );
+        let mut raw = vec![];
+        envelope.encode(&mut raw);
+        raw.into()
+    }
+
     fn test_merged_block(bid_slot: u64, base_block_hash: B256) -> MergedBlockV1 {
         let execution_payload = ExecutionPayloadV3 {
             payload_inner: ExecutionPayloadV2 {
@@ -1537,7 +1537,9 @@ mod tests {
                     extra_data: Default::default(),
                     base_fee_per_gas: U256::from(1),
                     block_hash: base_block_hash,
-                    transactions: vec![],
+                    // The base block's own payment tx plus the trailing distribution tx --
+                    // every real merged block has at least these two (see `MergeSession::emit`).
+                    transactions: vec![raw_plain_tx(), raw_plain_tx()],
                 },
                 withdrawals: vec![],
             },

--- a/crates/relay/src/block_merging/tile.rs
+++ b/crates/relay/src/block_merging/tile.rs
@@ -169,9 +169,10 @@ struct SlotStats {
     merged_regressed: usize,
     /// Merged blocks dropped because an appended blob's sidecar wasn't in our cache.
     merged_blob_missing: usize,
-    /// Merged blocks whose simulation was skipped because this slot's beacon parent
-    /// root for the merged block's parent hash isn't known yet.
-    merged_root_missing: usize,
+    /// Merged blocks whose simulation was skipped because a required piece of this
+    /// slot's state (beacon parent root, fee recipient, or registered gas limit)
+    /// isn't known yet.
+    merged_slot_data_missing: usize,
     /// Merged blocks dropped because the builder broke an order's atomicity.
     merged_unbundled: usize,
     /// TopBidUpdate messages received for the current bid slot.
@@ -359,11 +360,13 @@ fn handle_merged_block(
 }
 
 /// Builds the simulation request for a freshly accepted merged block, resolving
-/// `parent_beacon_block_root` from this slot's cached beacon payload attributes
-/// (`slot.attrs`, keyed by the merged block's own parent hash). `None` if that root
-/// isn't known yet: EIP-4788 writes it into the beacon-roots contract during
-/// execution, so simulating with a wrong (e.g. zero-defaulted) root would produce a
-/// genuine state-root mismatch that isn't actually the merge builder's fault.
+/// `parent_beacon_block_root`, `proposer_fee_recipient`, and `registered_gas_limit`
+/// from this slot's cached state. `None` if any of them isn't known yet, rather than
+/// silently defaulting: the external validator checks the merge builder's payment tx
+/// against `proposer_fee_recipient` and re-executes with `parent_beacon_block_root`
+/// (written into the EIP-4788 beacon-roots contract), so a zero-defaulted value
+/// produces a genuine validation failure that isn't actually the merge builder's
+/// fault.
 fn merged_validation_request(
     base_block_hash: B256,
     parent_hash: B256,
@@ -372,13 +375,15 @@ fn merged_validation_request(
     receive_ns: u64,
 ) -> Option<MergedValidationRequest> {
     let parent_beacon_block_root = *slot.attrs.get(&parent_hash)?;
+    let proposer_fee_recipient = slot.fee_recipient?;
+    let registered_gas_limit = slot.registered_gas_limit?;
     Some(MergedValidationRequest {
         merged_block_ix,
         base_block_hash,
         slot: slot.bid_slot,
         parent_beacon_block_root,
-        proposer_fee_recipient: slot.fee_recipient.unwrap_or_default(),
-        registered_gas_limit: slot.registered_gas_limit.unwrap_or_default(),
+        proposer_fee_recipient,
+        registered_gas_limit,
         apply_blacklist: slot.apply_blacklist.unwrap_or(true),
         inclusion_list: slot.inclusion_list.clone().unwrap_or_default(),
         receive_ns,
@@ -723,12 +728,13 @@ impl BlockMergingTile {
                                     merge_sim_ixs.push(sim_ix);
                                 }
                                 None => {
-                                    stats.merged_root_missing += 1;
+                                    stats.merged_slot_data_missing += 1;
                                     warn!(
                                         ?token,
                                         %parent_hash,
-                                        "no cached beacon parent root for merged block's \
-                                         parent hash, skipping simulation"
+                                        "beacon parent root, fee recipient, or gas limit not \
+                                         yet known for this slot, skipping merged block \
+                                         simulation"
                                     );
                                 }
                             }
@@ -870,7 +876,7 @@ impl BlockMergingTile {
             merged_stale = stats.merged_stale,
             merged_regressed = stats.merged_regressed,
             merged_blob_missing = stats.merged_blob_missing,
-            merged_root_missing = stats.merged_root_missing,
+            merged_slot_data_missing = stats.merged_slot_data_missing,
             merged_unbundled = stats.merged_unbundled,
             appendable_blocks = self.slot.appendable.len(),
             hydration_txs = self.hydration_cache.tx_count(),
@@ -1703,18 +1709,58 @@ mod tests {
         assert!(req.is_none(), "must not silently send a zero beacon root when it's unknown");
     }
 
+    /// RELAY-FR: `proposer_fee_recipient` must not silently default to the zero
+    /// address when this slot's registered fee recipient isn't known yet -- the
+    /// external validator checks the merge builder's payment tx against it, so a
+    /// zero-defaulted recipient produces "could not verify proposer payment" for a
+    /// perfectly valid block.
     #[test]
-    fn merged_validation_request_uses_known_parent_beacon_block_root() {
+    fn merged_validation_request_none_when_fee_recipient_missing() {
+        let mut slot = SlotState { bid_slot: 5, ..Default::default() };
+        let base_block_hash = B256::repeat_byte(1);
+        let parent_hash = B256::repeat_byte(2);
+        slot.attrs.insert(parent_hash, B256::repeat_byte(3));
+        slot.registered_gas_limit = Some(30_000_000);
+        // fee_recipient left unset
+
+        let req = merged_validation_request(base_block_hash, parent_hash, &slot, 0, 0);
+
+        assert!(req.is_none(), "must not silently send a zero fee recipient when it's unknown");
+    }
+
+    /// Same silent-default hazard as the fee recipient: a gas limit of zero would
+    /// simulate a merged block against the wrong registered limit for this proposer.
+    #[test]
+    fn merged_validation_request_none_when_gas_limit_missing() {
+        let mut slot = SlotState { bid_slot: 5, ..Default::default() };
+        let base_block_hash = B256::repeat_byte(1);
+        let parent_hash = B256::repeat_byte(2);
+        slot.attrs.insert(parent_hash, B256::repeat_byte(3));
+        slot.fee_recipient = Some(alloy_primitives::Address::repeat_byte(4));
+        // registered_gas_limit left unset
+
+        let req = merged_validation_request(base_block_hash, parent_hash, &slot, 0, 0);
+
+        assert!(req.is_none(), "must not silently send a zero gas limit when it's unknown");
+    }
+
+    #[test]
+    fn merged_validation_request_uses_known_slot_fields() {
         let mut slot = SlotState { bid_slot: 5, ..Default::default() };
         let base_block_hash = B256::repeat_byte(1);
         let parent_hash = B256::repeat_byte(2);
         let expected_root = B256::repeat_byte(3);
+        let expected_fee_recipient = alloy_primitives::Address::repeat_byte(4);
         slot.attrs.insert(parent_hash, expected_root);
+        slot.fee_recipient = Some(expected_fee_recipient);
+        slot.registered_gas_limit = Some(30_000_000);
 
         let req = merged_validation_request(base_block_hash, parent_hash, &slot, 7, 42)
-            .expect("known root resolves");
+            .expect("known fields resolve");
 
         assert_eq!(req.parent_beacon_block_root, expected_root);
+        assert_eq!(req.proposer_fee_recipient, expected_fee_recipient);
+        assert_eq!(req.registered_gas_limit, 30_000_000);
         assert_eq!(req.base_block_hash, base_block_hash);
         assert_eq!(req.merged_block_ix, 7);
         assert_eq!(req.receive_ns, 42);

--- a/crates/relay/src/block_merging/tile.rs
+++ b/crates/relay/src/block_merging/tile.rs
@@ -386,6 +386,39 @@ fn merge_sim_disable_check(
     Some((block_hash, err.clone()))
 }
 
+/// Whether a merged-block simulation failure is attributable to the merge builder, as
+/// opposed to a relay/simulator-side infra hiccup. Builds on `is_demotable()` (the same
+/// logic that decides whether a failed bid-submission simulation demotes its builder) but
+/// additionally excludes internal channel/queue failures, which are never the builder's
+/// fault even though `is_demotable()` -- calibrated for bid-submission demotion -- doesn't
+/// exclude them.
+fn is_merge_builder_attributable(err: &BlockSimError) -> bool {
+    err.is_demotable() &&
+        !matches!(
+            err,
+            BlockSimError::SendError |
+                BlockSimError::SimulationDropped |
+                BlockSimError::HydrationMiss
+        )
+}
+
+/// Decides whether a merged-block simulation result should disable block merging.
+/// Returns the block's hash and the failure reason to report if so.
+fn merge_sim_disable_check(
+    result: &MergedSimulationResultInner,
+    merged_blocks: &SharedVector<BlockMergeResponse>,
+) -> Option<(B256, BlockSimError)> {
+    let Err(err) = &result.result else { return None };
+    if !is_merge_builder_attributable(err) {
+        return None;
+    }
+    let block_hash = merged_blocks
+        .get(result.merged_block_ix)
+        .map(|r| r.execution_payload.block_hash)
+        .unwrap_or_default();
+    Some((block_hash, err.clone()))
+}
+
 /// order_id -> order_hash for every `latest_only` bundle in this submission.
 fn latest_only_ids(
     builder_pubkey: BlsPublicKeyBytes,
@@ -1566,6 +1599,79 @@ mod tests {
         assert!(result.is_some());
         assert!(slot.best_merged.contains_key(&base_block_hash));
         assert_eq!(stats.merged_blocks, 1);
+    }
+
+    #[test]
+    fn merge_sim_disable_check_table() {
+        let mut rng = SmallRng::seed_from_u64(3);
+        let payload = ExecutionPayload::random_for_test(&mut rng);
+        let merged_blocks = SharedVector::<BlockMergeResponse>::with_capacity(4);
+        let ix = merged_blocks.push(merge_response(payload, U256::from(1u64), vec![]));
+
+        let cases: &[(BlockSimError, bool)] = &[
+            (BlockSimError::RpcError, false),
+            (BlockSimError::Timeout, false),
+            (BlockSimError::NoSimulatorAvailable, false),
+            (BlockSimError::SendError, false),
+            (BlockSimError::SimulationDropped, false),
+            (BlockSimError::HydrationMiss, false),
+            (BlockSimError::BlockValidationFailed("unknown ancestor".to_owned()), false),
+            (BlockSimError::BlockValidationFailed("parent block not found".to_owned()), false),
+            (BlockSimError::BlockValidationFailed("block requires a reorg".to_owned()), false),
+            (BlockSimError::BlockValidationFailed("block already known".to_owned()), false),
+            (
+                BlockSimError::BlockValidationFailed(
+                    "block is too old, outside validation window".to_owned(),
+                ),
+                false,
+            ),
+            (
+                BlockSimError::BlockValidationFailed("some other validation failure".to_owned()),
+                true,
+            ),
+            (
+                BlockSimError::InvalidTxRoot { got: B256::ZERO, expected: B256::repeat_byte(1) },
+                true,
+            ),
+        ];
+
+        for (err, expect_disable) in cases {
+            let inner =
+                MergedSimulationResultInner { merged_block_ix: ix, result: Err(err.clone()) };
+            let outcome = merge_sim_disable_check(&inner, &merged_blocks);
+            assert_eq!(outcome.is_some(), *expect_disable, "case: {err:?}");
+        }
+    }
+
+    #[test]
+    fn merge_sim_disable_check_reports_block_hash() {
+        let mut rng = SmallRng::seed_from_u64(4);
+        let payload = ExecutionPayload::random_for_test(&mut rng);
+        let merged_blocks = SharedVector::<BlockMergeResponse>::with_capacity(4);
+        let ix = merged_blocks.push(merge_response(payload.clone(), U256::from(1u64), vec![]));
+
+        let inner = MergedSimulationResultInner {
+            merged_block_ix: ix,
+            result: Err(BlockSimError::InvalidTxRoot {
+                got: B256::ZERO,
+                expected: B256::repeat_byte(1),
+            }),
+        };
+        let (block_hash, err) = merge_sim_disable_check(&inner, &merged_blocks).unwrap();
+        assert_eq!(block_hash, payload.block_hash);
+        assert!(matches!(err, BlockSimError::InvalidTxRoot { .. }));
+    }
+
+    #[test]
+    fn merge_sim_disable_check_none_on_success() {
+        let merged_blocks = SharedVector::<BlockMergeResponse>::with_capacity(4);
+        let ix = merged_blocks.push(merge_response(
+            ExecutionPayload::random_for_test(&mut SmallRng::seed_from_u64(5)),
+            U256::ZERO,
+            vec![],
+        ));
+        let inner = MergedSimulationResultInner { merged_block_ix: ix, result: Ok(()) };
+        assert!(merge_sim_disable_check(&inner, &merged_blocks).is_none());
     }
 
     #[test]

--- a/crates/relay/src/block_merging/tile.rs
+++ b/crates/relay/src/block_merging/tile.rs
@@ -386,39 +386,6 @@ fn merge_sim_disable_check(
     Some((block_hash, err.clone()))
 }
 
-/// Whether a merged-block simulation failure is attributable to the merge builder, as
-/// opposed to a relay/simulator-side infra hiccup. Builds on `is_demotable()` (the same
-/// logic that decides whether a failed bid-submission simulation demotes its builder) but
-/// additionally excludes internal channel/queue failures, which are never the builder's
-/// fault even though `is_demotable()` -- calibrated for bid-submission demotion -- doesn't
-/// exclude them.
-fn is_merge_builder_attributable(err: &BlockSimError) -> bool {
-    err.is_demotable() &&
-        !matches!(
-            err,
-            BlockSimError::SendError |
-                BlockSimError::SimulationDropped |
-                BlockSimError::HydrationMiss
-        )
-}
-
-/// Decides whether a merged-block simulation result should disable block merging.
-/// Returns the block's hash and the failure reason to report if so.
-fn merge_sim_disable_check(
-    result: &MergedSimulationResultInner,
-    merged_blocks: &SharedVector<BlockMergeResponse>,
-) -> Option<(B256, BlockSimError)> {
-    let Err(err) = &result.result else { return None };
-    if !is_merge_builder_attributable(err) {
-        return None;
-    }
-    let block_hash = merged_blocks
-        .get(result.merged_block_ix)
-        .map(|r| r.execution_payload.block_hash)
-        .unwrap_or_default();
-    Some((block_hash, err.clone()))
-}
-
 /// order_id -> order_hash for every `latest_only` bundle in this submission.
 fn latest_only_ids(
     builder_pubkey: BlsPublicKeyBytes,
@@ -1599,79 +1566,6 @@ mod tests {
         assert!(result.is_some());
         assert!(slot.best_merged.contains_key(&base_block_hash));
         assert_eq!(stats.merged_blocks, 1);
-    }
-
-    #[test]
-    fn merge_sim_disable_check_table() {
-        let mut rng = SmallRng::seed_from_u64(3);
-        let payload = ExecutionPayload::random_for_test(&mut rng);
-        let merged_blocks = SharedVector::<BlockMergeResponse>::with_capacity(4);
-        let ix = merged_blocks.push(merge_response(payload, U256::from(1u64), vec![]));
-
-        let cases: &[(BlockSimError, bool)] = &[
-            (BlockSimError::RpcError, false),
-            (BlockSimError::Timeout, false),
-            (BlockSimError::NoSimulatorAvailable, false),
-            (BlockSimError::SendError, false),
-            (BlockSimError::SimulationDropped, false),
-            (BlockSimError::HydrationMiss, false),
-            (BlockSimError::BlockValidationFailed("unknown ancestor".to_owned()), false),
-            (BlockSimError::BlockValidationFailed("parent block not found".to_owned()), false),
-            (BlockSimError::BlockValidationFailed("block requires a reorg".to_owned()), false),
-            (BlockSimError::BlockValidationFailed("block already known".to_owned()), false),
-            (
-                BlockSimError::BlockValidationFailed(
-                    "block is too old, outside validation window".to_owned(),
-                ),
-                false,
-            ),
-            (
-                BlockSimError::BlockValidationFailed("some other validation failure".to_owned()),
-                true,
-            ),
-            (
-                BlockSimError::InvalidTxRoot { got: B256::ZERO, expected: B256::repeat_byte(1) },
-                true,
-            ),
-        ];
-
-        for (err, expect_disable) in cases {
-            let inner =
-                MergedSimulationResultInner { merged_block_ix: ix, result: Err(err.clone()) };
-            let outcome = merge_sim_disable_check(&inner, &merged_blocks);
-            assert_eq!(outcome.is_some(), *expect_disable, "case: {err:?}");
-        }
-    }
-
-    #[test]
-    fn merge_sim_disable_check_reports_block_hash() {
-        let mut rng = SmallRng::seed_from_u64(4);
-        let payload = ExecutionPayload::random_for_test(&mut rng);
-        let merged_blocks = SharedVector::<BlockMergeResponse>::with_capacity(4);
-        let ix = merged_blocks.push(merge_response(payload.clone(), U256::from(1u64), vec![]));
-
-        let inner = MergedSimulationResultInner {
-            merged_block_ix: ix,
-            result: Err(BlockSimError::InvalidTxRoot {
-                got: B256::ZERO,
-                expected: B256::repeat_byte(1),
-            }),
-        };
-        let (block_hash, err) = merge_sim_disable_check(&inner, &merged_blocks).unwrap();
-        assert_eq!(block_hash, payload.block_hash);
-        assert!(matches!(err, BlockSimError::InvalidTxRoot { .. }));
-    }
-
-    #[test]
-    fn merge_sim_disable_check_none_on_success() {
-        let merged_blocks = SharedVector::<BlockMergeResponse>::with_capacity(4);
-        let ix = merged_blocks.push(merge_response(
-            ExecutionPayload::random_for_test(&mut SmallRng::seed_from_u64(5)),
-            U256::ZERO,
-            vec![],
-        ));
-        let inner = MergedSimulationResultInner { merged_block_ix: ix, result: Ok(()) };
-        assert!(merge_sim_disable_check(&inner, &merged_blocks).is_none());
     }
 
     #[test]

--- a/crates/relay/src/simulator/client.rs
+++ b/crates/relay/src/simulator/client.rs
@@ -1,8 +1,5 @@
 use alloy_primitives::{Address, U256};
-use helix_common::{
-    SimulatorConfig,
-    simulator::{BlockSimError, JsonValidationRequest, SszValidationRequest},
-};
+use helix_common::{SimulatorConfig, simulator::BlockSimError};
 use helix_types::ForkName;
 use reqwest::{
     RequestBuilder,
@@ -36,6 +33,9 @@ pub struct SimulatorClient {
     pub config: SimulatorConfig,
     pub sim_method_v4: String,
     pub sim_method_v5: String,
+    /// Relay-internal merged-block validation method; never reachable by an externally
+    /// submitted builder block. See `helix_common::simulator::MergedJsonValidationRequest`.
+    pub sim_method_merged_v5: String,
     /// If set, use SSZ binary endpoint instead of JSON-RPC for simulations
     pub ssz_url: Option<String>,
 }
@@ -44,8 +44,10 @@ impl SimulatorClient {
     pub fn new(client: reqwest::Client, config: SimulatorConfig) -> Self {
         let sim_method_v4 = format!("{}_validateBuilderSubmissionV4", config.namespace);
         let sim_method_v5 = format!("{}_validateBuilderSubmissionV5", config.namespace);
+        let sim_method_merged_v5 =
+            format!("{}_validateMergedBuilderSubmissionV5", config.namespace);
         let ssz_url = config.ssz_url.clone();
-        Self { client, config, sim_method_v4, sim_method_v5, ssz_url }
+        Self { client, config, sim_method_v4, sim_method_v5, sim_method_merged_v5, ssz_url }
     }
 
     pub fn endpoint(&self) -> &str {
@@ -54,6 +56,11 @@ impl SimulatorClient {
 
     pub fn ssz_request_builder(&self) -> Option<RequestBuilder> {
         self.ssz_url.as_ref().map(|url| self.client.post(format!("{url}/validate")))
+    }
+
+    /// Relay-internal merged-block SSZ route; see `sim_method_merged_v5`.
+    pub fn ssz_merged_request_builder(&self) -> Option<RequestBuilder> {
+        self.ssz_url.as_ref().map(|url| self.client.post(format!("{url}/validate_merged")))
     }
 
     /// Returns `None` for a fork this client has no validation RPC method for yet, rather than
@@ -69,8 +76,14 @@ impl SimulatorClient {
         Some((self.client.post(&self.config.url), method))
     }
 
+    /// Merged-block counterpart of `sim_request_builder`: only V5 applies (the network is long
+    /// past the forks V4 covers), so this doesn't need a fork parameter.
+    pub fn merged_sim_request_builder(&self) -> (RequestBuilder, &str) {
+        (self.client.post(&self.config.url), &self.sim_method_merged_v5)
+    }
+
     pub async fn do_json_sim_request(
-        request: &JsonValidationRequest,
+        request: &impl serde::Serialize,
         is_top_bid: bool,
         sim_method: &str,
         to_send: RequestBuilder,
@@ -107,7 +120,7 @@ impl SimulatorClient {
     }
 
     pub async fn do_sim_request(
-        ssz_req: &SszValidationRequest,
+        ssz_req: &impl Encode,
         is_top_bid: bool,
         to_send: RequestBuilder,
     ) -> Result<(), BlockSimError> {

--- a/crates/relay/src/simulator/mod.rs
+++ b/crates/relay/src/simulator/mod.rs
@@ -66,6 +66,13 @@ pub struct BlockMergeResponse {
     pub base_builder_revenue: U256,
     pub relay_revenue: U256,
     pub builder_inclusions: HashMap<Address, BuilderInclusionResult>,
+    /// Index, within `execution_payload.transactions`, of the base block's own proposer
+    /// payment tx. Base txs keep their original positions in a merged block -- only new
+    /// content is ever appended after them -- so this is always
+    /// `execution_payload.transactions.len() - <appended order txs> - 2` (the `- 2` for the
+    /// appended order txs' own count and the trailing distribution tx). Lets a merged-block
+    /// validator recognise the base block's payment directly instead of scanning every tx.
+    pub base_payment_tx_index: usize,
     pub trace: MergedBlockTrace,
 }
 

--- a/crates/relay/src/simulator/mod.rs
+++ b/crates/relay/src/simulator/mod.rs
@@ -6,7 +6,7 @@ use helix_common::{
     simulator::BlockSimError,
 };
 use helix_types::{
-    BlobWithMetadata, BuilderInclusionResult, ExecutionPayload, ExecutionRequests, MergedBlockTrace,
+    BlobsBundle, BuilderInclusionResult, ExecutionPayload, ExecutionRequests, MergedBlockTrace,
 };
 
 use crate::{
@@ -57,9 +57,10 @@ pub struct BlockMergeResponse {
     pub base_block_hash: B256,
     pub execution_payload: ExecutionPayload,
     pub execution_requests: ExecutionRequests,
-    /// Blob sidecars for appended blob transactions, re-attached from `BlockMergingTile`'s
-    /// own cache of blobs seen in submissions this slot.
-    pub appended_blobs: Vec<BlobWithMetadata>,
+    /// The merged block's full blob set (base block's own blob txs plus any newly
+    /// appended ones), re-attached from `BlockMergingTile`'s own cache of blobs seen in
+    /// submissions this slot.
+    pub blobs_bundle: BlobsBundle,
     /// Total value for the proposer
     pub proposer_value: U256,
     pub base_builder_revenue: U256,

--- a/crates/relay/src/simulator/tile.rs
+++ b/crates/relay/src/simulator/tile.rs
@@ -29,8 +29,8 @@ use helix_common::{
     validator_preferences::{Filtering, ValidatorPreferences},
 };
 use helix_types::{
-    BidTrace, BlobWithMetadata, BlobsBundle, BlsPublicKeyBytes, BlsSignatureBytes, KzgCommitments,
-    SignedBidSubmission, SimHydrationCache, Submission,
+    BidTrace, BlsPublicKeyBytes, BlsSignatureBytes, SignedBidSubmission, SimHydrationCache,
+    Submission,
 };
 use ssz::Encode as _;
 use tracing::{debug, error, info, warn};
@@ -942,24 +942,10 @@ fn merged_block_to_submission(
     Ok(SignedBidSubmission {
         message,
         execution_payload: Arc::new(payload.clone()),
-        blobs_bundle: Arc::new(blobs_bundle_from_appended(&response.appended_blobs)?),
+        blobs_bundle: Arc::new(response.blobs_bundle.clone()),
         execution_requests: Arc::new(response.execution_requests.clone()),
         signature: BlsSignatureBytes::default(),
     })
-}
-
-fn blobs_bundle_from_appended(appended: &[BlobWithMetadata]) -> Result<BlobsBundle, BlockSimError> {
-    let mut commitments = Vec::with_capacity(appended.len());
-    let mut proofs = Vec::new();
-    let mut blobs = Vec::with_capacity(appended.len());
-    for b in appended {
-        commitments.push(b.commitment);
-        proofs.extend(b.proofs.iter().copied());
-        blobs.push(b.blob.clone());
-    }
-    let commitments = KzgCommitments::new(commitments)
-        .map_err(|_| BlockSimError::BlockValidationFailed("too many appended blobs".to_owned()))?;
-    Ok(BlobsBundle { commitments, proofs, blobs })
 }
 
 fn create_ssz_request(
@@ -995,7 +981,10 @@ fn ssz_request(
 #[cfg(test)]
 mod tests {
     use alloy_primitives::{Address, U256};
-    use helix_types::{ExecutionPayload, ExecutionRequests, MergedBlockTrace, TestRandom};
+    use helix_types::{
+        BlobWithMetadata, BlobsBundle, ExecutionPayload, ExecutionRequests, MergedBlockTrace,
+        TestRandom,
+    };
     use rand::{SeedableRng, rngs::SmallRng};
 
     use super::*;
@@ -1005,11 +994,15 @@ mod tests {
         proposer_value: U256,
         blobs: Vec<BlobWithMetadata>,
     ) -> BlockMergeResponse {
+        let mut blobs_bundle = BlobsBundle::default();
+        for blob in blobs {
+            blobs_bundle.push_blob(blob.commitment, &blob.proofs, blob.blob, 9).unwrap();
+        }
         BlockMergeResponse {
             base_block_hash: payload.parent_hash,
             execution_payload: payload,
             execution_requests: ExecutionRequests::default(),
-            appended_blobs: blobs,
+            blobs_bundle,
             proposer_value,
             base_builder_revenue: U256::ZERO,
             relay_revenue: U256::ZERO,

--- a/crates/relay/src/simulator/tile.rs
+++ b/crates/relay/src/simulator/tile.rs
@@ -23,7 +23,10 @@ use helix_common::{
     is_local_dev,
     metrics::SimulatorMetrics,
     record_submission_step,
-    simulator::{BlockSimError, JsonValidationRequest, SszValidationRequest},
+    simulator::{
+        BlockSimError, JsonValidationRequest, MergedJsonValidationRequest,
+        SszMergedValidationRequest, SszValidationRequest,
+    },
     spawn_tracked,
     utils::avg_duration,
     validator_preferences::{Filtering, ValidatorPreferences},
@@ -520,32 +523,14 @@ impl SimulatorTile {
             }
         };
 
+        let base_payment_tx_index = response.base_payment_tx_index as u64;
+
         let sim = &mut self.simulators[id];
         let dispatch = if let Some(url) = &sim.client.ssz_url {
-            SimDispatch::Ssz {
-                to_send: sim.client.client.post(format!("{url}/validate")),
-                ssz_url: url.clone(),
-                http: sim.client.client.clone(),
-            }
+            MergedSimDispatch::Ssz(sim.client.client.post(format!("{url}/validate_merged")))
         } else {
-            let fork = submission.fork_name();
-            let Some((builder, method)) = sim.client.sim_request_builder(fork) else {
-                warn!(%fork, "no validation RPC method for fork, dropping merged block");
-                sim.pending += 1;
-                let inner = MergedSimulationResultInner {
-                    merged_block_ix: req.merged_block_ix,
-                    result: Err(BlockSimError::UnsupportedFork(fork)),
-                };
-                let result_ix = self.sim_results.push(SimResult::ValidateMerged((id, Some(inner))));
-                let _ = self.task_tx.try_send(SimTileInternalEvent::TaskDone {
-                    id,
-                    paused_until: None,
-                    result_ix,
-                    elapsed: None,
-                });
-                return;
-            };
-            SimDispatch::Json { to_send: builder, method: method.to_owned() }
+            let (builder, method) = sim.client.merged_sim_request_builder();
+            MergedSimDispatch::Json { to_send: builder, method: method.to_owned() }
         };
         sim.pending += 1;
 
@@ -565,26 +550,30 @@ impl SimulatorTile {
 
             SimulatorMetrics::sim_count(false);
             let res = match dispatch {
-                SimDispatch::Ssz { to_send, .. } => {
-                    let request = ssz_request(
+                MergedSimDispatch::Ssz(to_send) => {
+                    let request = ssz_merged_request(
                         apply_blacklist,
                         registered_gas_limit,
                         parent_beacon_block_root,
                         inclusion_list,
                         &submission,
+                        base_payment_tx_index,
                     );
                     SimulatorClient::do_sim_request(&request, false, to_send).await
                 }
-                SimDispatch::Json { to_send, method } => {
+                MergedSimDispatch::Json { to_send, method } => {
                     let filtering =
                         if apply_blacklist { Filtering::Regional } else { Filtering::Global };
-                    let json_req = JsonValidationRequest::new(
-                        registered_gas_limit,
-                        &submission,
-                        ValidatorPreferences { filtering, ..Default::default() },
-                        Some(parent_beacon_block_root),
-                        Some(inclusion_list),
-                    );
+                    let json_req = MergedJsonValidationRequest {
+                        base: JsonValidationRequest::new(
+                            registered_gas_limit,
+                            &submission,
+                            ValidatorPreferences { filtering, ..Default::default() },
+                            Some(parent_beacon_block_root),
+                            Some(inclusion_list),
+                        ),
+                        base_payment_tx_index,
+                    };
                     SimulatorClient::do_json_sim_request(&json_req, false, &method, to_send).await
                 }
             };
@@ -778,6 +767,13 @@ pub struct MergedSimulationResultInner {
 
 enum SimDispatch {
     Ssz { to_send: reqwest::RequestBuilder, ssz_url: String, http: reqwest::Client },
+    Json { to_send: reqwest::RequestBuilder, method: String },
+}
+
+/// Merged-block counterpart of [`SimDispatch`]: no hydration-miss retry (merged blocks are
+/// always full, never dehydrated), so it doesn't need `SimDispatch::Ssz`'s extra fields.
+enum MergedSimDispatch {
+    Ssz(reqwest::RequestBuilder),
     Json { to_send: reqwest::RequestBuilder, method: String },
 }
 
@@ -978,6 +974,26 @@ fn ssz_request(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
+fn ssz_merged_request(
+    apply_blacklist: bool,
+    registered_gas_limit: u64,
+    parent_beacon_block_root: B256,
+    inclusion_list: InclusionListWithMetadata,
+    submission: &SignedBidSubmission,
+    base_payment_tx_index: u64,
+) -> SszMergedValidationRequest {
+    SszMergedValidationRequest {
+        apply_blacklist,
+        registered_gas_limit,
+        parent_beacon_block_root,
+        inclusion_list,
+        decoder_params: None,
+        signed_bid_submission: submission.as_ssz_bytes(),
+        base_payment_tx_index,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use alloy_primitives::{Address, U256};
@@ -1007,6 +1023,7 @@ mod tests {
             base_builder_revenue: U256::ZERO,
             relay_revenue: U256::ZERO,
             builder_inclusions: Default::default(),
+            base_payment_tx_index: 0,
             trace: MergedBlockTrace::default(),
         }
     }

--- a/crates/simulator/src/ssz_server.rs
+++ b/crates/simulator/src/ssz_server.rs
@@ -8,7 +8,7 @@ use axum::{
 };
 use helix_common::{
     decoder::{DecoderError, SubmissionDecoder},
-    simulator::SszValidationRequest,
+    simulator::{SszMergedValidationRequest, SszValidationRequest},
 };
 use helix_types::Submission;
 use ssz::Decode;
@@ -16,11 +16,15 @@ use tokio::net::TcpListener;
 use tracing::error;
 
 use crate::validation::{
-    BlockSubmissionValidationApiServer, ExtendedValidationRequestV5, ValidationApi,
+    BlockSubmissionValidationApiServer, ExtendedMergedValidationRequestV5,
+    ExtendedValidationRequestV5, ValidationApi,
 };
 
 pub async fn run(api: ValidationApi, port: u16) {
-    let router = Router::new().route("/validate", post(handler)).with_state(api);
+    let router = Router::new()
+        .route("/validate", post(handler))
+        .route("/validate_merged", post(merged_handler))
+        .with_state(api);
     let listener = match TcpListener::bind(("0.0.0.0", port)).await {
         Ok(l) => l,
         Err(e) => {
@@ -33,29 +37,42 @@ pub async fn run(api: ValidationApi, port: u16) {
     }
 }
 
+/// Decodes the submission carried by an SSZ validation request body, in either shape: full
+/// bytes, or a dehydrated reference (which this server can't yet rehydrate -- see the 424
+/// below).
+fn decode_submission(
+    decoder_params: Option<helix_common::decoder::SubmissionDecoderParams>,
+    signed_bid_submission: &[u8],
+) -> Result<Result<SignedBidSubmissionV5, Response>, DecoderError> {
+    Ok(match decoder_params {
+        Some(decode_params) => {
+            let mut buf = vec![];
+            let mut decoder = SubmissionDecoder::new(&decode_params);
+            let (submission, _, _) = decoder.decode(signed_bid_submission, &mut buf)?;
+            match submission {
+                Submission::Full(s) => Ok(s.into()),
+                Submission::Dehydrated(_) => {
+                    // Simulator-side hydration cache not yet implemented.
+                    // Return 424 so the relay retries with full SSZ bytes.
+                    Err(StatusCode::FAILED_DEPENDENCY.into_response())
+                }
+            }
+        }
+        None => Ok(SignedBidSubmissionV5::from_ssz_bytes(signed_bid_submission)?),
+    })
+}
+
 async fn handler(
     State(api): State<ValidationApi>,
     body: axum::body::Bytes,
 ) -> Result<Response, DecoderError> {
     let req = SszValidationRequest::from_ssz_bytes(&body)?;
 
-    let signed_bid_submission = match req.decoder_params {
-        Some(decode_params) => {
-            let mut buf = vec![];
-            let mut decoder = SubmissionDecoder::new(&decode_params);
-            let (submission, _, _) =
-                decoder.decode(req.signed_bid_submission.as_slice(), &mut buf)?;
-            match submission {
-                Submission::Full(s) => s.into(),
-                Submission::Dehydrated(_) => {
-                    // Simulator-side hydration cache not yet implemented.
-                    // Return 424 so the relay retries with full SSZ bytes.
-                    return Ok(StatusCode::FAILED_DEPENDENCY.into_response());
-                }
-            }
-        }
-        None => SignedBidSubmissionV5::from_ssz_bytes(req.signed_bid_submission.as_slice())?,
-    };
+    let signed_bid_submission =
+        match decode_submission(req.decoder_params, &req.signed_bid_submission)? {
+            Ok(submission) => submission,
+            Err(early_response) => return Ok(early_response),
+        };
 
     let ext = ExtendedValidationRequestV5 {
         base: BuilderBlockValidationRequestV5 {
@@ -68,6 +85,39 @@ async fn handler(
     };
 
     Ok(match api.validate_builder_submission_v5(ext).await {
+        Ok(()) => StatusCode::OK.into_response(),
+        Err(e) => (StatusCode::BAD_REQUEST, e.message().to_string()).into_response(),
+    })
+}
+
+/// Relay-internal merged-block route; never reachable by an externally submitted builder
+/// block. See `ExtendedMergedValidationRequestV5`.
+async fn merged_handler(
+    State(api): State<ValidationApi>,
+    body: axum::body::Bytes,
+) -> Result<Response, DecoderError> {
+    let req = SszMergedValidationRequest::from_ssz_bytes(&body)?;
+
+    let signed_bid_submission =
+        match decode_submission(req.decoder_params, &req.signed_bid_submission)? {
+            Ok(submission) => submission,
+            Err(early_response) => return Ok(early_response),
+        };
+
+    let ext = ExtendedMergedValidationRequestV5 {
+        base: ExtendedValidationRequestV5 {
+            base: BuilderBlockValidationRequestV5 {
+                request: signed_bid_submission,
+                registered_gas_limit: req.registered_gas_limit,
+                parent_beacon_block_root: req.parent_beacon_block_root,
+            },
+            inclusion_list: Some(req.inclusion_list),
+            apply_blacklist: req.apply_blacklist,
+        },
+        base_payment_tx_index: req.base_payment_tx_index,
+    };
+
+    Ok(match api.validate_merged_builder_submission_v5(ext).await {
         Ok(()) => StatusCode::OK.into_response(),
         Err(e) => (StatusCode::BAD_REQUEST, e.message().to_string()).into_response(),
     })

--- a/crates/simulator/src/validation/mod.rs
+++ b/crates/simulator/src/validation/mod.rs
@@ -474,8 +474,10 @@ impl ValidationApi {
     /// Ensures that the proposer has received [`BidTrace::value`] for this block.
     ///
     /// Firstly attempts to verify the payment by checking the state changes, otherwise falls back
-    /// to checking the latest block transaction, which may pay the recipient directly or through
-    /// the [`PAYMENT_FORWARDER`].
+    /// to summing every transaction's recognized payment to the recipient -- the payment isn't
+    /// always confined to (or even present in) the last transaction: a merged block keeps the
+    /// base block's own payment tx in place and pays the rest of the value via a newly appended
+    /// one (see crates/builder/src/engine/session.rs), so no single position can be assumed.
     fn ensure_payment(
         &self,
         block: &SealedBlock<Block>,
@@ -507,58 +509,70 @@ impl ValidationApi {
             return Ok(());
         }
 
-        let (receipt, tx) = output
-            .receipts
-            .last()
-            .zip(block.body().transactions().last())
-            .ok_or(ValidationApiError::ProposerPayment)?;
-
-        if !receipt.status() {
-            return Err(ValidationApiError::ProposerPayment);
+        let total = self.sum_recognized_payments(block, output, message.proposer_fee_recipient)?;
+        if total >= message.value {
+            return Ok(());
         }
 
-        if tx.chain_id() != Some(self.evm_config.chain_spec().chain().id()) {
-            return Err(ValidationApiError::ProposerPayment);
-        }
+        Err(ValidationApiError::ProposerPayment)
+    }
 
-        // Either a direct transfer, one routed through the PaymentForwarder (which
-        // sends the full value on to the recipient in its calldata), or a Gnosis
-        // Safe execTransaction -> multiSend delegatecall (the merge-builder payment
-        // engine's mechanism, see crates/builder/src/engine/payment.rs). The
-        // forwarder is only trusted where its runtime is actually deployed, since a
-        // value call to a codeless address succeeds and keeps the value.
-        let paid_directly =
-            tx.to() == Some(message.proposer_fee_recipient) && tx.input().is_empty();
-        let paid_via_forwarder = tx.to() == Some(PAYMENT_FORWARDER) &&
-            payment_forwarder_recipient(tx.input()) == Some(message.proposer_fee_recipient) &&
-            self.provider
-                .latest()
-                .and_then(|state| state.basic_account(&PAYMENT_FORWARDER))
-                .is_ok_and(|account| {
-                    account.is_some_and(|account| {
-                        account.bytecode_hash == Some(PAYMENT_FORWARDER_CODE_HASH)
-                    })
-                });
-        let paid_via_multisend =
-            multisend_pays(tx.input(), message.proposer_fee_recipient, message.value);
-        if !paid_directly && !paid_via_forwarder && !paid_via_multisend {
-            return Err(ValidationApiError::ProposerPayment);
-        }
+    /// Sums every successful transaction's recognized payment to `recipient`: a direct
+    /// transfer, one routed through the [`PAYMENT_FORWARDER`], or a batched entry in a Gnosis
+    /// Safe `execTransaction` -> `multiSend` delegatecall (the merge-builder payment engine's
+    /// mechanism, see crates/builder/src/engine/payment.rs). Not position-restricted, since a
+    /// legitimate payment can be split across more than one transaction and need not be last.
+    /// A contributing transaction must still pass the same anti-MEV-extraction checks the old
+    /// single-tx fallback applied (chain id, zero priority fee) -- if it doesn't, its payment
+    /// isn't credited, but that alone doesn't fail the block: another transaction's payment may
+    /// still be enough.
+    fn sum_recognized_payments(
+        &self,
+        block: &SealedBlock<Block>,
+        output: &BlockExecutionOutput<Receipt>,
+        recipient: Address,
+    ) -> Result<U256, ValidationApiError> {
+        let chain_id = self.evm_config.chain_spec().chain().id();
+        let block_base_fee = block.header().base_fee_per_gas();
 
-        // The multisend's value moves from the Safe's own balance via internal
-        // calls, not from this outer tx's msg.value, so it doesn't apply here --
-        // multisend_pays already confirmed a matching (recipient, value) entry.
-        if !paid_via_multisend && tx.value() != message.value {
-            return Err(ValidationApiError::ProposerPayment);
-        }
-
-        if let Some(block_base_fee) = block.header().base_fee_per_gas() {
-            if tx.effective_tip_per_gas(block_base_fee).unwrap_or_default() != 0 {
-                return Err(ValidationApiError::ProposerPayment);
+        let mut total = U256::ZERO;
+        for (receipt, tx) in output.receipts.iter().zip(block.body().transactions()) {
+            if !receipt.status() {
+                continue;
             }
-        }
 
-        Ok(())
+            let paid_directly = tx.to() == Some(recipient) && tx.input().is_empty();
+            let paid_via_forwarder = tx.to() == Some(PAYMENT_FORWARDER) &&
+                payment_forwarder_recipient(tx.input()) == Some(recipient) &&
+                self.provider
+                    .latest()
+                    .and_then(|state| state.basic_account(&PAYMENT_FORWARDER))
+                    .is_ok_and(|account| {
+                        account.is_some_and(|account| {
+                            account.bytecode_hash == Some(PAYMENT_FORWARDER_CODE_HASH)
+                        })
+                    });
+            let contributed = if paid_directly || paid_via_forwarder {
+                tx.value()
+            } else {
+                multisend_paid_amount(tx.input(), recipient)
+            };
+            if contributed.is_zero() {
+                continue;
+            }
+
+            if tx.chain_id() != Some(chain_id) {
+                continue;
+            }
+            if let Some(block_base_fee) = block_base_fee &&
+                tx.effective_tip_per_gas(block_base_fee).unwrap_or_default() != 0
+            {
+                continue;
+            }
+
+            total += contributed;
+        }
+        Ok(total)
     }
 
     /// Validates the given [`BlobsBundleV1`] and returns versioned hashes for blobs.
@@ -727,18 +741,20 @@ sol! {
 
 const SAFE_DELEGATECALL: u8 = 1;
 
-/// Whether a Safe `execTransaction` -> `multiSend` delegatecall's batched calls pay
-/// `recipient` exactly `value`. `false` on any decode failure or shape mismatch
-/// (not a delegatecall, not a multiSend payload, no matching entry) -- this is a
-/// best-effort recognizer, not a signature/authenticity check: the caller must
-/// already know the transaction actually succeeded on-chain.
-fn multisend_pays(input: &[u8], recipient: Address, value: U256) -> bool {
-    let Ok(exec) = execTransactionCall::abi_decode(input) else { return false };
+/// Sums the value a Safe `execTransaction` -> `multiSend` delegatecall's batched
+/// calls pay `recipient` (zero on any decode failure or shape mismatch: not a
+/// delegatecall, not a multiSend payload, no matching entry). Best-effort
+/// recognition, not a signature/authenticity check: the caller must already know
+/// the transaction actually succeeded on-chain.
+fn multisend_paid_amount(input: &[u8], recipient: Address) -> U256 {
+    let Ok(exec) = execTransactionCall::abi_decode(input) else { return U256::ZERO };
     if exec.operation != SAFE_DELEGATECALL {
-        return false;
+        return U256::ZERO;
     }
-    let Ok(multisend) = multiSendCall::abi_decode(&exec.data) else { return false };
-    multisend_entries(&multisend.transactions).any(|(to, val)| to == recipient && val == value)
+    let Ok(multisend) = multiSendCall::abi_decode(&exec.data) else { return U256::ZERO };
+    multisend_entries(&multisend.transactions)
+        .filter(|(to, _)| *to == recipient)
+        .fold(U256::ZERO, |acc, (_, value)| acc + value)
 }
 
 /// Iterates a Safe `multiSend` packed payload: per entry, `[1B operation][20B
@@ -789,7 +805,8 @@ mod multisend_payment_tests {
 
     /// Mirrors `crates/builder/src/engine/payment.rs::encode_multisend_calldata`'s
     /// `execTransaction` wrapping, minus the real Safe signature (irrelevant here:
-    /// `multisend_pays` only decodes calldata shape, it doesn't verify signatures).
+    /// `multisend_paid_amount` only decodes calldata shape, it doesn't verify
+    /// signatures).
     fn exec_transaction_calldata(
         multisend_contract: Address,
         entries: &[(Address, U256)],
@@ -812,7 +829,7 @@ mod multisend_payment_tests {
     }
 
     #[test]
-    fn multisend_pays_recognizes_matching_entry_among_several() {
+    fn multisend_paid_amount_finds_matching_entry_among_several() {
         let multisend_contract = address!("0x1111111111111111111111111111111111111111");
         let proposer = address!("0x2222222222222222222222222222222222222222");
         let other = address!("0x3333333333333333333333333333333333333333");
@@ -821,20 +838,33 @@ mod multisend_payment_tests {
             (proposer, U256::from(42)),
         ]);
 
-        assert!(multisend_pays(&calldata, proposer, U256::from(42)));
+        assert_eq!(multisend_paid_amount(&calldata, proposer), U256::from(42));
     }
 
     #[test]
-    fn multisend_pays_rejects_wrong_value() {
+    fn multisend_paid_amount_sums_multiple_entries_to_the_same_recipient() {
         let multisend_contract = address!("0x1111111111111111111111111111111111111111");
         let proposer = address!("0x2222222222222222222222222222222222222222");
-        let calldata = exec_transaction_calldata(multisend_contract, &[(proposer, U256::from(42))]);
+        let calldata = exec_transaction_calldata(multisend_contract, &[
+            (proposer, U256::from(42)),
+            (proposer, U256::from(8)),
+        ]);
 
-        assert!(!multisend_pays(&calldata, proposer, U256::from(43)));
+        assert_eq!(multisend_paid_amount(&calldata, proposer), U256::from(50));
     }
 
     #[test]
-    fn multisend_pays_rejects_non_delegatecall_operation() {
+    fn multisend_paid_amount_zero_when_recipient_absent() {
+        let multisend_contract = address!("0x1111111111111111111111111111111111111111");
+        let proposer = address!("0x2222222222222222222222222222222222222222");
+        let other = address!("0x3333333333333333333333333333333333333333");
+        let calldata = exec_transaction_calldata(multisend_contract, &[(other, U256::from(42))]);
+
+        assert_eq!(multisend_paid_amount(&calldata, proposer), U256::ZERO);
+    }
+
+    #[test]
+    fn multisend_paid_amount_zero_for_non_delegatecall_operation() {
         let multisend_contract = address!("0x1111111111111111111111111111111111111111");
         let proposer = address!("0x2222222222222222222222222222222222222222");
         let multisend_calldata =
@@ -854,13 +884,13 @@ mod multisend_payment_tests {
         }
         .abi_encode();
 
-        assert!(!multisend_pays(&calldata, proposer, U256::from(42)));
+        assert_eq!(multisend_paid_amount(&calldata, proposer), U256::ZERO);
     }
 
     #[test]
-    fn multisend_pays_rejects_unrelated_calldata() {
+    fn multisend_paid_amount_zero_for_unrelated_calldata() {
         let proposer = address!("0x2222222222222222222222222222222222222222");
-        assert!(!multisend_pays(&[0xde, 0xad, 0xbe, 0xef], proposer, U256::from(42)));
+        assert_eq!(multisend_paid_amount(&[0xde, 0xad, 0xbe, 0xef], proposer), U256::ZERO);
     }
 
     #[test]

--- a/crates/simulator/src/validation/mod.rs
+++ b/crates/simulator/src/validation/mod.rs
@@ -16,6 +16,7 @@ use alloy_rpc_types::{
         ExecutionPayloadSidecar, PraguePayloadFields,
     },
 };
+use alloy_sol_types::{SolCall, sol};
 use async_trait::async_trait;
 use dashmap::DashSet;
 use helix_common::{
@@ -520,10 +521,12 @@ impl ValidationApi {
             return Err(ValidationApiError::ProposerPayment);
         }
 
-        // Either a direct transfer, or one routed through the PaymentForwarder,
-        // which sends the full value on to the recipient in its calldata. The
-        // forwarder is only trusted where its runtime is actually deployed,
-        // since a value call to a codeless address succeeds and keeps the value.
+        // Either a direct transfer, one routed through the PaymentForwarder (which
+        // sends the full value on to the recipient in its calldata), or a Gnosis
+        // Safe execTransaction -> multiSend delegatecall (the merge-builder payment
+        // engine's mechanism, see crates/builder/src/engine/payment.rs). The
+        // forwarder is only trusted where its runtime is actually deployed, since a
+        // value call to a codeless address succeeds and keeps the value.
         let paid_directly =
             tx.to() == Some(message.proposer_fee_recipient) && tx.input().is_empty();
         let paid_via_forwarder = tx.to() == Some(PAYMENT_FORWARDER) &&
@@ -536,11 +539,16 @@ impl ValidationApi {
                         account.bytecode_hash == Some(PAYMENT_FORWARDER_CODE_HASH)
                     })
                 });
-        if !paid_directly && !paid_via_forwarder {
+        let paid_via_multisend =
+            multisend_pays(tx.input(), message.proposer_fee_recipient, message.value);
+        if !paid_directly && !paid_via_forwarder && !paid_via_multisend {
             return Err(ValidationApiError::ProposerPayment);
         }
 
-        if tx.value() != message.value {
+        // The multisend's value moves from the Safe's own balance via internal
+        // calls, not from this outer tx's msg.value, so it doesn't apply here --
+        // multisend_pays already confirmed a matching (recipient, value) entry.
+        if !paid_via_multisend && tx.value() != message.value {
             return Err(ValidationApiError::ProposerPayment);
         }
 
@@ -694,6 +702,174 @@ impl ValidationApi {
             parent_header
         };
         Ok(parent_header)
+    }
+}
+
+sol! {
+    /// Gnosis Safe entry point the merge-builder payment engine calls
+    /// (crates/builder/src/engine/payment.rs) to delegatecall `multiSend`.
+    function execTransaction(
+        address to,
+        uint256 value,
+        bytes data,
+        uint8 operation,
+        uint256 safeTxGas,
+        uint256 baseGas,
+        uint256 gasPrice,
+        address gasToken,
+        address refundReceiver,
+        bytes signatures
+    ) external returns (bool);
+
+    /// Gnosis `MultiSendCallOnly` entry point, delegatecalled by `execTransaction`.
+    function multiSend(bytes transactions) external payable;
+}
+
+const SAFE_DELEGATECALL: u8 = 1;
+
+/// Whether a Safe `execTransaction` -> `multiSend` delegatecall's batched calls pay
+/// `recipient` exactly `value`. `false` on any decode failure or shape mismatch
+/// (not a delegatecall, not a multiSend payload, no matching entry) -- this is a
+/// best-effort recognizer, not a signature/authenticity check: the caller must
+/// already know the transaction actually succeeded on-chain.
+fn multisend_pays(input: &[u8], recipient: Address, value: U256) -> bool {
+    let Ok(exec) = execTransactionCall::abi_decode(input) else { return false };
+    if exec.operation != SAFE_DELEGATECALL {
+        return false;
+    }
+    let Ok(multisend) = multiSendCall::abi_decode(&exec.data) else { return false };
+    multisend_entries(&multisend.transactions).any(|(to, val)| to == recipient && val == value)
+}
+
+/// Iterates a Safe `multiSend` packed payload: per entry, `[1B operation][20B
+/// to][32B value][32B dataLength][dataLength B data]`. Stops (yields no more
+/// entries) on any length that doesn't fit the remaining bytes, rather than
+/// panicking on malformed/adversarial input.
+fn multisend_entries(transactions: &[u8]) -> impl Iterator<Item = (Address, U256)> + '_ {
+    const ENTRY_HEADER_LEN: usize = 1 + 20 + 32 + 32;
+    let mut offset = 0usize;
+    std::iter::from_fn(move || {
+        if transactions.len().saturating_sub(offset) < ENTRY_HEADER_LEN {
+            return None;
+        }
+        offset += 1; // operation: irrelevant for a payment check
+        let to = Address::from_slice(&transactions[offset..offset + 20]);
+        offset += 20;
+        let value = U256::from_be_slice(&transactions[offset..offset + 32]);
+        offset += 32;
+        let data_len: usize =
+            U256::from_be_slice(&transactions[offset..offset + 32]).try_into().ok()?;
+        offset += 32;
+        if transactions.len().saturating_sub(offset) < data_len {
+            return None;
+        }
+        offset += data_len;
+        Some((to, value))
+    })
+}
+
+#[cfg(test)]
+mod multisend_payment_tests {
+    use alloy_primitives::{Bytes, address};
+    use alloy_sol_types::SolCall;
+
+    use super::*;
+
+    /// Mirrors `crates/builder/src/engine/payment.rs::build_multisend_payload`.
+    fn multisend_payload(entries: &[(Address, U256)]) -> Vec<u8> {
+        let mut payload = Vec::new();
+        for (to, value) in entries {
+            payload.push(0u8); // operation = CALL
+            payload.extend_from_slice(to.as_slice());
+            payload.extend_from_slice(&value.to_be_bytes::<32>());
+            payload.extend_from_slice(&U256::ZERO.to_be_bytes::<32>()); // data length
+        }
+        payload
+    }
+
+    /// Mirrors `crates/builder/src/engine/payment.rs::encode_multisend_calldata`'s
+    /// `execTransaction` wrapping, minus the real Safe signature (irrelevant here:
+    /// `multisend_pays` only decodes calldata shape, it doesn't verify signatures).
+    fn exec_transaction_calldata(
+        multisend_contract: Address,
+        entries: &[(Address, U256)],
+    ) -> Vec<u8> {
+        let multisend_calldata =
+            multiSendCall { transactions: multisend_payload(entries).into() }.abi_encode();
+        execTransactionCall {
+            to: multisend_contract,
+            value: U256::ZERO,
+            data: multisend_calldata.into(),
+            operation: SAFE_DELEGATECALL,
+            safeTxGas: U256::ZERO,
+            baseGas: U256::ZERO,
+            gasPrice: U256::ZERO,
+            gasToken: Address::ZERO,
+            refundReceiver: Address::ZERO,
+            signatures: Bytes::new(),
+        }
+        .abi_encode()
+    }
+
+    #[test]
+    fn multisend_pays_recognizes_matching_entry_among_several() {
+        let multisend_contract = address!("0x1111111111111111111111111111111111111111");
+        let proposer = address!("0x2222222222222222222222222222222222222222");
+        let other = address!("0x3333333333333333333333333333333333333333");
+        let calldata = exec_transaction_calldata(multisend_contract, &[
+            (other, U256::from(100)),
+            (proposer, U256::from(42)),
+        ]);
+
+        assert!(multisend_pays(&calldata, proposer, U256::from(42)));
+    }
+
+    #[test]
+    fn multisend_pays_rejects_wrong_value() {
+        let multisend_contract = address!("0x1111111111111111111111111111111111111111");
+        let proposer = address!("0x2222222222222222222222222222222222222222");
+        let calldata = exec_transaction_calldata(multisend_contract, &[(proposer, U256::from(42))]);
+
+        assert!(!multisend_pays(&calldata, proposer, U256::from(43)));
+    }
+
+    #[test]
+    fn multisend_pays_rejects_non_delegatecall_operation() {
+        let multisend_contract = address!("0x1111111111111111111111111111111111111111");
+        let proposer = address!("0x2222222222222222222222222222222222222222");
+        let multisend_calldata =
+            multiSendCall { transactions: multisend_payload(&[(proposer, U256::from(42))]).into() }
+                .abi_encode();
+        let calldata = execTransactionCall {
+            to: multisend_contract,
+            value: U256::ZERO,
+            data: multisend_calldata.into(),
+            operation: 0, // CALL, not DELEGATECALL
+            safeTxGas: U256::ZERO,
+            baseGas: U256::ZERO,
+            gasPrice: U256::ZERO,
+            gasToken: Address::ZERO,
+            refundReceiver: Address::ZERO,
+            signatures: Bytes::new(),
+        }
+        .abi_encode();
+
+        assert!(!multisend_pays(&calldata, proposer, U256::from(42)));
+    }
+
+    #[test]
+    fn multisend_pays_rejects_unrelated_calldata() {
+        let proposer = address!("0x2222222222222222222222222222222222222222");
+        assert!(!multisend_pays(&[0xde, 0xad, 0xbe, 0xef], proposer, U256::from(42)));
+    }
+
+    #[test]
+    fn multisend_entries_stops_on_truncated_payload() {
+        let to = address!("0x2222222222222222222222222222222222222222");
+        let mut payload = multisend_payload(&[(to, U256::from(42))]);
+        payload.truncate(payload.len() - 1); // cut into the last entry's data-length field
+
+        assert_eq!(multisend_entries(&payload).count(), 0);
     }
 }
 

--- a/crates/simulator/src/validation/mod.rs
+++ b/crates/simulator/src/validation/mod.rs
@@ -183,7 +183,10 @@ impl ValidationApi {
 }
 
 impl ValidationApi {
-    /// Validates the given block and a [`BidTrace`] against it.
+    /// Validates the given block and a [`BidTrace`] against it. `base_payment_tx_index` is
+    /// `Some` only for the merged-block-only validation endpoint, and switches the payment
+    /// check from `ensure_payment` (regular submissions, single trailing tx) to
+    /// `ensure_merged_payment` (a merged block's base payment tx plus its distribution tx).
     pub async fn validate_message_against_block(
         &self,
         block: RecoveredBlock<Block>,
@@ -191,6 +194,7 @@ impl ValidationApi {
         _registered_gas_limit: u64,
         apply_blacklist: bool,
         inclusion_list: Option<InclusionListWithMetadata>,
+        base_payment_tx_index: Option<usize>,
     ) -> Result<(), ValidationApiError> {
         self.validate_message_against_header(block.sealed_header(), &message)?;
 
@@ -235,7 +239,10 @@ impl ValidationApi {
 
         self.consensus.validate_block_post_execution(&block, &output, None, None)?;
 
-        self.ensure_payment(&block, &output, &message)?;
+        match base_payment_tx_index {
+            Some(ix) => self.ensure_merged_payment(&block, &output, &message, ix)?,
+            None => self.ensure_payment(&block, &output, &message)?,
+        }
 
         let state_root =
             state_provider.state_root(state_provider.hashed_post_state(&output.state))?;
@@ -473,11 +480,13 @@ impl ValidationApi {
 
     /// Ensures that the proposer has received [`BidTrace::value`] for this block.
     ///
-    /// Firstly attempts to verify the payment by checking the state changes, otherwise falls back
-    /// to summing every transaction's recognized payment to the recipient -- the payment isn't
-    /// always confined to (or even present in) the last transaction: a merged block keeps the
-    /// base block's own payment tx in place and pays the rest of the value via a newly appended
-    /// one (see crates/builder/src/engine/session.rs), so no single position can be assumed.
+    /// Firstly attempts to verify the payment by checking the state changes, otherwise falls
+    /// back to requiring the last transaction in the block to pay it directly. Shared by every
+    /// externally-submitted builder block (v4/v5) -- regular submissions always pay in a single
+    /// trailing transaction, so this deliberately doesn't scan the rest of the block. A merged
+    /// block's payment can legitimately span two transactions (see
+    /// crates/builder/src/engine/session.rs); that's handled by `ensure_merged_payment`, on the
+    /// merged-block-only validation endpoint, not here.
     fn ensure_payment(
         &self,
         block: &SealedBlock<Block>,
@@ -509,7 +518,108 @@ impl ValidationApi {
             return Ok(());
         }
 
-        let total = self.sum_recognized_payments(block, output, message.proposer_fee_recipient)?;
+        let (receipt, tx) = output
+            .receipts
+            .last()
+            .zip(block.body().transactions().last())
+            .ok_or(ValidationApiError::ProposerPayment)?;
+
+        if !receipt.status() {
+            return Err(ValidationApiError::ProposerPayment);
+        }
+
+        if tx.chain_id() != Some(self.evm_config.chain_spec().chain().id()) {
+            return Err(ValidationApiError::ProposerPayment);
+        }
+
+        // Either a direct transfer, or one routed through the PaymentForwarder,
+        // which sends the full value on to the recipient in its calldata. The
+        // forwarder is only trusted where its runtime is actually deployed,
+        // since a value call to a codeless address succeeds and keeps the value.
+        let paid_directly =
+            tx.to() == Some(message.proposer_fee_recipient) && tx.input().is_empty();
+        let paid_via_forwarder = tx.to() == Some(PAYMENT_FORWARDER) &&
+            payment_forwarder_recipient(tx.input()) == Some(message.proposer_fee_recipient) &&
+            self.provider
+                .latest()
+                .and_then(|state| state.basic_account(&PAYMENT_FORWARDER))
+                .is_ok_and(|account| {
+                    account.is_some_and(|account| {
+                        account.bytecode_hash == Some(PAYMENT_FORWARDER_CODE_HASH)
+                    })
+                });
+        if !paid_directly && !paid_via_forwarder {
+            return Err(ValidationApiError::ProposerPayment);
+        }
+
+        if tx.value() != message.value {
+            return Err(ValidationApiError::ProposerPayment);
+        }
+
+        if let Some(block_base_fee) = block.header().base_fee_per_gas() {
+            if tx.effective_tip_per_gas(block_base_fee).unwrap_or_default() != 0 {
+                return Err(ValidationApiError::ProposerPayment);
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Merged-block counterpart of `ensure_payment`, for the merged-block-only validation
+    /// endpoint. A merged block's payment is legitimately split across exactly two
+    /// transactions: the base block's own payment tx (kept at `base_payment_tx_index`, paying
+    /// `base_value`) and a newly appended distribution tx at the very end of the block (paying
+    /// the incremental `proposer_added_value`) -- see crates/builder/src/engine/session.rs.
+    /// Checking only these two positions (as opposed to `ensure_payment`'s regular-submission
+    /// single-last-tx check, or scanning every tx in the block) is safe here because
+    /// `base_payment_tx_index` is derived and trusted upstream, at the relay
+    /// (`BlockMergeResponse::base_payment_tx_index`) -- if it's wrong, this fails closed (the
+    /// payment isn't found), it never lets an underpaid block through.
+    fn ensure_merged_payment(
+        &self,
+        block: &SealedBlock<Block>,
+        output: &BlockExecutionOutput<Receipt>,
+        message: &BidTrace,
+        base_payment_tx_index: usize,
+    ) -> Result<(), ValidationApiError> {
+        let (mut balance_before, balance_after) = if let Some(acc) =
+            output.state.state.get(&message.proposer_fee_recipient)
+        {
+            let balance_before = acc.original_info.as_ref().map(|i| i.balance).unwrap_or_default();
+            let balance_after = acc.info.as_ref().map(|i| i.balance).unwrap_or_default();
+
+            (balance_before, balance_after)
+        } else {
+            (U256::ZERO, U256::ZERO)
+        };
+
+        if let Some(withdrawals) = block.body().withdrawals() {
+            for withdrawal in withdrawals {
+                if withdrawal.address == message.proposer_fee_recipient {
+                    balance_before += withdrawal.amount_wei();
+                }
+            }
+        }
+
+        if balance_after >= balance_before + message.value {
+            return Ok(());
+        }
+
+        let Some(last_ix) = block.body().transactions().count().checked_sub(1) else {
+            return Err(ValidationApiError::ProposerPayment);
+        };
+
+        let mut total =
+            self.recognized_payment_at(block, output, message.proposer_fee_recipient, last_ix);
+        if base_payment_tx_index != last_ix {
+            total += self.recognized_payment_at(
+                block,
+                output,
+                message.proposer_fee_recipient,
+                base_payment_tx_index,
+            );
+        }
+
         if total >= message.value {
             return Ok(());
         }
@@ -517,62 +627,58 @@ impl ValidationApi {
         Err(ValidationApiError::ProposerPayment)
     }
 
-    /// Sums every successful transaction's recognized payment to `recipient`: a direct
-    /// transfer, one routed through the [`PAYMENT_FORWARDER`], or a batched entry in a Gnosis
-    /// Safe `execTransaction` -> `multiSend` delegatecall (the merge-builder payment engine's
-    /// mechanism, see crates/builder/src/engine/payment.rs). Not position-restricted, since a
-    /// legitimate payment can be split across more than one transaction and need not be last.
-    /// A contributing transaction must still pass the same anti-MEV-extraction checks the old
-    /// single-tx fallback applied (chain id, zero priority fee) -- if it doesn't, its payment
-    /// isn't credited, but that alone doesn't fail the block: another transaction's payment may
-    /// still be enough.
-    fn sum_recognized_payments(
+    /// The recognized payment to `recipient` from the transaction at `ix`: a direct transfer,
+    /// one routed through the [`PAYMENT_FORWARDER`], or a batched entry in a Gnosis Safe
+    /// `execTransaction` -> `multiSend` delegatecall (the merge-builder payment engine's
+    /// mechanism, see crates/builder/src/engine/payment.rs). Zero for an out-of-range index, an
+    /// unsuccessful receipt, or a transaction that fails the same anti-MEV-extraction checks
+    /// (chain id, zero priority fee) the payment-recognition checks above apply -- never an
+    /// error, since a single unrecognized/invalid position shouldn't itself fail validation.
+    fn recognized_payment_at(
         &self,
         block: &SealedBlock<Block>,
         output: &BlockExecutionOutput<Receipt>,
         recipient: Address,
-    ) -> Result<U256, ValidationApiError> {
-        let chain_id = self.evm_config.chain_spec().chain().id();
-        let block_base_fee = block.header().base_fee_per_gas();
-
-        let mut total = U256::ZERO;
-        for (receipt, tx) in output.receipts.iter().zip(block.body().transactions()) {
-            if !receipt.status() {
-                continue;
-            }
-
-            let paid_directly = tx.to() == Some(recipient) && tx.input().is_empty();
-            let paid_via_forwarder = tx.to() == Some(PAYMENT_FORWARDER) &&
-                payment_forwarder_recipient(tx.input()) == Some(recipient) &&
-                self.provider
-                    .latest()
-                    .and_then(|state| state.basic_account(&PAYMENT_FORWARDER))
-                    .is_ok_and(|account| {
-                        account.is_some_and(|account| {
-                            account.bytecode_hash == Some(PAYMENT_FORWARDER_CODE_HASH)
-                        })
-                    });
-            let contributed = if paid_directly || paid_via_forwarder {
-                tx.value()
-            } else {
-                multisend_paid_amount(tx.input(), recipient)
-            };
-            if contributed.is_zero() {
-                continue;
-            }
-
-            if tx.chain_id() != Some(chain_id) {
-                continue;
-            }
-            if let Some(block_base_fee) = block_base_fee &&
-                tx.effective_tip_per_gas(block_base_fee).unwrap_or_default() != 0
-            {
-                continue;
-            }
-
-            total += contributed;
+        ix: usize,
+    ) -> U256 {
+        let Some((receipt, tx)) = output.receipts.get(ix).zip(block.body().transactions().nth(ix))
+        else {
+            return U256::ZERO;
+        };
+        if !receipt.status() {
+            return U256::ZERO;
         }
-        Ok(total)
+
+        let paid_directly = tx.to() == Some(recipient) && tx.input().is_empty();
+        let paid_via_forwarder = tx.to() == Some(PAYMENT_FORWARDER) &&
+            payment_forwarder_recipient(tx.input()) == Some(recipient) &&
+            self.provider
+                .latest()
+                .and_then(|state| state.basic_account(&PAYMENT_FORWARDER))
+                .is_ok_and(|account| {
+                    account.is_some_and(|account| {
+                        account.bytecode_hash == Some(PAYMENT_FORWARDER_CODE_HASH)
+                    })
+                });
+        let contributed = if paid_directly || paid_via_forwarder {
+            tx.value()
+        } else {
+            multisend_paid_amount(tx.input(), recipient)
+        };
+        if contributed.is_zero() {
+            return U256::ZERO;
+        }
+
+        if tx.chain_id() != Some(self.evm_config.chain_spec().chain().id()) {
+            return U256::ZERO;
+        }
+        if let Some(block_base_fee) = block.header().base_fee_per_gas() &&
+            tx.effective_tip_per_gas(block_base_fee).unwrap_or_default() != 0
+        {
+            return U256::ZERO;
+        }
+
+        contributed
     }
 
     /// Validates the given [`BlobsBundleV1`] and returns versioned hashes for blobs.
@@ -646,6 +752,7 @@ impl ValidationApi {
             request.base.registered_gas_limit,
             request.apply_blacklist,
             request.inclusion_list,
+            None,
         )
         .await
     }
@@ -654,6 +761,28 @@ impl ValidationApi {
     async fn _validate_builder_submission_v5(
         &self,
         request: ExtendedValidationRequestV5,
+    ) -> Result<(), ValidationApiError> {
+        self._validate_builder_submission_v5_inner(request, None).await
+    }
+
+    /// Core logic for validating a merged block through the merged-block-only endpoint: the
+    /// same v5 pipeline, but with `base_payment_tx_index` passed through to
+    /// `ensure_merged_payment` instead of the regular submission path's `ensure_payment`.
+    async fn _validate_merged_builder_submission_v5(
+        &self,
+        request: ExtendedMergedValidationRequestV5,
+    ) -> Result<(), ValidationApiError> {
+        self._validate_builder_submission_v5_inner(
+            request.base,
+            Some(request.base_payment_tx_index as usize),
+        )
+        .await
+    }
+
+    async fn _validate_builder_submission_v5_inner(
+        &self,
+        request: ExtendedValidationRequestV5,
+        base_payment_tx_index: Option<usize>,
     ) -> Result<(), ValidationApiError> {
         let block = self.payload_validator.ensure_well_formed_payload(ExecutionData {
             payload: ExecutionPayload::V3(request.base.request.execution_payload),
@@ -688,6 +817,7 @@ impl ValidationApi {
             request.base.registered_gas_limit,
             request.apply_blacklist,
             request.inclusion_list,
+            base_payment_tx_index,
         )
         .await
     }
@@ -965,6 +1095,26 @@ impl BlockSubmissionValidationApiServer for ValidationApi {
 
         rx.await.map_err(|_| internal_rpc_err("Internal blocking task error"))?
     }
+
+    /// Validates a merged block. Relay-internal only -- never reachable by an externally
+    /// submitted builder block -- so it can recognise the base block's payment tx by index
+    /// instead of requiring it to be the last transaction.
+    async fn validate_merged_builder_submission_v5(
+        &self,
+        request: ExtendedMergedValidationRequestV5,
+    ) -> RpcResult<()> {
+        let this = self.clone();
+        let (tx, rx) = oneshot::channel();
+
+        self.task_spawner.spawn_blocking_task(Box::pin(async move {
+            let result = Self::_validate_merged_builder_submission_v5(&this, request)
+                .await
+                .map_err(ErrorObject::from);
+            let _ = tx.send(result);
+        }));
+
+        rx.await.map_err(|_| internal_rpc_err("Internal blocking task error"))?
+    }
 }
 
 /// Result of [`ValidationApi::execute_block`].
@@ -1083,6 +1233,19 @@ pub struct ExtendedValidationRequestV5 {
     pub apply_blacklist: bool,
 }
 
+/// Merged-block counterpart of [`ExtendedValidationRequestV5`], carrying the extra
+/// `base_payment_tx_index` the merged-block-only validation endpoint uses to recognise the
+/// base block's own payment tx directly -- see
+/// `helix_common::simulator::SszMergedValidationRequest`.
+#[serde_as]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExtendedMergedValidationRequestV5 {
+    #[serde(flatten)]
+    pub base: ExtendedValidationRequestV5,
+
+    pub base_payment_tx_index: u64,
+}
+
 /// Block validation rpc interface.
 #[rpc(server, namespace = "relay")]
 pub trait BlockSubmissionValidationApi {
@@ -1119,6 +1282,13 @@ pub trait BlockSubmissionValidationApi {
     async fn validate_builder_submission_v5(
         &self,
         request: ExtendedValidationRequestV5,
+    ) -> jsonrpsee::core::RpcResult<()>;
+
+    /// A request to validate a merged block. Relay-internal only.
+    #[method(name = "validateMergedBuilderSubmissionV5")]
+    async fn validate_merged_builder_submission_v5(
+        &self,
+        request: ExtendedMergedValidationRequestV5,
     ) -> jsonrpsee::core::RpcResult<()>;
 }
 


### PR DESCRIPTION
Issue: #500 (step 4 of 4 -- last step)

Base branch: `od/merged_block_sim_step3` (step 3, #508) -- stacked per CONTRIBUTING.md, not yet merged. Diff will shrink as earlier steps merge and this retargets down toward `develop`.

## What this PR does
Wires the relay's `/admin/v1/block-merging` route (added in #502) into the admin portal, end to end, mirroring the existing kill-switch pattern exactly (this crate had zero bespoke proxy wrapping for it before -- confirmed no generic admin-route proxy exists in `crates/admin`, so this needed the same bespoke client method + handler + route as every other admin action here):
- `RelayAdminClient` gains `block_merging_enabled` on `RelayAdminStatus` and a `set_block_merging(enabled)` method.
- `handlers.rs` gains `enable_block_merging`/`disable_block_merging` (proxying to the relay) and `overview()`/`OverviewResponse` gain `block_merging_enabled: Option<bool>` (`None` when the relay admin API is unreachable, same convention as `kill_switch_enabled`).
- `service.rs` gains the `/api/v1/actions/block-merging` route.
- Frontend: a "Block merging" toggle in Settings (two buttons + two `ConfirmDialog`s, mirroring the kill-switch block) and a status tile on the Overview page.

## Also included: merged-block blob resolution fix
While this step was in review, RELAY-FR hit repeated `CRITICAL: block merging disabled` alerts from merged-block simulation failing with `expected blob versioned hashes do not match the given transactions` / `invalid number of versionedHashes`. Root cause: the merge-simulation and merge-storage paths built a merged block's `blobs_bundle` only from the wire's `appended_blobs` list, dropping the base block's own blob sidecars whenever the base block already carried blob txs and the merge builder appended nothing new -- a false builder attribution (`is_merge_builder_attributable`) that auto-disabled merging for a bug in our own response construction, not a bad builder block.

Fix: `merged_block_to_response` now decodes the merged block's own transactions to find every referenced blob versioned hash (base txs and appended txs alike) and resolves all of them from `blob_sidecars`, producing the complete `blobs_bundle` once. The simulator and auctioneer consumers (`merged_block_to_submission`, `prepare_merged_payload_for_storage`) now use that resolved bundle directly instead of each separately (and, in the simulator's case, incompletely) reconstructing it.

This landed here rather than as a separate issue/PR since the step 3 stack (where the bug lives) hasn't merged yet -- see discussion on this PR.

## Also included: merged-block beacon-root resolution fix
A second, structurally similar RELAY-FR alert followed the blob fix: `block validation failed. Reason: invalid merkle root (remote: ... local: ...)`, from the same external (Go) EL validator used for merge-block simulation. That phrasing is a state-root mismatch, not a tx/receipts/withdrawals-root one.

Root cause: the merge-validation request built `parent_beacon_block_root` from `slot.attrs.get(&parent_hash).copied().unwrap_or_default()` -- silently sending a zero root whenever this slot's cached beacon payload attributes had no entry yet for the merged block's own parent hash. EIP-4788 writes `parent_beacon_block_root` into the beacon-roots contract during execution, so a wrong (zero) value changes the recomputed state root while leaving every other root untouched -- exactly this symptom. Same class of bug as the blob fix: an unresolved/missing local value silently defaulted instead of being treated as "can't validate this one."

Fix: `merged_validation_request` (extracted out of `poll_sockets` for testability, mirroring `handle_merged_block`) now returns `None` when the parent hash has no matching `attrs` entry, and the caller skips simulation for that merged block rather than simulating against a fabricated root. This does not affect serving -- the auctioneer publishes the merge independently of the simulation result -- it only stops a resolution gap on our side from being misread as a builder-attributable failure.

## Also included: merged-block fee-recipient/gas-limit resolution fix
A third RELAY-FR alert, same shape: `block validation failed. Reason: could not verify proposer payment`. `merged_validation_request` had the identical silent-default pattern on two more fields -- `proposer_fee_recipient: slot.fee_recipient.unwrap_or_default()` and `registered_gas_limit: slot.registered_gas_limit.unwrap_or_default()` -- sending the zero address / zero gas limit whenever this slot's registration data hadn't resolved yet. The external validator checks the merge builder's payment tx against `proposer_fee_recipient`, so a zero-defaulted recipient can never match, producing exactly this failure.

Fix: `merged_validation_request` now requires all three fields (beacon root, fee recipient, gas limit) and returns `None` -- skipping simulation, not serving -- if any of them isn't known yet, same as the beacon-root fix. `apply_blacklist`/`inclusion_list` were left as-is: their existing fallbacks (`unwrap_or(true)`, an empty inclusion list) look like deliberate, already-considered choices rather than the same oversight.

While investigating why these slot fields go missing in the first place, found that it's not just network timing: `housekeeper`'s `ChainHead` (`chain_head.rs`) sends exactly one `SlotUpdate` per slot -- whatever data it has at a hard 4-second deadline -- and then permanently latches (`ChainHeadState::Sent`) so no corrective update is ever sent later, even though housekeeper does eventually receive the missing data. This affects the auctioneer's main bid path too, not just merging, so it's a separate, larger fix -- tracked as a follow-up issue rather than folded in here.

## What this PR deliberately does not do
- No change to the disable/re-enable *decision* logic itself (#508 covers when/why merging gets disabled) -- the admin-portal work is purely wiring so an admin doesn't have to hit the relay's raw HTTP API by hand to re-enable it.
- No change to where `prepare_merged_payload_for_storage` or the auctioneer's payload-store gate live -- explored fully absorbing merge finalization into `BlockMergingTile` and decided against it for now (would require either duplicating the auctioneer's accepted-payload store into a second tile, or tightening the merge-accept path to enforce base-block activation instead of just `appendable`); left as a candidate follow-up, not part of this PR.
- No fix to `housekeeper`'s one-shot `SlotUpdate`/`ChainHead::Sent` latch (see above) -- root cause of why these slot fields go missing, but it's a housekeeper-wide behavior change affecting the main bid path, not scoped to block merging; needs its own issue and tests.

## Tests
Admin portal wiring: written first, reviewed, then implemented against. This crate (`helix-admin`) has no test coverage today -- `enable_kill_switch`/`disable_kill_switch` and siblings are all untested. Rather than add a new dependency (e.g. httpmock) to test `RelayAdminClient`, a small in-process axum server standing in for the relay's admin API (axum is already a dependency) is spun up on an OS-assigned ephemeral port:
- `set_block_merging_toggles_and_status_reflects_it`: exercises the client's URL/method construction and status-field parsing end to end against the fake relay.

The handler/route wiring itself is a one-line proxy call, same as its untested siblings, so no new test pattern was introduced there -- consistent with existing precedent in this crate.

Frontend: `tsc --noEmit` and `vite build` both pass; this crate has no eslint config to run.

Blob resolution fix: two regression tests added in `crates/relay/src/block_merging/mod.rs`, written first against the current (buggy) code and confirmed failing before the fix:
- `merged_block_to_response_includes_base_blocks_own_blob_tx` -- reproduces the RELAY-FR scenario exactly (base block has a blob tx, `appended_blobs` empty).
- `merged_block_to_response_includes_both_base_and_appended_blobs` -- base and merge-builder-appended blobs must both survive resolution.

Beacon-root and fee-recipient/gas-limit fixes: regression tests added in `crates/relay/src/block_merging/tile.rs` against the extracted `merged_validation_request`, each written first and confirmed failing before its fix:
- `merged_validation_request_none_when_attrs_missing` -- reproduces the beacon-root RELAY-FR scenario (no cached attrs for the merged block's parent hash).
- `merged_validation_request_none_when_fee_recipient_missing` / `merged_validation_request_none_when_gas_limit_missing` -- reproduce the payment-verification RELAY-FR scenario.
- `merged_validation_request_uses_known_slot_fields` -- correct-path coverage when all three fields are known.

`just fmt-check`, `cargo clippy --all-features --no-deps -- -D warnings`, and `just test` (full workspace, Postgres-backed) all pass.

## Reviewer checklist
- [ ] CI (`lint`, `unit-test`) is green
- [ ] Matches the linked issue/step
- [ ] No unexplained scope creep or unrelated files touched


