### PR TITLE
Select the builder's roles from the supplied configs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6476,6 +6476,7 @@ dependencies = [
  "flux-utils",
  "helix-tcp-types",
  "hex",
+ "num_cpus",
  "rand 0.9.5",
  "rand_xorshift 0.4.0",
  "rayon",

--- a/crates/builder/Cargo.toml
+++ b/crates/builder/Cargo.toml
@@ -35,6 +35,7 @@ hex.workspace = true
 flux-network.workspace = true
 flux-utils.workspace = true
 helix-tcp-types.workspace = true
+num_cpus.workspace = true
 rand.workspace = true
 rayon.workspace = true
 rustc-hash.workspace = true

--- a/crates/builder/sim-config.example.yml
+++ b/crates/builder/sim-config.example.yml
@@ -1,0 +1,14 @@
+# helix-builder simulation configuration (--sim.config)
+
+ssz_addr: "0.0.0.0:8552"
+
+# Must differ from ssz_addr.
+rpc_addr: "0.0.0.0:8553"
+
+blacklist_endpoint: "http://localhost:3520/blacklist"
+
+# Maximum parent-to-head block distance a submission may build on.
+validation_window: 3
+
+# Defaults to the core count.
+max_concurrent_validations: 32

--- a/crates/builder/src/cli.rs
+++ b/crates/builder/src/cli.rs
@@ -12,15 +12,19 @@ use tracing::Level;
 #[derive(Parser)]
 #[command(
     name = "helix-builder",
-    about = "Helix block-merging builder: embedded ethrex node + relay-facing merging TCP server"
+    about = "Helix embedded ethrex node, running the block-merging role, the block-simulation role, or both"
 )]
 pub struct BuilderCli {
     #[command(flatten)]
     pub node: NodeOptions,
 
-    /// Path to the merging YAML config (listen address, relay api keys, limits)
+    /// Path to the merging YAML config. Activates the merging role.
     #[arg(long = "merging.config", env = "HELIX_BUILDER_MERGING_CONFIG")]
-    pub merging_config: PathBuf,
+    pub merging_config: Option<PathBuf>,
+
+    /// Path to the simulation YAML config. Activates the simulation role.
+    #[arg(long = "sim.config", env = "HELIX_BUILDER_SIM_CONFIG")]
+    pub sim_config: Option<PathBuf>,
 }
 
 /// Embedded-ethrex node options. Flag and env names match the upstream `ethrex`

--- a/crates/builder/src/config.rs
+++ b/crates/builder/src/config.rs
@@ -89,6 +89,95 @@ impl MergingConfig {
     }
 }
 
+/// Builder-owned simulation configuration, loaded from YAML (`--sim.config`).
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SimulationConfig {
+    pub ssz_addr: SocketAddr,
+    pub rpc_addr: SocketAddr,
+    #[serde(default = "default_blacklist_endpoint")]
+    pub blacklist_endpoint: String,
+    /// Maximum parent-to-head block distance a submission may build on.
+    #[serde(default = "default_validation_window")]
+    pub validation_window: u64,
+    #[serde(default = "default_max_concurrent_validations")]
+    pub max_concurrent_validations: usize,
+}
+
+impl SimulationConfig {
+    pub fn load(path: &Path) -> eyre::Result<Self> {
+        let raw = std::fs::read_to_string(path)
+            .map_err(|e| eyre::eyre!("failed to read simulation config {}: {e}", path.display()))?;
+        let config: Self = serde_yaml::from_str(&raw).map_err(|e| {
+            eyre::eyre!("failed to parse simulation config {}: {e}", path.display())
+        })?;
+        config.validate()?;
+        Ok(config)
+    }
+
+    fn validate(&self) -> eyre::Result<()> {
+        if self.ssz_addr == self.rpc_addr {
+            eyre::bail!("simulation config: ssz_addr and rpc_addr must differ");
+        }
+        if self.blacklist_endpoint.is_empty() {
+            eyre::bail!("simulation config: blacklist_endpoint must not be empty");
+        }
+        if self.validation_window == 0 {
+            eyre::bail!("simulation config: validation_window must be > 0");
+        }
+        if self.max_concurrent_validations == 0 {
+            eyre::bail!("simulation config: max_concurrent_validations must be > 0");
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum Roles {
+    Merging(MergingConfig),
+    Simulation(SimulationConfig),
+    Both { merging: MergingConfig, simulation: SimulationConfig },
+}
+
+impl Roles {
+    pub fn resolve(
+        merging: Option<MergingConfig>,
+        simulation: Option<SimulationConfig>,
+    ) -> eyre::Result<Self> {
+        match (merging, simulation) {
+            (Some(merging), Some(simulation)) => Ok(Self::Both { merging, simulation }),
+            (Some(merging), None) => Ok(Self::Merging(merging)),
+            (None, Some(simulation)) => Ok(Self::Simulation(simulation)),
+            (None, None) => {
+                eyre::bail!("no role selected: supply --merging.config, --sim.config, or both")
+            }
+        }
+    }
+
+    pub fn merging(&self) -> Option<&MergingConfig> {
+        match self {
+            Self::Merging(merging) | Self::Both { merging, .. } => Some(merging),
+            Self::Simulation(_) => None,
+        }
+    }
+
+    pub fn simulation(&self) -> Option<&SimulationConfig> {
+        match self {
+            Self::Simulation(simulation) | Self::Both { simulation, .. } => Some(simulation),
+            Self::Merging(_) => None,
+        }
+    }
+}
+
+fn default_blacklist_endpoint() -> String {
+    "http://localhost:3520/blacklist".to_string()
+}
+fn default_validation_window() -> u64 {
+    3
+}
+fn default_max_concurrent_validations() -> usize {
+    num_cpus::get()
+}
 fn default_max_orders_per_slot() -> u32 {
     8192
 }
@@ -141,5 +230,85 @@ mod tests {
         assert_eq!(config.max_frame_bytes, 32 * 1024 * 1024);
         assert_eq!(config.handshake_timeout_ms, 3000);
         assert!(config.cores.server_tile.is_none());
+    }
+}
+
+#[cfg(test)]
+mod simulation_config_tests {
+    use super::*;
+
+    fn minimal_merging_config() -> MergingConfig {
+        serde_yaml::from_str(
+            "listen_addr: \"0.0.0.0:9876\"\napi_keys: [\"00000000-0000-0000-0000-000000000001\"]\n",
+        )
+        .expect("the minimal merging config must parse")
+    }
+
+    fn minimal_simulation_config() -> SimulationConfig {
+        serde_yaml::from_str("ssz_addr: \"0.0.0.0:8552\"\nrpc_addr: \"0.0.0.0:8553\"\n")
+            .expect("the minimal simulation config must parse")
+    }
+
+    #[test]
+    fn parses_the_example_sim_config() {
+        let example = include_str!("../sim-config.example.yml");
+        let config: SimulationConfig = serde_yaml::from_str(example).unwrap();
+        config.validate().unwrap();
+
+        assert_eq!(config.ssz_addr, "0.0.0.0:8552".parse::<SocketAddr>().unwrap());
+        assert_eq!(config.rpc_addr, "0.0.0.0:8553".parse::<SocketAddr>().unwrap());
+        assert_eq!(config.blacklist_endpoint, "http://localhost:3520/blacklist");
+        assert_eq!(config.validation_window, 3);
+        assert_eq!(config.max_concurrent_validations, 32);
+    }
+
+    #[test]
+    fn minimal_sim_config_gets_defaults() {
+        let config = minimal_simulation_config();
+        config.validate().unwrap();
+
+        assert_eq!(config.blacklist_endpoint, "http://localhost:3520/blacklist");
+        assert_eq!(config.validation_window, 3);
+        assert_eq!(config.max_concurrent_validations, num_cpus::get());
+    }
+
+    #[test]
+    fn sim_config_rejects_one_address_for_both_servers() {
+        let config: SimulationConfig =
+            serde_yaml::from_str("ssz_addr: \"0.0.0.0:8552\"\nrpc_addr: \"0.0.0.0:8552\"\n")
+                .unwrap();
+
+        assert!(config.validate().is_err(), "ssz_addr must differ from rpc_addr");
+    }
+
+    #[test]
+    fn a_merging_config_alone_selects_the_merging_role() {
+        let roles = Roles::resolve(Some(minimal_merging_config()), None).unwrap();
+
+        assert!(roles.merging().is_some());
+        assert!(roles.simulation().is_none());
+    }
+
+    #[test]
+    fn a_sim_config_alone_selects_the_simulation_role() {
+        let roles = Roles::resolve(None, Some(minimal_simulation_config())).unwrap();
+
+        assert!(roles.simulation().is_some());
+        assert!(roles.merging().is_none(), "no merging role means no RELAY_KEY is needed");
+    }
+
+    #[test]
+    fn both_configs_select_both_roles() {
+        let roles =
+            Roles::resolve(Some(minimal_merging_config()), Some(minimal_simulation_config()))
+                .unwrap();
+
+        assert!(roles.merging().is_some());
+        assert!(roles.simulation().is_some());
+    }
+
+    #[test]
+    fn neither_config_is_a_startup_error() {
+        assert!(Roles::resolve(None, None).is_err(), "the builder must run at least one role");
     }
 }

--- a/crates/builder/src/main.rs
+++ b/crates/builder/src/main.rs
@@ -16,7 +16,7 @@ mod spine;
 mod utils;
 
 use cli::BuilderCli;
-use config::MergingConfig;
+use config::{MergingConfig, Roles, SimulationConfig};
 use engine::{MergeEngine, types::EngineConfig};
 use server::MergingServerTile;
 use spine::BuilderSpine;
@@ -28,50 +28,67 @@ fn main() -> eyre::Result<()> {
     let cli = BuilderCli::parse();
     init_tracing(&cli);
 
-    let merging_config = MergingConfig::load(&cli.merging_config)?;
-    info!(listen_addr = %merging_config.listen_addr, "Loaded merging config");
+    let merging_config = cli.merging_config.as_deref().map(MergingConfig::load).transpose()?;
+    let simulation_config = cli.sim_config.as_deref().map(SimulationConfig::load).transpose()?;
+    let roles = Roles::resolve(merging_config, simulation_config)?;
 
     // Fail fast on a missing/invalid RELAY_KEY, before the node boots.
-    let relay_signer = EngineConfig::load_relay_signer();
+    let relay_signer = roles.merging().map(|merging_config| {
+        info!(listen_addr = %merging_config.listen_addr, "Loaded merging config");
+        EngineConfig::load_relay_signer()
+    });
 
     let runtime = tokio::runtime::Builder::new_multi_thread().enable_all().build()?;
 
     let node = runtime.block_on(node::start(&cli.node))?;
 
-    let (event_tx, event_rx) = crossbeam_channel::bounded(merging_config.event_queue_capacity);
-    let (output_tx, output_rx) = crossbeam_channel::bounded(64);
+    if let Some(simulation_config) = roles.simulation() {
+        info!(
+            ssz_addr = %simulation_config.ssz_addr,
+            rpc_addr = %simulation_config.rpc_addr,
+            "Simulation role active"
+        );
+    }
 
-    let engine_config = EngineConfig {
-        relay_signer,
-        max_blocks_per_slot: merging_config.max_blocks_per_slot,
-        max_orders_per_slot: merging_config.max_orders_per_slot as usize,
-        min_value_increase_wei: alloy_primitives::U256::from(
-            merging_config.emission.min_value_increase_wei,
-        ),
-        min_emission_interval: std::time::Duration::from_millis(
-            merging_config.emission.min_interval_ms,
-        ),
-        core: merging_config.cores.merge_worker,
-    };
-    let _engine = MergeEngine::spawn(
-        engine_config,
-        node.store.clone(),
-        node.blockchain.clone(),
-        node.head.clone(),
-        event_rx,
-        output_tx,
-    );
+    // `BuilderSpine::start` blocks until its tiles stop, so merging starts last.
+    if let Some(merging_config) = roles.merging() {
+        let relay_signer = relay_signer.expect("the merging role loads a relay signer");
 
-    BuilderSpine::remove_all_files();
-    let spine = BuilderSpine::new(None);
-    let server_tile_config = match merging_config.cores.server_tile {
-        Some(core) => TileConfig::new(core, ThreadPriority::OSDefault),
-        None => TileConfig::background(None, None),
-    };
-    spine.start(None, None, |spine| {
-        let tile = MergingServerTile::new(&merging_config, event_tx.clone(), output_rx.clone());
-        attach_tile(tile, spine, server_tile_config);
-    });
+        let (event_tx, event_rx) = crossbeam_channel::bounded(merging_config.event_queue_capacity);
+        let (output_tx, output_rx) = crossbeam_channel::bounded(64);
+
+        let engine_config = EngineConfig {
+            relay_signer,
+            max_blocks_per_slot: merging_config.max_blocks_per_slot,
+            max_orders_per_slot: merging_config.max_orders_per_slot as usize,
+            min_value_increase_wei: alloy_primitives::U256::from(
+                merging_config.emission.min_value_increase_wei,
+            ),
+            min_emission_interval: std::time::Duration::from_millis(
+                merging_config.emission.min_interval_ms,
+            ),
+            core: merging_config.cores.merge_worker,
+        };
+        let _engine = MergeEngine::spawn(
+            engine_config,
+            node.store.clone(),
+            node.blockchain.clone(),
+            node.head.clone(),
+            event_rx,
+            output_tx,
+        );
+
+        BuilderSpine::remove_all_files();
+        let spine = BuilderSpine::new(None);
+        let server_tile_config = match merging_config.cores.server_tile {
+            Some(core) => TileConfig::new(core, ThreadPriority::OSDefault),
+            None => TileConfig::background(None, None),
+        };
+        spine.start(None, None, |spine| {
+            let tile = MergingServerTile::new(merging_config, event_tx.clone(), output_rx.clone());
+            attach_tile(tile, spine, server_tile_config);
+        });
+    }
 
     runtime.block_on(async {
         let mut sigterm = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())


### PR DESCRIPTION
Issue: #527 (step 1 of 10)

## What this PR does

Gives `helix-builder` a second selectable role: simulation. Roles come from
which config file is supplied. `--merging.config` activates merging and is now
optional, the new `--sim.config` activates simulation, and neither is a startup
error. The relay signer loads only for merging, so a simulation-only deployment
needs no `RELAY_KEY`.

`BuilderSpine::start` blocks until its tiles stop, so merging still starts last.
Merging-only behavior is unchanged.

## What this PR deliberately does not do

No validation work. The simulation role boots the node, logs its listen
addresses, and stops. The servers arrive in step 9 and the ethrex pipeline in
steps 3 to 8, so `SimulationConfig` is parsed but not yet consumed.

## Tests

Written first and signed off before implementation
(`crates/builder/src/config.rs`, `simulation_config_tests`, 8 tests):

- `sim-config.example.yml` parses; a minimal config gets its defaults.
- `ssz_addr` equal to `rpc_addr` is rejected.
- All four rows of the role table. The simulation-only case asserts no merging
  role, which is the observable form of "no `RELAY_KEY` needed".

Smoke-tested on the binary: no config errors before the node boots;
`--sim.config` with `RELAY_KEY` unset logs `Simulation role active`.

`just fmt-check`, `just test` and `cargo clippy --all-features --no-deps -- -D warnings`
are clean. `cargo clippy -p helix-builder` reports 4 pre-existing errors in
`src/engine/`, none in the files this PR touches. CI's `just clippy` passes no
`-p`/`--workspace`, so it only lints `default-members` and never covered them.

## Reviewer checklist
- [ ] CI (`lint`, `unit-test`) is green
- [ ] Matches the linked issue/step
- [ ] No unexplained scope creep or unrelated files touched
