### PR TITLE
Serve real Gloas bids and envelopes from the auctioneer's existing submissions

### DIFF
--- a/crates/relay/src/api/proposer/mod.rs
+++ b/crates/relay/src/api/proposer/mod.rs
@@ -19,7 +19,7 @@ use helix_common::{
 use helix_database::handle::DbHandle;
 use helix_operator::OperatorPubSub;
 use hyper::StatusCode;
-pub use submit_signed_beacon_block::{GloasBuilderIdentity, GloasPayloadStore, NoHeldPayloads};
+pub use submit_signed_beacon_block::{GloasBuilderIdentity, HeldGloasPayload};
 
 use crate::{
     api::{Api, router::Terminating},
@@ -46,7 +46,6 @@ pub struct ProposerApi<A: Api> {
     pub reg_handle: RegWorkerHandle,
     pub operator_api: Option<Arc<OperatorPubSub>>,
     pub gloas_builder_identity: Arc<GloasBuilderIdentity>,
-    pub gloas_payload_store: Arc<dyn GloasPayloadStore>,
 }
 
 impl<A: Api> ProposerApi<A> {
@@ -65,7 +64,6 @@ impl<A: Api> ProposerApi<A> {
         reg_handle: RegWorkerHandle,
         alert_manager: Arc<AlertManager>,
         operator_api: Option<Arc<OperatorPubSub>>,
-        gloas_payload_store: Arc<dyn GloasPayloadStore>,
     ) -> Self {
         let gloas_builder_identity = Arc::new(GloasBuilderIdentity {
             builder_index: relay_config.gloas_builder_index,
@@ -87,7 +85,6 @@ impl<A: Api> ProposerApi<A> {
             reg_handle,
             operator_api,
             gloas_builder_identity,
-            gloas_payload_store,
         }
     }
 }

--- a/crates/relay/src/api/proposer/submit_signed_beacon_block.rs
+++ b/crates/relay/src/api/proposer/submit_signed_beacon_block.rs
@@ -10,7 +10,7 @@ use helix_types::{
 };
 use hyper::StatusCode;
 use ssz::Decode;
-use tracing::info;
+use tracing::{info, warn};
 use tree_hash::TreeHash;
 
 use super::{ProposerApi, get_payload::fork_name_from_header};
@@ -20,22 +20,6 @@ use crate::api::{Api, proposer::error::ProposerApiError};
 pub struct HeldGloasPayload {
     pub payload: ExecutionPayloadGloas,
     pub execution_requests: ExecutionRequestsGloas,
-}
-
-/// Looks up and consumes the payload held for a bid's committed block hash. Must not return
-/// the same payload twice.
-pub trait GloasPayloadStore: Send + Sync {
-    fn take_held_payload(&self, block_hash: B256) -> Option<HeldGloasPayload>;
-}
-
-/// Placeholder `GloasPayloadStore`: nothing has held a payload yet.
-// TODO(gloas): implement against the auctioneer; see gattaca-com/helix#489 step 3.
-pub struct NoHeldPayloads;
-
-impl GloasPayloadStore for NoHeldPayloads {
-    fn take_held_payload(&self, _block_hash: B256) -> Option<HeldGloasPayload> {
-        None
-    }
 }
 
 /// Helix's own on-chain Gloas builder identity: `builder_index` plus signing key.
@@ -64,12 +48,31 @@ impl GloasBuilderIdentity {
         let signature = self.keypair.sk.sign(message.signing_root(domain));
         SignedExecutionPayloadEnvelope { message, signature }
     }
+
+    /// Signs a `SignedExecutionPayloadBid` under the same domain as `sign_envelope`.
+    pub fn sign_bid(
+        &self,
+        message: helix_types::ExecutionPayloadBid,
+        chain_info: &ChainInfo,
+    ) -> helix_types::SignedExecutionPayloadBid {
+        let epoch = message.slot.epoch(MainnetEthSpec::slots_per_epoch());
+        let fork = chain_info.spec.fork_at_epoch(epoch);
+        let domain = chain_info.spec.get_domain(
+            epoch,
+            Domain::BeaconBuilder,
+            &fork,
+            chain_info.genesis_validators_root,
+        );
+        let signature = self.keypair.sk.sign(message.signing_root(domain));
+        helix_types::SignedExecutionPayloadBid { message, signature }
+    }
 }
 
 /// Constructs and signs the `SignedExecutionPayloadEnvelope` fulfilling `block`'s committed bid.
+/// `held` is the payload the auctioneer has stored for the bid's committed block hash, if any.
 pub(super) fn construct_signed_envelope(
     block: &SignedBeaconBlockGloas,
-    store: &dyn GloasPayloadStore,
+    held: Option<HeldGloasPayload>,
     identity: &GloasBuilderIdentity,
     chain_info: &ChainInfo,
 ) -> Result<SignedExecutionPayloadEnvelope, ProposerApiError> {
@@ -83,9 +86,7 @@ pub(super) fn construct_signed_envelope(
         });
     }
 
-    let held = store
-        .take_held_payload(bid_block_hash)
-        .ok_or(ProposerApiError::NoHeldPayloadForBlock(bid_block_hash))?;
+    let held = held.ok_or(ProposerApiError::NoHeldPayloadForBlock(bid_block_hash))?;
 
     let held_block_hash: B256 = held.payload.block_hash.0;
     if held_block_hash != bid_block_hash {
@@ -128,9 +129,25 @@ impl<A: Api> ProposerApi<A> {
 
         info!(slot = block.message.slot.as_u64(), "accepted submitSignedBeaconBlock request");
 
+        let bid_block_hash: B256 =
+            block.message.body.signed_execution_payload_bid.message.block_hash.0;
+        let Ok(rx) = proposer_api
+            .auctioneer_handle
+            .take_held_gloas_payload(bid_block_hash, block.message.slot)
+        else {
+            return Err(ProposerApiError::InternalServerError);
+        };
+        let held = match rx.await {
+            Ok(held) => held,
+            Err(err) => {
+                warn!(%err, "failed to fetch held Gloas payload from auctioneer");
+                return Err(ProposerApiError::InternalServerError);
+            }
+        };
+
         let signed_envelope = construct_signed_envelope(
             &block,
-            proposer_api.gloas_payload_store.as_ref(),
+            held,
             &proposer_api.gloas_builder_identity,
             &proposer_api.chain_info,
         )?;
@@ -146,30 +163,10 @@ impl<A: Api> ProposerApi<A> {
 
 #[cfg(test)]
 mod construct_signed_envelope_tests {
-    use std::sync::Mutex;
-
     use helix_common::utils::install_default_crypto_provider;
     use helix_types::{BeaconBlockGloas, BlsSignature, EmptyBlock, ExecutionBlockHash};
 
     use super::*;
-
-    struct StubStore(Mutex<Option<HeldGloasPayload>>);
-
-    impl StubStore {
-        fn holding(payload: HeldGloasPayload) -> Self {
-            Self(Mutex::new(Some(payload)))
-        }
-
-        fn empty() -> Self {
-            Self(Mutex::new(None))
-        }
-    }
-
-    impl GloasPayloadStore for StubStore {
-        fn take_held_payload(&self, _block_hash: B256) -> Option<HeldGloasPayload> {
-            self.0.lock().unwrap().take()
-        }
-    }
 
     fn held_payload(block_hash: B256) -> HeldGloasPayload {
         let mut payload = ExecutionPayloadGloas::default();
@@ -202,11 +199,11 @@ mod construct_signed_envelope_tests {
         let block_hash = B256::repeat_byte(0x11);
         let parent_root = B256::repeat_byte(0x22);
         let block = test_block(block_hash, 7, parent_root);
-        let store = StubStore::holding(held_payload(block_hash));
+        let held = Some(held_payload(block_hash));
         let identity = identity(7);
 
         let signed_envelope =
-            construct_signed_envelope(&block, &store, &identity, &chain_info).unwrap();
+            construct_signed_envelope(&block, held, &identity, &chain_info).unwrap();
 
         assert_eq!(signed_envelope.message.builder_index, 7);
         assert_eq!(signed_envelope.message.beacon_block_root, block.message.tree_hash_root());
@@ -219,11 +216,11 @@ mod construct_signed_envelope_tests {
         let chain_info = ChainInfo::default();
         let block_hash = B256::repeat_byte(0x33);
         let block = test_block(block_hash, 3, B256::ZERO);
-        let store = StubStore::holding(held_payload(block_hash));
+        let held = Some(held_payload(block_hash));
         let identity = identity(3);
 
         let signed_envelope =
-            construct_signed_envelope(&block, &store, &identity, &chain_info).unwrap();
+            construct_signed_envelope(&block, held, &identity, &chain_info).unwrap();
 
         let epoch = signed_envelope.message.slot().epoch(MainnetEthSpec::slots_per_epoch());
         let fork = chain_info.spec.fork_at_epoch(epoch);
@@ -240,10 +237,9 @@ mod construct_signed_envelope_tests {
         let chain_info = ChainInfo::default();
         let block_hash = B256::repeat_byte(0x44);
         let block = test_block(block_hash, 1, B256::ZERO);
-        let store = StubStore::empty();
         let identity = identity(1);
 
-        let result = construct_signed_envelope(&block, &store, &identity, &chain_info);
+        let result = construct_signed_envelope(&block, None, &identity, &chain_info);
 
         assert!(
             matches!(result, Err(ProposerApiError::NoHeldPayloadForBlock(hash)) if hash == block_hash)
@@ -256,10 +252,10 @@ mod construct_signed_envelope_tests {
         let bid_block_hash = B256::repeat_byte(0x55);
         let wrong_held_hash = B256::repeat_byte(0x66);
         let block = test_block(bid_block_hash, 1, B256::ZERO);
-        let store = StubStore::holding(held_payload(wrong_held_hash));
+        let held = Some(held_payload(wrong_held_hash));
         let identity = identity(1);
 
-        let result = construct_signed_envelope(&block, &store, &identity, &chain_info);
+        let result = construct_signed_envelope(&block, held, &identity, &chain_info);
 
         assert!(matches!(
             result,
@@ -273,10 +269,10 @@ mod construct_signed_envelope_tests {
         let chain_info = ChainInfo::default();
         let block_hash = B256::repeat_byte(0x77);
         let block = test_block(block_hash, 9, B256::ZERO);
-        let store = StubStore::holding(held_payload(block_hash));
+        let held = Some(held_payload(block_hash));
         let identity = identity(1);
 
-        let result = construct_signed_envelope(&block, &store, &identity, &chain_info);
+        let result = construct_signed_envelope(&block, held, &identity, &chain_info);
 
         assert!(matches!(
             result,

--- a/crates/relay/src/api/service.rs
+++ b/crates/relay/src/api/service.rs
@@ -26,11 +26,8 @@ use tracing::{error, info};
 use crate::{
     AuctioneerHandle, DbHandle, PostgresDatabaseService, RegWorkerHandle,
     api::{
-        Api, FutureBidSubmissionResult,
-        builder::api::BuilderApi,
-        extract::raw_web_socket::RawWebSocket,
-        proposer::{NoHeldPayloads, ProposerApi},
-        router::build_router,
+        Api, FutureBidSubmissionResult, builder::api::BuilderApi,
+        extract::raw_web_socket::RawWebSocket, proposer::ProposerApi, router::build_router,
     },
     gossip::{GossipedMessage, GrpcGossiperClientManager, process_gossip_messages},
     network::api::RelayNetworkApi,
@@ -154,7 +151,6 @@ pub async fn run_api_service<A: Api>(
         registrations_handle,
         alert_manager,
         operator_api,
-        Arc::new(NoHeldPayloads),
     ));
 
     tokio::spawn(process_gossip_messages(

--- a/crates/relay/src/auctioneer/context.rs
+++ b/crates/relay/src/auctioneer/context.rs
@@ -30,7 +30,9 @@ use tracing::{debug, info, warn};
 
 use crate::{
     SubmissionDataWithSpan,
-    api::{FutureBidSubmissionResult, builder::error::BuilderApiError},
+    api::{
+        FutureBidSubmissionResult, builder::error::BuilderApiError, proposer::GloasBuilderIdentity,
+    },
     auctioneer::{
         AuctioneerHandle, BlockMergeResponse,
         bid_adjustor::BidAdjustor,
@@ -77,6 +79,7 @@ pub struct Context<B: BidAdjustor> {
     pub alert_manager: Arc<AlertManager>,
     pub operator_api: Option<Arc<OperatorPubSub>>,
     pub builder_preferences: BuilderPreferencesStore,
+    pub gloas_builder_identity: Arc<GloasBuilderIdentity>,
 }
 
 const EXPECTED_PAYLOADS_PER_SLOT: usize = 5000;
@@ -100,6 +103,7 @@ impl<B: BidAdjustor> Context<B> {
         auctioneer_handle: AuctioneerHandle,
         alert_manager: Arc<AlertManager>,
         operator_api: Option<Arc<OperatorPubSub>>,
+        gloas_builder_identity: Arc<GloasBuilderIdentity>,
     ) -> Self {
         let unknown_builder_info = BuilderInfo {
             collateral: U256::ZERO,
@@ -146,6 +150,7 @@ impl<B: BidAdjustor> Context<B> {
             alert_manager,
             operator_api,
             builder_preferences: BuilderPreferencesStore::default(),
+            gloas_builder_identity,
         }
     }
 

--- a/crates/relay/src/auctioneer/get_execution_payload_bid.rs
+++ b/crates/relay/src/auctioneer/get_execution_payload_bid.rs
@@ -1,13 +1,18 @@
-use helix_common::api::proposer_api::GetExecutionPayloadBidParams;
+use helix_common::{api::proposer_api::GetExecutionPayloadBidParams, chain_info::ChainInfo};
+use helix_types::{
+    ExecutionBlockHash, ExecutionPayloadBid, SignedExecutionPayloadBid, Slot,
+    convert_kzg_commitments_to_progressive, execution_requests_to_gloas,
+};
 use tokio::sync::oneshot;
 use tracing::warn;
+use tree_hash::TreeHash;
 
 use crate::{
-    api::proposer::ProposerApiError,
+    api::proposer::{GloasBuilderIdentity, ProposerApiError},
     auctioneer::{
         bid_adjustor::BidAdjustor,
         context::Context,
-        types::{GetExecutionPayloadBidResult, SlotData},
+        types::{GetExecutionPayloadBidResult, PayloadEntry, SlotData},
     },
 };
 
@@ -18,17 +23,24 @@ impl<B: BidAdjustor> Context<B> {
         slot_data: &SlotData,
         res_tx: oneshot::Sender<GetExecutionPayloadBidResult>,
     ) {
-        let _ = res_tx.send(get_execution_payload_bid(&params, slot_data));
+        let result = check_execution_payload_bid_liveness(&params, slot_data).and_then(|()| {
+            let best_block_hash = self
+                .bid_sorter
+                .get_header(&params.parent_hash)
+                .ok_or(ProposerApiError::NoBidPrepared)?;
+            let entry =
+                self.payloads.get(&best_block_hash).ok_or(ProposerApiError::NoBidPrepared)?;
+            build_signed_bid(entry, &params, &self.gloas_builder_identity, &self.chain_info)
+        });
+        let _ = res_tx.send(result);
     }
 }
 
-/// Checks `params.parent_hash`/`params.parent_root` against currently-live payload attributes,
-/// then reports "no bid available" -- serving a real Gloas bid needs step 5's builder->relay
-/// submission wire format, not landed yet.
-pub(super) fn get_execution_payload_bid(
+/// Checks `params.parent_hash`/`params.parent_root` against currently-live payload attributes.
+pub(super) fn check_execution_payload_bid_liveness(
     params: &GetExecutionPayloadBidParams,
     slot_data: &SlotData,
-) -> GetExecutionPayloadBidResult {
+) -> Result<(), ProposerApiError> {
     let Some(attrs) = slot_data.payload_attributes_map.get(&params.parent_hash) else {
         warn!(
             req =% params.parent_hash,
@@ -47,14 +59,56 @@ pub(super) fn get_execution_payload_bid(
         return Err(ProposerApiError::NoBidPrepared);
     }
 
-    Err(ProposerApiError::NoBidPrepared)
+    Ok(())
+}
+
+/// Builds and signs the `SignedExecutionPayloadBid` for the winning submission held in `entry`,
+/// under helix's own configured Gloas builder identity.
+pub(super) fn build_signed_bid(
+    entry: &PayloadEntry,
+    params: &GetExecutionPayloadBidParams,
+    identity: &GloasBuilderIdentity,
+    chain_info: &ChainInfo,
+) -> Result<SignedExecutionPayloadBid, ProposerApiError> {
+    let slot = Slot::new(params.slot);
+
+    let payload = entry.execution_payload().to_lighthouse_gloas_payload(slot).map_err(|err| {
+        warn!(%err, block_hash =% entry.block_hash(), "failed to convert held payload to Gloas shape for bid");
+        ProposerApiError::InternalServerError
+    })?;
+
+    let execution_requests = execution_requests_to_gloas(entry.bid_data_ref().execution_requests);
+    let execution_requests_root = execution_requests.tree_hash_root();
+
+    // Per gattaca-com/helix#489: no payment-split product need yet, so execution_payment = value.
+    let value = entry.value().saturating_to::<u64>();
+
+    let bid = ExecutionPayloadBid {
+        parent_block_hash: ExecutionBlockHash(params.parent_hash),
+        parent_block_root: params.parent_root,
+        block_hash: ExecutionBlockHash(*entry.block_hash()),
+        prev_randao: payload.prev_randao,
+        fee_recipient: payload.fee_recipient,
+        gas_limit: payload.gas_limit,
+        builder_index: identity.builder_index,
+        slot,
+        value,
+        execution_payment: value,
+        blob_kzg_commitments: convert_kzg_commitments_to_progressive(
+            &entry.payload_and_blobs().blobs_bundle.commitments,
+        ),
+        execution_requests_root,
+        _phantom: std::marker::PhantomData,
+    };
+
+    Ok(identity.sign_bid(bid, chain_info))
 }
 
 #[cfg(test)]
 mod tests {
     use alloy_primitives::B256;
     use helix_common::PayloadAttributesUpdate;
-    use helix_types::ForkName;
+    use helix_types::{Domain, EthSpec, ForkName, SignedRoot, TestRandomSeed};
     use rustc_hash::FxHashMap;
 
     use super::*;
@@ -98,7 +152,7 @@ mod tests {
         let parent_root = B256::repeat_byte(0x22);
         let data = slot_data(FxHashMap::default());
 
-        let result = get_execution_payload_bid(&params(parent_hash, parent_root), &data);
+        let result = check_execution_payload_bid_liveness(&params(parent_hash, parent_root), &data);
 
         assert!(matches!(result, Err(ProposerApiError::NoBidPrepared)));
     }
@@ -112,7 +166,8 @@ mod tests {
         map.insert(parent_hash, attrs_update(parent_hash, Some(live_root)));
         let data = slot_data(map);
 
-        let result = get_execution_payload_bid(&params(parent_hash, requested_root), &data);
+        let result =
+            check_execution_payload_bid_liveness(&params(parent_hash, requested_root), &data);
 
         assert!(matches!(result, Err(ProposerApiError::NoBidPrepared)));
     }
@@ -125,21 +180,85 @@ mod tests {
         map.insert(parent_hash, attrs_update(parent_hash, None));
         let data = slot_data(map);
 
-        let result = get_execution_payload_bid(&params(parent_hash, requested_root), &data);
+        let result =
+            check_execution_payload_bid_liveness(&params(parent_hash, requested_root), &data);
 
         assert!(matches!(result, Err(ProposerApiError::NoBidPrepared)));
     }
 
     #[test]
-    fn matching_parent_still_reports_no_bid_until_step_5() {
+    fn matching_parent_passes_liveness_check() {
         let parent_hash = B256::repeat_byte(0x11);
         let parent_root = B256::repeat_byte(0x22);
         let mut map = FxHashMap::default();
         map.insert(parent_hash, attrs_update(parent_hash, Some(parent_root)));
         let data = slot_data(map);
 
-        let result = get_execution_payload_bid(&params(parent_hash, parent_root), &data);
+        let result = check_execution_payload_bid_liveness(&params(parent_hash, parent_root), &data);
 
-        assert!(matches!(result, Err(ProposerApiError::NoBidPrepared)));
+        assert!(result.is_ok());
+    }
+
+    fn payload_entry(block_hash: B256, value: u64) -> PayloadEntry {
+        use std::sync::Arc;
+
+        use alloy_primitives::U256;
+        use helix_types::{BlobsBundle, ExecutionPayload, ExecutionRequests, PayloadAndBlobs};
+
+        let mut payload = ExecutionPayload::test_random();
+        payload.block_hash = block_hash;
+
+        PayloadEntry::new_gossip(
+            PayloadAndBlobs {
+                execution_payload: Arc::new(payload),
+                blobs_bundle: Arc::new(BlobsBundle::default()),
+            },
+            helix_types::PayloadBidData {
+                withdrawals_root: B256::ZERO,
+                tx_root: None,
+                execution_requests: Arc::new(ExecutionRequests::default()),
+                value: U256::from(value),
+                builder_pubkey: Default::default(),
+            },
+        )
+    }
+
+    fn bid_identity(builder_index: u64) -> GloasBuilderIdentity {
+        helix_common::utils::install_default_crypto_provider();
+        GloasBuilderIdentity { builder_index, keypair: helix_types::BlsKeypair::random() }
+    }
+
+    #[test]
+    fn build_signed_bid_uses_the_entrys_data_and_configured_identity() {
+        let chain_info = ChainInfo::default();
+        let block_hash = B256::repeat_byte(0x99);
+        let parent_hash = B256::repeat_byte(0x11);
+        let parent_root = B256::repeat_byte(0x22);
+        let entry = payload_entry(block_hash, 42);
+        let identity = bid_identity(7);
+        let params = params(parent_hash, parent_root);
+
+        let signed_bid = build_signed_bid(&entry, &params, &identity, &chain_info).unwrap();
+
+        assert_eq!(signed_bid.message.block_hash.0, block_hash);
+        assert_eq!(signed_bid.message.parent_block_hash.0, parent_hash);
+        assert_eq!(signed_bid.message.parent_block_root, parent_root);
+        assert_eq!(signed_bid.message.builder_index, 7);
+        assert_eq!(signed_bid.message.value, 42);
+        assert_eq!(signed_bid.message.execution_payment, 42);
+
+        let epoch = signed_bid.message.slot.epoch(helix_types::MainnetEthSpec::slots_per_epoch());
+        let fork = chain_info.spec.fork_at_epoch(epoch);
+        let domain = chain_info.spec.get_domain(
+            epoch,
+            Domain::BeaconBuilder,
+            &fork,
+            chain_info.genesis_validators_root,
+        );
+        assert!(
+            signed_bid
+                .signature
+                .verify(&identity.keypair.pk, signed_bid.message.signing_root(domain))
+        );
     }
 }

--- a/crates/relay/src/auctioneer/gloas_payload.rs
+++ b/crates/relay/src/auctioneer/gloas_payload.rs
@@ -1,0 +1,35 @@
+use alloy_primitives::B256;
+use helix_types::{Slot, execution_requests_to_gloas};
+use tokio::sync::oneshot;
+use tracing::warn;
+
+use crate::{
+    api::proposer::HeldGloasPayload,
+    auctioneer::{bid_adjustor::BidAdjustor, context::Context},
+};
+
+impl<B: BidAdjustor> Context<B> {
+    /// Looks up the payload a submission held for `block_hash`, converting it to the real Gloas
+    /// consensus shape for `submitSignedBeaconBlock`'s envelope construction.
+    pub(super) fn handle_take_held_gloas_payload(
+        &self,
+        block_hash: B256,
+        slot: Slot,
+        res_tx: oneshot::Sender<Option<HeldGloasPayload>>,
+    ) {
+        let held = self.payloads.get(&block_hash).and_then(|entry| {
+            let payload = match entry.execution_payload().to_lighthouse_gloas_payload(slot) {
+                Ok(payload) => payload,
+                Err(err) => {
+                    warn!(%block_hash, %err, "failed to convert held payload to Gloas shape");
+                    return None;
+                }
+            };
+            let execution_requests =
+                execution_requests_to_gloas(entry.bid_data_ref().execution_requests);
+            Some(HeldGloasPayload { payload, execution_requests })
+        });
+
+        let _ = res_tx.send(held);
+    }
+}

--- a/crates/relay/src/auctioneer/handle.rs
+++ b/crates/relay/src/auctioneer/handle.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use alloy_primitives::B256;
 use dashmap::DashMap;
 use futures::{FutureExt, future::Shared};
 use helix_common::{
@@ -9,13 +10,13 @@ use helix_common::{
 };
 use helix_types::{
     BlsPublicKey, BlsPublicKeyBytes, ExecPayload, GetPayloadResponse, SigError,
-    SignedBlindedBeaconBlock,
+    SignedBlindedBeaconBlock, Slot,
 };
 use tokio::sync::oneshot::{self, Receiver};
 use tracing::trace;
 
 use crate::{
-    api::proposer::{ProposerApiError, get_payload::ProposerApiVersion},
+    api::proposer::{HeldGloasPayload, ProposerApiError, get_payload::ProposerApiVersion},
     auctioneer::types::{
         Event, GetExecutionPayloadBidResult, GetHeaderResult, GetPayloadResult,
         SubmitBuilderPreferencesResult,
@@ -103,6 +104,19 @@ impl AuctioneerHandle {
                 max_execution_payment,
                 res_tx: tx,
             })
+            .map_err(|_| ChannelFull)?;
+        Ok(rx)
+    }
+
+    pub fn take_held_gloas_payload(
+        &self,
+        block_hash: B256,
+        slot: Slot,
+    ) -> Result<oneshot::Receiver<Option<HeldGloasPayload>>, ChannelFull> {
+        let (tx, rx) = oneshot::channel();
+        trace!("sending to auctioneer");
+        self.auctioneer
+            .try_send(Event::TakeHeldGloasPayload { block_hash, slot, res_tx: tx })
             .map_err(|_| ChannelFull)?;
         Ok(rx)
     }

--- a/crates/relay/src/auctioneer/mod.rs
+++ b/crates/relay/src/auctioneer/mod.rs
@@ -6,6 +6,7 @@ mod context;
 mod get_execution_payload_bid;
 mod get_header;
 mod get_payload;
+mod gloas_payload;
 mod handle;
 mod submit_block;
 mod types;
@@ -42,7 +43,11 @@ pub use types::{
 
 use crate::{
     HelixSpine, SubmissionDataWithSpan,
-    api::{FutureBidSubmissionResult, builder::error::BuilderApiError, proposer::ProposerApiError},
+    api::{
+        FutureBidSubmissionResult,
+        builder::error::BuilderApiError,
+        proposer::{GloasBuilderIdentity, ProposerApiError},
+    },
     auctioneer::types::PendingPayload,
     housekeeper::SlotUpdate,
     simulator::{SimRequest, SimResult},
@@ -93,6 +98,7 @@ impl<B: BidAdjustor> Auctioneer<B> {
         merged_blocks: Arc<SharedVector<BlockMergeResponse>>,
         alert_manager: Arc<AlertManager>,
         operator_api: Option<Arc<OperatorPubSub>>,
+        gloas_builder_identity: Arc<GloasBuilderIdentity>,
     ) -> Self {
         let ctx = Context::new(
             chain_info,
@@ -109,6 +115,7 @@ impl<B: BidAdjustor> Auctioneer<B> {
             auctioneer_handle,
             alert_manager,
             operator_api,
+            gloas_builder_identity,
         );
         Self {
             ctx,
@@ -686,6 +693,15 @@ impl State {
                     ctx.builder_preferences.store(proposer_pubkey, slot, max_execution_payment);
                     let _ = res_tx.send(Ok(()));
                 }
+            }
+
+            // take_held_gloas_payload (Gloas), valid regardless of state -- payloads are
+            // block-hash-keyed, so a lookup after the slot has moved on just misses.
+            (
+                State::Slot { .. } | State::Sorting(_) | State::Broadcasting { .. },
+                Event::TakeHeldGloasPayload { block_hash, slot, res_tx },
+            ) => {
+                ctx.handle_take_held_gloas_payload(block_hash, slot, res_tx);
             }
         }
     }

--- a/crates/relay/src/auctioneer/types.rs
+++ b/crates/relay/src/auctioneer/types.rs
@@ -31,7 +31,8 @@ use crate::{
     SubmissionDataWithSpan,
     api::{
         HEADER_API_KEY, HEADER_API_TOKEN, HEADER_HYDRATE, HEADER_IS_MERGEABLE, HEADER_MERGE_TYPE,
-        HEADER_PESSIMISTIC, HEADER_SEQUENCE, HEADER_WITH_ADJUSTMENTS, proposer::ProposerApiError,
+        HEADER_PESSIMISTIC, HEADER_SEQUENCE, HEADER_WITH_ADJUSTMENTS,
+        proposer::{HeldGloasPayload, ProposerApiError},
     },
     auctioneer::MergeResult,
     gossip::BroadcastPayloadParams,
@@ -450,6 +451,13 @@ pub enum Event {
         max_execution_payment: u64,
         res_tx: oneshot::Sender<SubmitBuilderPreferencesResult>,
     },
+    /// Looks up the execution payload a submission held for `block_hash`, so
+    /// `submitSignedBeaconBlock` can build the envelope fulfilling a proposer's committed bid.
+    TakeHeldGloasPayload {
+        block_hash: B256,
+        slot: Slot,
+        res_tx: oneshot::Sender<Option<HeldGloasPayload>>,
+    },
     // Receive multiple of these potentially, assume some light validation
     GetPayload {
         block_hash: B256,
@@ -477,6 +485,7 @@ impl Event {
             Event::GetHeader { .. } => "GetHeader",
             Event::GetExecutionPayloadBid { .. } => "GetExecutionPayloadBid",
             Event::SubmitBuilderPreferences { .. } => "SubmitBuilderPreferences",
+            Event::TakeHeldGloasPayload { .. } => "TakeHeldGloasPayload",
             Event::GetPayload { .. } => "GetPayload",
             Event::GossipPayload(_) => "GossipPayload",
             Event::SimResult(_) => "SimResult",

--- a/crates/relay/src/lib.rs
+++ b/crates/relay/src/lib.rs
@@ -28,7 +28,7 @@ pub use crate::block_merging::{OrderTxs, find_unbundled_txs};
 pub use crate::{
     api::{
         Api, BidAdjustor, DefaultBidAdjustor, FutureBidSubmissionResult, builder::TopBidTile,
-        start_admin_service, start_api_service,
+        proposer::GloasBuilderIdentity, start_admin_service, start_api_service,
     },
     auctioneer::{
         Auctioneer, AuctioneerHandle, BidSorter, Context, Event, PayloadEntry, SimulatorClient,

--- a/crates/relay/src/main.rs
+++ b/crates/relay/src/main.rs
@@ -30,10 +30,11 @@ use helix_operator::spawn_operator_connection;
 use helix_relay::{
     Api, Auctioneer, AuctioneerHandle, BidSorter, BidSubmissionTcpListener, BlockMergeResponse,
     BlockMergingTile, BroadcastPayloadParams, DataGatherer, DbHandle, DecoderTile,
-    DefaultBidAdjustor, FutureBidSubmissionResult, GossipedMessage, HelixSpine, HelixSpineConfig,
-    HousekeeperTile, NewBidSubmission, RegWorkerHandle, RegistrationTile, RelayNetworkManager,
-    SimRequest, SimResult, SimulatorTile, SlotUpdate, SubmissionDataWithSpan, TopBidTile,
-    spawn_tokio_monitoring, start_admin_service, start_api_service, start_db_service,
+    DefaultBidAdjustor, FutureBidSubmissionResult, GloasBuilderIdentity, GossipedMessage,
+    HelixSpine, HelixSpineConfig, HousekeeperTile, NewBidSubmission, RegWorkerHandle,
+    RegistrationTile, RelayNetworkManager, SimRequest, SimResult, SimulatorTile, SlotUpdate,
+    SubmissionDataWithSpan, TopBidTile, spawn_tokio_monitoring, start_admin_service,
+    start_api_service, start_db_service,
 };
 use helix_types::BlsKeypair;
 use helix_website::WebsiteService;
@@ -240,7 +241,7 @@ async fn run(
             local_cache.clone(),
             current_slot_info,
             chain_info.clone(),
-            relay_signing_context,
+            relay_signing_context.clone(),
             beacon_client,
             Arc::new(DefaultApiProvider {}),
             known_validators_loaded,
@@ -367,6 +368,11 @@ async fn run(
                 );
             }
 
+            let gloas_builder_identity = Arc::new(GloasBuilderIdentity {
+                builder_index: config.gloas_builder_index,
+                keypair: relay_signing_context.keypair.clone(),
+            });
+
             let auctioneer_core = config.cores.auctioneer;
             let auctioneer = Auctioneer::new(
                 chain_info.as_ref().clone(),
@@ -388,6 +394,7 @@ async fn run(
                 merged_blocks,
                 alert_manager.clone(),
                 operator_api.clone(),
+                gloas_builder_identity,
             );
             attach_tile(
                 auctioneer,

--- a/crates/types/src/fields.rs
+++ b/crates/types/src/fields.rs
@@ -43,6 +43,13 @@ pub fn convert_transactions_to_progressive(
     )
 }
 
+/// Real, progressive-list Gloas KZG commitments shape, per EIP-7688.
+pub fn convert_kzg_commitments_to_progressive(
+    commitments: &KzgCommitments,
+) -> lh_types::ProgressiveKzgCommitments {
+    ProgressiveVariableList::new(commitments.iter().map(|c| lh_types::KzgCommitment(c.0)).collect())
+}
+
 /// Converts helix's Electra-shaped builder-submission execution requests into the real,
 /// progressive-list Gloas shape. `builder_deposits`/`builder_exits` are left empty --
 /// TODO(gloas): populate once EIP-8282 builder deposit/exit submission exists.
@@ -159,6 +166,22 @@ mod tests {
         assert_eq!(progressive.len(), txs.len());
         for (converted, original) in progressive.as_slice().iter().zip(txs.iter()) {
             assert_eq!(converted.as_slice(), original.as_ref());
+        }
+    }
+
+    #[test]
+    fn convert_kzg_commitments_to_progressive_preserves_bytes() {
+        let commitments = KzgCommitments::new(vec![
+            KzgCommitment::repeat_byte(0x11),
+            KzgCommitment::repeat_byte(0x22),
+        ])
+        .unwrap();
+
+        let progressive = convert_kzg_commitments_to_progressive(&commitments);
+
+        assert_eq!(progressive.len(), commitments.len());
+        for (converted, original) in progressive.as_slice().iter().zip(commitments.iter()) {
+            assert_eq!(converted.0, original.0);
         }
     }
 


### PR DESCRIPTION
Issue: #489 (step 6 of 6, per the reordering in #514)

## What this PR does
- `getExecutionPayloadBid` now builds and signs a real `SignedExecutionPayloadBid`:
  it reads the winning submission out of `ctx.payloads`/`bid_sorter` (the same
  map `get_header` already reads), converts it via the prior step's
  `to_lighthouse_gloas_payload`/`execution_requests_to_gloas`, and signs under
  helix's own configured `GloasBuilderIdentity` -- no longer a permanent
  `NoBidPrepared` stub.
- `submitSignedBeaconBlock`'s `GloasPayloadStore`/`NoHeldPayloads` placeholder is
  replaced by a real auctioneer round trip (`Event::TakeHeldGloasPayload`) that
  looks up the same payload by block hash and converts it for envelope
  construction.
- `GloasBuilderIdentity` is now constructed once in `main.rs` (from
  `config.gloas_builder_index` + the relay's signing keypair) and shared
  between the proposer API and the auctioneer, instead of being built
  separately inside `ProposerApi::new`.
- `execution_payment` is set equal to `value` (no payment-split product need
  yet -- see the resolved design note added to #489).

## What this PR deliberately does NOT do
- Does not enforce `submitBuilderPreferences`'s `max_execution_payment` against
  the served bid -- still a known follow-up, unrelated to this step.
- Does not add a new builder-facing HTTP endpoint -- external builders keep
  submitting via the existing `submit_block` pipeline exactly as before; this
  PR only changes what happens to the winning submission when Gloas serves it.

## Tests
Written before implementation, per this repo's workflow:
- `check_execution_payload_bid_liveness` keeps its 4 existing liveness tests
  (last one updated to expect `Ok(())` now that a real bid follows).
- New `build_signed_bid` test: constructs a `PayloadEntry`, builds+signs a bid,
  checks every field maps from the entry/params/identity correctly, and
  verifies the BLS signature against the configured identity.
- `construct_signed_envelope`'s 5 existing tests updated for the new
  `Option<HeldGloasPayload>` signature (same coverage, same assertions).

## Reviewer checklist
- [ ] CI (`lint`, `unit-test`) is green
- [ ] This PR matches the step it claims to be (see linked issue)
- [ ] Nothing surprising: no unexplained scope creep, no unrelated files
      touched, no obviously-wrong code the tests happen not to cover