### PR TITLE
Stop mis-routing Gloas submissions to the Electra-shaped validation RPC

### DIFF
--- a/crates/common/src/simulator.rs
+++ b/crates/common/src/simulator.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use alloy_primitives::B256;
 use helix_types::{
-    BidTrace, BlobsBundle, BlsSignatureBytes, ExecutionPayload, ExecutionRequests,
+    BidTrace, BlobsBundle, BlsSignatureBytes, ExecutionPayload, ExecutionRequests, ForkName,
     SignedBidSubmission,
 };
 use ssz_derive::{Decode, Encode};
@@ -90,6 +90,11 @@ pub enum BlockSimError {
 
     #[error("hydration miss: simulator cache does not have required transactions/blobs")]
     HydrationMiss,
+
+    /// Not the builder's fault -- helix's own simulator client has no validation RPC method for
+    /// this fork yet.
+    #[error("no validation RPC method for fork {0}")]
+    UnsupportedFork(ForkName),
 }
 
 impl BlockSimError {
@@ -106,6 +111,7 @@ impl BlockSimError {
             BlockSimError::Timeout => true,
             BlockSimError::RpcError => true,
             BlockSimError::NoSimulatorAvailable => true,
+            BlockSimError::UnsupportedFork(_) => true,
             _ => false,
         }
     }

--- a/crates/common/src/simulator.rs
+++ b/crates/common/src/simulator.rs
@@ -92,7 +92,7 @@ pub enum BlockSimError {
     HydrationMiss,
 
     /// Not the builder's fault -- helix's own simulator client has no validation RPC method for
-    /// this fork yet.
+    /// this fork yet. See gattaca-com/helix#518.
     #[error("no validation RPC method for fork {0}")]
     UnsupportedFork(ForkName),
 }

--- a/crates/relay/src/simulator/client.rs
+++ b/crates/relay/src/simulator/client.rs
@@ -56,9 +56,17 @@ impl SimulatorClient {
         self.ssz_url.as_ref().map(|url| self.client.post(format!("{url}/validate")))
     }
 
-    pub fn sim_request_builder(&self, fork: ForkName) -> (RequestBuilder, &str) {
-        let method = if fork == ForkName::Fulu { &self.sim_method_v5 } else { &self.sim_method_v4 };
-        (self.client.post(&self.config.url), method)
+    /// Returns `None` for a fork this client has no validation RPC method for yet, rather than
+    /// silently mis-routing it to a method shaped for a different fork.
+    pub fn sim_request_builder(&self, fork: ForkName) -> Option<(RequestBuilder, &str)> {
+        let method = match fork {
+            ForkName::Fulu => &self.sim_method_v5,
+            ForkName::Bellatrix | ForkName::Capella | ForkName::Deneb | ForkName::Electra => {
+                &self.sim_method_v4
+            }
+            ForkName::Base | ForkName::Altair | ForkName::Gloas | ForkName::Heze => return None,
+        };
+        Some((self.client.post(&self.config.url), method))
     }
 
     pub async fn do_json_sim_request(
@@ -179,6 +187,37 @@ impl SimulatorClient {
 mod test {
     use alloy_primitives::hex::FromHex;
     use helix_common::SimulatorConfig;
+    use helix_types::ForkName;
+
+    use super::SimulatorClient;
+
+    fn sim_client() -> SimulatorClient {
+        SimulatorClient::new(reqwest::Client::new(), SimulatorConfig {
+            url: "http://localhost:8545".into(),
+            namespace: "relay".into(),
+            max_concurrent_tasks: 1,
+            ssz_url: None,
+        })
+    }
+
+    #[test]
+    fn routes_fulu_to_v5() {
+        let client = sim_client();
+        let (_, method) = client.sim_request_builder(ForkName::Fulu).unwrap();
+        assert!(method.ends_with("V5"));
+    }
+
+    #[test]
+    fn routes_electra_to_v4() {
+        let client = sim_client();
+        let (_, method) = client.sim_request_builder(ForkName::Electra).unwrap();
+        assert!(method.ends_with("V4"));
+    }
+
+    #[test]
+    fn gloas_has_no_validation_method_yet() {
+        assert!(sim_client().sim_request_builder(ForkName::Gloas).is_none());
+    }
 
     #[tokio::test]
     async fn balance_request() {

--- a/crates/relay/src/simulator/tile.rs
+++ b/crates/relay/src/simulator/tile.rs
@@ -324,7 +324,27 @@ impl SimulatorTile {
                 http: sim.client.client.clone(),
             }
         } else {
-            let (builder, method) = sim.client.sim_request_builder(submission.fork_name());
+            let fork = submission.fork_name();
+            let Some((builder, method)) = sim.client.sim_request_builder(fork) else {
+                warn!(%fork, "no validation RPC method for fork, dropping submission");
+                sim.pending += 1;
+                let result_ix = self.sim_results.push(SimResult::Validate((
+                    id,
+                    Some(SimulationResultInner {
+                        submission_ref: req.submission_ref,
+                        optimistic_version: req.optimistic_version(),
+                        bid: None,
+                        result: Err(BlockSimError::UnsupportedFork(fork)),
+                    }),
+                )));
+                let _ = self.task_tx.try_send(SimTileInternalEvent::TaskDone {
+                    id,
+                    paused_until: None,
+                    result_ix,
+                    elapsed: None,
+                });
+                return;
+            };
             SimDispatch::Json { to_send: builder, method: method.to_owned() }
         };
         sim.pending += 1;


### PR DESCRIPTION
## What this PR does
\`SimulatorClient::sim_request_builder\` picked the validation RPC method by fork:

\`\`\`rust
let method = if fork == ForkName::Fulu { &self.sim_method_v5 } else { &self.sim_method_v4 };
\`\`\`

Since #514 made \`submit_block\` able to decode Gloas-fork submissions (unrelated to this bug -- helix's own builder-submission wire shape didn't need to change for Gloas, so nothing stopped a Gloas submission reaching this point), a Gloas submission landing here would silently fall into the \`else\` branch and get validated via \`sim_method_v4\`, the Electra/Prague-shaped RPC. Wrong, and silent about it.

- \`sim_request_builder\` now returns \`Option<(RequestBuilder, &str)>\`, explicit about which forks it knows how to route (\`Fulu\` -> v5, \`Bellatrix\`/\`Capella\`/\`Deneb\`/\`Electra\` -> v4) and returning \`None\` for anything else (currently \`Gloas\`/\`Heze\`, plus the pre-merge forks that can't reach this path anyway).
- Added \`BlockSimError::UnsupportedFork\`, treated as temporary/non-demotable -- this is helix's own limitation, not the builder's fault.
- The one caller (\`SimulatorTile::spawn_sim\`) now reports that error and drops the submission instead of dispatching, mirroring the existing early-return pattern used for missing decoded data / hydration misses just above it.

## What this PR deliberately does NOT do
Does not add real Gloas validation support to \`helix-simulator\` -- that needs a Gloas-aware EL client (reth has no Amsterdam/ePBS support in its tagged release yet, only on a devnet branch) and a new \`validateBuilderSubmissionV6\` path. Tracked as its own issue.

## Tests
Written before implementation:
- \`routes_fulu_to_v5\`, \`routes_electra_to_v4\`: existing routing unchanged.
- \`gloas_has_no_validation_method_yet\`: the actual regression this PR closes.

## Reviewer checklist
- [ ] CI (\`lint\`, \`unit-test\`) is green
- [ ] Nothing surprising