### PR TITLE
Re-arm ChainHead to send a corrective SlotUpdate on late data

### DIFF
--- a/crates/relay/src/housekeeper/chain_head.rs
+++ b/crates/relay/src/housekeeper/chain_head.rs
@@ -24,6 +24,12 @@ pub struct ChainHead {
     payload_attributes_done: bool,
     duties_done: bool,
     inclusion_list_done: bool,
+    /// Whether duties/payload-attributes/inclusion-list were all done at the moment
+    /// of the last `sent()` call. `false` means that send went out incomplete (the
+    /// deadline fired first), so `is_ready()` re-arms once the picture completes,
+    /// letting a corrective `SlotUpdate` go out instead of losing late-arriving data
+    /// for this slot.
+    sent_was_complete: bool,
 }
 
 // let epoch = self.chain_head.slot.epoch(self.chain_info.slots_per_epoch());
@@ -48,6 +54,7 @@ impl ChainHead {
             duties_done: false,
             payload_attributes_done: false,
             inclusion_list_done: false,
+            sent_was_complete: false,
             chain_info,
         }
     }
@@ -78,7 +85,14 @@ impl ChainHead {
                         self.payload_attributes_done &&
                         self.inclusion_list_done)
             }
-            ChainHeadState::Sent => false,
+            // Already sent: only re-ready for a corrective send if the original went
+            // out incomplete and the picture has since become fully complete.
+            ChainHeadState::Sent => {
+                !self.sent_was_complete &&
+                    self.duties_done &&
+                    self.payload_attributes_done &&
+                    self.inclusion_list_done
+            }
         }
     }
     pub fn is_new_slot(&mut self) -> bool {
@@ -98,6 +112,7 @@ impl ChainHead {
             self.duties_done = false;
             self.payload_attributes_done = false;
             self.inclusion_list_done = false;
+            self.sent_was_complete = false;
             true
         } else {
             false
@@ -125,6 +140,7 @@ impl ChainHead {
             self.duties_done = false;
             self.payload_attributes_done = false;
             self.inclusion_list_done = false;
+            self.sent_was_complete = false;
             true
         }
     }
@@ -139,6 +155,8 @@ impl ChainHead {
     }
     pub fn sent(&mut self) {
         self.state = ChainHeadState::Sent;
+        self.sent_was_complete =
+            self.duties_done && self.payload_attributes_done && self.inclusion_list_done;
     }
 
     #[cfg(test)]
@@ -354,6 +372,54 @@ mod tests {
         ch.sent();
         ch.force_deadline_expired();
         assert!(!ch.is_ready());
+    }
+
+    // --- Corrective update after an incomplete send ---
+
+    #[test]
+    fn sent_incomplete_becomes_ready_once_late_data_completes_the_picture() {
+        // The deadline fires before the inclusion list has arrived, so an
+        // incomplete SlotUpdate goes out (RELAY-FR: this is why merged-block
+        // simulation sometimes sees a slot with no known fee recipient/beacon
+        // root -- housekeeper gave up early and never corrected itself).
+        // Housekeeper does eventually learn the inclusion list; it must be able
+        // to send a corrective update instead of silently dropping the data for
+        // this slot forever.
+        let (mut ch, ci) = make_head();
+        ch.update(head_event(ci.current_slot() + 1));
+        ch.mark_duties_done();
+        ch.mark_payload_attrs_done();
+        // inclusion list not done yet
+        ch.force_deadline_expired();
+        assert!(ch.is_ready());
+        ch.sent();
+        assert!(!ch.is_ready());
+
+        // Late-arriving inclusion list completes the picture.
+        ch.mark_il_done();
+
+        assert!(
+            ch.is_ready(),
+            "a corrective SlotUpdate must be sendable once previously-missing data arrives"
+        );
+    }
+
+    #[test]
+    fn sent_incomplete_stays_not_ready_while_still_incomplete() {
+        // Only one of two missing pieces arrives -- the picture is still
+        // incomplete, so no corrective update should be sendable yet.
+        let (mut ch, ci) = make_head();
+        ch.update(head_event(ci.current_slot() + 1));
+        ch.mark_duties_done();
+        // payload attrs and il both still missing
+        ch.force_deadline_expired();
+        assert!(ch.is_ready());
+        ch.sent();
+        assert!(!ch.is_ready());
+
+        ch.mark_payload_attrs_done();
+
+        assert!(!ch.is_ready(), "must not re-ready until the picture is fully complete");
     }
 
     // --- Flag reset on new head ---


### PR DESCRIPTION
Issue: #525 (step 1 of 1)

## What this PR does
`ChainHead` sent exactly one `SlotUpdate` per slot -- whatever data it had at a hard 4-second deadline -- and then permanently latched into `Sent`, so `is_ready()` returned `false` for the rest of the slot even once the missing data (duties, payload attributes, inclusion list) arrived. Downstream consumers were already written expecting a corrective follow-up event that never came: `BlockMergingTile` has a comment "housekeeper sends incremental updates for the same slot", and the auctioneer's state machine has an explicit merge path for a second `Event::SlotData` per `bid_slot` (`crates/relay/src/auctioneer/mod.rs:296-325`) that was dead code.

`ChainHead` now tracks whether the picture was fully complete at the moment of the last `sent()` call. `is_ready()` re-arms in the `Sent` state once a previously-incomplete send is followed by all three pieces of data becoming available, letting `send_slot_event` go out again with the complete picture.

Found while investigating RELAY-FR merged-block-simulation alerts ("could not verify proposer payment", "invalid merkle root") on `od/merged_block_sim_step4` (#513): `BlockMergingTile`'s per-slot cache was sometimes still missing fee recipient / beacon root by the time a merge builder's response came back, because the one-shot `SlotUpdate` had gone out before those fetches completed and no correction ever arrived. Given elsewhere in this repo's history there's precedent for `ChainHead`/housekeeper state changes going out as their own PR (this one affects the auctioneer's main bid-processing path too, not just block merging).

## What this PR deliberately does not do
- No changes to `HousekeeperTile`: it already polls `chain_head.is_ready()` every loop tick and reads duties/payload-attributes fresh at send time, and `pending_il` is already re-populated before `mark_il_done()` fires, so the fix is fully contained to the `ChainHead` state machine.
- No change to the 4-second `CUTOFF_TIME` itself, or to when the *first* `SlotUpdate` goes out -- only whether a second, corrective one can follow it.

## Tests
Written first against the current (buggy) code and confirmed failing before the fix:
- `sent_incomplete_becomes_ready_once_late_data_completes_the_picture` -- reproduces the defect: a send goes out missing the inclusion list, which then arrives late; `is_ready()` must become `true` again so a corrective `SlotUpdate` can go out.
- `sent_incomplete_stays_not_ready_while_still_incomplete` -- guards the boundary: partial improvement (one of two missing pieces arrives) must not trigger a premature correction.

All 20 pre-existing `chain_head` tests still pass unchanged, including `sent_does_not_re_enter_ready_from_deadline` and `head_event_after_sent_does_not_re_enable_ready`, which cover the cases that must still stay `false` (a repeated event, or the deadline re-firing with no new data).

`just fmt-check`, `cargo clippy --all-features --no-deps -- -D warnings`, and `just test` (full workspace, Postgres-backed) all pass. One unrelated pre-existing flaky test (`helix-builder::server::tests::bad_api_key_is_rejected_and_disconnected`) intermittently fails under parallel test-thread contention but passes in isolation and on a clean full-suite rerun.

## Reviewer checklist
- [ ] CI (`lint`, `unit-test`) is green
- [ ] Matches the linked issue/step
- [ ] No unexplained scope creep or unrelated files touched
