### PR TITLE
Fix flaky/slow test_duration_into_slot

### DIFF
--- a/crates/types/src/clock.rs
+++ b/crates/types/src/clock.rs
@@ -18,22 +18,27 @@ pub fn duration_into_slot(clock: &SlotClock, slot: Slot) -> Option<Duration> {
 
 #[cfg(test)]
 mod tests {
-    use std::thread::sleep;
-
     use super::*;
 
+    /// `duration_into_slot` takes its own live `SystemTime::now()` reading, so it can't be
+    /// pinned to an exact expected value without mocking time. Instead this brackets it: the
+    /// result must fall between `now - slot_start` measured just before and just after the
+    /// call, which holds by construction regardless of scheduling delays — unlike comparing two
+    /// independent live clock reads against a fixed tolerance, which is exactly what made the
+    /// old version of this test flaky under parallel test-thread contention.
     #[test]
     fn test_duration_into_slot() {
         let clock = new_slot_clock(MAINNET_GENESIS_TIME, Duration::from_secs(12));
+        let slot = clock.now().unwrap();
+        let slot_start = clock.start_of(slot).unwrap();
 
-        for _ in 0..100 {
-            let slot = clock.now().unwrap();
-            let dur_1 = clock.millis_from_current_slot_start().unwrap().as_nanos() as i128;
-            let dur_2 = duration_into_slot(&clock, slot).unwrap().as_nanos() as i128;
-            let delta = dur_1 - dur_2;
-            assert!(delta.abs() < 1_000_000, "clock delta above 1ms: {delta}");
+        let before = SystemTime::now().duration_since(UNIX_EPOCH).unwrap() - slot_start;
+        let actual = duration_into_slot(&clock, slot).unwrap();
+        let after = SystemTime::now().duration_since(UNIX_EPOCH).unwrap() - slot_start;
 
-            sleep(Duration::from_millis(10));
-        }
+        assert!(
+            actual >= before && actual <= after,
+            "duration {actual:?} not within [{before:?}, {after:?}]"
+        );
     }
 }


### PR DESCRIPTION
Issue: #521 (step 1 of 1)

## What this PR does
`helix-types::clock::tests::test_duration_into_slot` compared two independent live `SystemTime::now()` reads against a 1ms tolerance, looped 100 times with a 10ms sleep each — flaky under CI's parallel test-thread contention and slow (1s+ minimum runtime). Replaces it with a bracketing assertion around the single call under test: capture `now` just before and after, and assert the result falls in between. Deterministic by construction, no sleep, single iteration.

## What this PR deliberately does not do
Doesn't touch `duration_into_slot` itself or any other clock code — this is a test-only fix.

## Tests
The fix is the test change itself. Ran it 30x standalone and 5x as part of the full `helix-types` suite; passes every time in ~0.00-0.01s (previously ~1s+ and occasionally failing).

`just fmt-check` passes. `cargo clippy -p helix-types --all-features --no-deps -- -D warnings` has 4 pre-existing failures unrelated to this file (confirmed identical with/without this change, e.g. `bid_adjustment_data.rs`, `bid_submission.rs`) — not introduced or touched by this PR.

## Reviewer checklist
- [ ] CI (`lint`, `unit-test`) is green
- [ ] Matches the linked issue/step
- [ ] No unexplained scope creep or unrelated files touched