### PR TITLE
Fix needless-borrow clippy lint in header_stream.rs

### DIFF
--- a/crates/relay/src/api/proposer/header_stream.rs
+++ b/crates/relay/src/api/proposer/header_stream.rs
@@ -64,7 +64,7 @@ impl<A: Api> ProposerApi<A> {
 
         proposer_api
             .api_provider
-            .admit_header_stream(&params, &headers, &preferences, &config)
+            .admit_header_stream(&params, &headers, &preferences, config)
             .map_err(|reason| {
                 warn!(slot = params.slot, proposer = %params.pubkey, reason, "refusing header stream");
                 ProposerApiError::StreamNotAdmitted


### PR DESCRIPTION
## What this PR does
\`cargo clippy --all-features --no-deps -- -D warnings\` -- the exact command this repo's workflow requires before any step is declared done -- currently fails on a clean \`develop\` checkout:

\`\`\`
error: this expression creates a reference which is immediately dereferenced by the compiler
  --> crates/relay/src/api/proposer/header_stream.rs:67:67
   | .admit_header_stream(&params, &headers, &preferences, &config)
   |                                                        ^^^^^^^ help: change this to: `config`
\`\`\`

\`config\` is already a reference (\`let config = &proposer_api.relay_config.header_stream;\`), so \`&config\` double-borrows. One-line fix.

## What this PR deliberately does NOT do
Nothing else -- found while verifying an unrelated change, unblocking clean clippy runs for everyone.

## Tests
No behavior change; existing \`header_stream\` tests still pass.

## Reviewer checklist
- [ ] CI (\`lint\`, \`unit-test\`) is green
- [ ] Nothing surprising