### PR TITLE
Convert a submitted payload to an ethrex block and locate its parent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6474,6 +6474,7 @@ dependencies = [
  "flux",
  "flux-network",
  "flux-utils",
+ "helix-common",
  "helix-tcp-types",
  "hex",
  "num_cpus",

--- a/crates/builder/Cargo.toml
+++ b/crates/builder/Cargo.toml
@@ -53,4 +53,5 @@ uuid = { workspace = true, features = ["serde"] }
 zstd.workspace = true
 
 [dev-dependencies]
+helix-common.workspace = true
 rand_xorshift.workspace = true

--- a/crates/builder/src/engine/convert.rs
+++ b/crates/builder/src/engine/convert.rs
@@ -9,8 +9,16 @@ use alloy_rpc_types::{
 };
 use ethrex_common::{
     Address as EAddress, H256, U256 as EU256,
-    types::{Block, Withdrawal, requests::EncodedRequests},
+    constants::DEFAULT_OMMERS_HASH,
+    types::{
+        Block, BlockBody, BlockHeader, Transaction, Withdrawal, compute_transactions_root,
+        compute_withdrawals_root,
+        requests::{EncodedRequests, compute_requests_hash},
+    },
 };
+use ethrex_crypto::NativeCrypto;
+
+use crate::validation::error::ValidationError;
 
 pub fn h256(b: B256) -> H256 {
     H256(b.0)
@@ -81,6 +89,63 @@ pub fn block_to_payload_v3(block: &Block) -> ExecutionPayloadV3 {
         blob_gas_used: header.blob_gas_used.unwrap_or_default(),
         excess_blob_gas: header.excess_blob_gas.unwrap_or_default(),
     }
+}
+
+/// Inverse of [`block_to_payload_v3`]. The roots the payload omits are
+/// recomputed, so the hash this yields is the one the submission is bound to.
+#[allow(dead_code)]
+pub fn payload_v3_to_block(
+    payload: &ExecutionPayloadV3,
+    parent_beacon_block_root: B256,
+    requests: &ExecutionRequestsV4,
+) -> Result<Block, ValidationError> {
+    let inner = &payload.payload_inner.payload_inner;
+
+    let transactions = inner
+        .transactions
+        .iter()
+        .map(|encoded| Transaction::decode_canonical(encoded))
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| ValidationError::DecodeTransaction(e.to_string()))?;
+    let withdrawals: Vec<Withdrawal> =
+        payload.payload_inner.withdrawals.iter().map(ewithdrawal).collect();
+
+    let base_fee_per_gas: u64 =
+        inner.base_fee_per_gas.try_into().map_err(|_| ValidationError::BaseFeeTooLarge)?;
+
+    let header = BlockHeader {
+        parent_hash: h256(inner.parent_hash),
+        ommers_hash: *DEFAULT_OMMERS_HASH,
+        coinbase: eaddr(inner.fee_recipient),
+        state_root: h256(inner.state_root),
+        transactions_root: compute_transactions_root(&transactions, &NativeCrypto),
+        receipts_root: h256(inner.receipts_root),
+        logs_bloom: ethrex_common::Bloom(inner.logs_bloom.0.0),
+        difficulty: EU256::zero(),
+        number: inner.block_number,
+        gas_limit: inner.gas_limit,
+        gas_used: inner.gas_used,
+        timestamp: inner.timestamp,
+        extra_data: inner.extra_data.0.clone(),
+        prev_randao: h256(inner.prev_randao),
+        nonce: 0,
+        base_fee_per_gas: Some(base_fee_per_gas),
+        withdrawals_root: Some(compute_withdrawals_root(&withdrawals, &NativeCrypto)),
+        blob_gas_used: Some(payload.blob_gas_used),
+        excess_blob_gas: Some(payload.excess_blob_gas),
+        parent_beacon_block_root: Some(h256(parent_beacon_block_root)),
+        requests_hash: Some(compute_requests_hash(&encoded_requests(requests))),
+        ..Default::default()
+    };
+
+    let body = BlockBody { transactions, ommers: vec![], withdrawals: Some(withdrawals) };
+    Ok(Block::new(header, body))
+}
+
+/// Inverse of [`requests_to_v4`]. `compute_requests_hash` skips type-byte-only
+/// entries, so the empty ones the wire format drops need not be restored.
+fn encoded_requests(requests: &ExecutionRequestsV4) -> Vec<EncodedRequests> {
+    requests.to_requests().iter().map(|request| EncodedRequests(request.clone().0.into())).collect()
 }
 
 /// Converts ethrex's encoded EIP-7685 requests into the wire

--- a/crates/builder/src/engine/tests.rs
+++ b/crates/builder/src/engine/tests.rs
@@ -1,17 +1,13 @@
-use std::{str::FromStr, sync::Arc, time::Duration};
+use std::{sync::Arc, time::Duration};
 
-use alloy_consensus::{SignableTransaction, TxEip1559};
-use alloy_eips::eip2718::Encodable2718;
 use alloy_primitives::{Address, B256, U256};
-use alloy_signer::SignerSync;
 use alloy_signer_local::PrivateKeySigner;
 use ethrex_blockchain::{
     Blockchain, BlockchainOptions, BlockchainType,
     payload::{BuildPayloadArgs, create_payload},
 };
 use ethrex_common::types::ELASTICITY_MULTIPLIER;
-use ethrex_config::networks::Network;
-use ethrex_storage::{EngineType, Store};
+use ethrex_storage::Store;
 use helix_tcp_types::merging::{
     builder_to_relay::RejectCode,
     control::{BuilderCollateral, RelayConfigV1},
@@ -28,59 +24,10 @@ use crate::{
         types::EngineConfig,
     },
     node::HeadInfo,
+    testing::{ETH, GWEI, dev_genesis_store, funded_signers, signed_transfer},
 };
 
-const KEYS: [&str; 20] = [
-    "0x941e103320615d394a55708be13e45994c7d93b932b064dbcb2b511fe3254e2e",
-    "0xbcdf20249abf0ed6d944c0288fad489e33f66b3960d9e6229c1cd214ed3bbe31",
-    "0x39725efee3fb28614de3bacaffe4cc4bd8c436257e2c8bb887c4b5c4be45e76d",
-    "0x53321db7c1e331d93a11a41d16f004d7ff63972ec8ec7c25db329728ceeb1710",
-    "0xab63b23eb7941c1251757e24b3d2350d2bc05c3c388d06f8fe6feafefb1e8c70",
-    "0x5d2344259f42259f82d2c140aa66102ba89b57b4883ee441a8b312622bd42491",
-    "0x27515f805127bebad2fb9b183508bdacb8c763da16f54e0678b16e8f28ef3fff",
-    "0x7ff1a4c1d57e5e784d327c4c7651e952350bc271f156afb3d00d20f5ef924856",
-    "0x3a91003acaf4c21b3953d94fa4a6db694fa69e5242b2e37be05dd82761058899",
-    "0xbb1d0f125b4fb2bb173c318cdead45468474ca71474e2247776b2b4c0fa2d3f5",
-    "0x850643a0224065ecce3882673c21f56bcf6eef86274cc21cadff15930b59fc8c",
-    "0x94eb3102993b41ec55c241060f47daa0f6372e2e3ad7e91612ae36c364042e44",
-    "0xdaf15504c22a352648a71ef2926334fe040ac1d5005019e09f6c979808024dc7",
-    "0xeaba42282ad33c8ef2524f07277c03a776d98ae19f581990ce75becb7cfa1c23",
-    "0x3fd98b5187bf6526734efaa644ffbb4e3670d66f5d0268ce0323ec09124bff61",
-    "0x5288e2f440c7f0cb61a9be8afdeb4295f786383f96f5e35eb0c94ef103996b64",
-    "0xf296c7802555da2a5a662be70e078cbd38b44f96f8615ae529da41122ce8db05",
-    "0xbf3beef3bd999ba9f2451e06936f0423cd62b815c9233dd3bc90f7e02a1e8673",
-    "0x6ecadc396415970e91293726c3f5775225440ea0844ae5616135fd10d66b5954",
-    "0xa492823c3e193d6c595f37a18e3c06650cf4c74558cc818b16130b293716106f",
-];
-
-const GWEI: u128 = 1_000_000_000;
-const ETH: u128 = 1_000_000_000_000_000_000;
 const SLOT: u64 = 1;
-
-#[allow(clippy::too_many_arguments)]
-fn signed_transfer(
-    signer: &PrivateKeySigner,
-    chain_id: u64,
-    nonce: u64,
-    to: Address,
-    value: U256,
-    max_fee_per_gas: u128,
-    max_priority_fee_per_gas: u128,
-) -> Vec<u8> {
-    let tx = TxEip1559 {
-        chain_id,
-        nonce,
-        gas_limit: 21_000,
-        max_fee_per_gas,
-        max_priority_fee_per_gas,
-        to: to.into(),
-        value,
-        access_list: Default::default(),
-        input: Default::default(),
-    };
-    let signature = signer.sign_hash_sync(&tx.signature_hash()).unwrap();
-    alloy_consensus::TxEnvelope::from(tx.into_signed(signature)).encoded_2718()
-}
 
 struct Fixture {
     store: Store,
@@ -97,27 +44,19 @@ struct Fixture {
 
 impl Fixture {
     async fn new() -> Self {
-        let genesis = Network::LocalDevnet.get_genesis().unwrap();
+        let (store, genesis) = dev_genesis_store().await;
         let chain_id = genesis.config.chain_id;
         let genesis_block = genesis.get_block();
         let genesis_hash = genesis_block.hash();
         let genesis_header = genesis_block.header.clone();
 
-        let mut store = Store::new("memory", EngineType::InMemory).unwrap();
-        store.add_initial_state(genesis.clone()).await.unwrap();
         let blockchain: Arc<Blockchain> = Blockchain::new(store.clone(), BlockchainOptions {
             r#type: BlockchainType::L1,
             ..Default::default()
         })
         .into();
 
-        let signers: Vec<PrivateKeySigner> = KEYS
-            .iter()
-            .map(|key| PrivateKeySigner::from_str(key).unwrap())
-            .filter(|signer| genesis.alloc.contains_key(&eaddr(signer.address())))
-            .take(8)
-            .collect();
-        assert_eq!(signers.len(), 8, "dev genesis funds too few of the fixture keys");
+        let signers = funded_signers(&genesis, 8);
 
         let relay_config = RelayConfigV1 {
             relay_fee_recipient: signers[4].address(),

--- a/crates/builder/src/main.rs
+++ b/crates/builder/src/main.rs
@@ -13,7 +13,10 @@ mod engine;
 mod node;
 mod server;
 mod spine;
+#[cfg(test)]
+mod testing;
 mod utils;
+mod validation;
 
 use cli::BuilderCli;
 use config::{MergingConfig, Roles, SimulationConfig};

--- a/crates/builder/src/testing.rs
+++ b/crates/builder/src/testing.rs
@@ -1,0 +1,83 @@
+use std::str::FromStr;
+
+use alloy_consensus::{SignableTransaction, TxEip1559};
+use alloy_eips::eip2718::Encodable2718;
+use alloy_primitives::{Address, U256};
+use alloy_signer::SignerSync;
+use alloy_signer_local::PrivateKeySigner;
+use ethrex_common::types::Genesis;
+use ethrex_config::networks::Network;
+use ethrex_storage::{EngineType, Store};
+
+use crate::engine::convert::eaddr;
+
+/// Dev keys from ethrex's `fixtures/keys/private_keys_l1.txt`; a fixture picks
+/// the ones the `LocalDevnet` genesis actually funds.
+pub const KEYS: [&str; 20] = [
+    "0x941e103320615d394a55708be13e45994c7d93b932b064dbcb2b511fe3254e2e",
+    "0xbcdf20249abf0ed6d944c0288fad489e33f66b3960d9e6229c1cd214ed3bbe31",
+    "0x39725efee3fb28614de3bacaffe4cc4bd8c436257e2c8bb887c4b5c4be45e76d",
+    "0x53321db7c1e331d93a11a41d16f004d7ff63972ec8ec7c25db329728ceeb1710",
+    "0xab63b23eb7941c1251757e24b3d2350d2bc05c3c388d06f8fe6feafefb1e8c70",
+    "0x5d2344259f42259f82d2c140aa66102ba89b57b4883ee441a8b312622bd42491",
+    "0x27515f805127bebad2fb9b183508bdacb8c763da16f54e0678b16e8f28ef3fff",
+    "0x7ff1a4c1d57e5e784d327c4c7651e952350bc271f156afb3d00d20f5ef924856",
+    "0x3a91003acaf4c21b3953d94fa4a6db694fa69e5242b2e37be05dd82761058899",
+    "0xbb1d0f125b4fb2bb173c318cdead45468474ca71474e2247776b2b4c0fa2d3f5",
+    "0x850643a0224065ecce3882673c21f56bcf6eef86274cc21cadff15930b59fc8c",
+    "0x94eb3102993b41ec55c241060f47daa0f6372e2e3ad7e91612ae36c364042e44",
+    "0xdaf15504c22a352648a71ef2926334fe040ac1d5005019e09f6c979808024dc7",
+    "0xeaba42282ad33c8ef2524f07277c03a776d98ae19f581990ce75becb7cfa1c23",
+    "0x3fd98b5187bf6526734efaa644ffbb4e3670d66f5d0268ce0323ec09124bff61",
+    "0x5288e2f440c7f0cb61a9be8afdeb4295f786383f96f5e35eb0c94ef103996b64",
+    "0xf296c7802555da2a5a662be70e078cbd38b44f96f8615ae529da41122ce8db05",
+    "0xbf3beef3bd999ba9f2451e06936f0423cd62b815c9233dd3bc90f7e02a1e8673",
+    "0x6ecadc396415970e91293726c3f5775225440ea0844ae5616135fd10d66b5954",
+    "0xa492823c3e193d6c595f37a18e3c06650cf4c74558cc818b16130b293716106f",
+];
+
+pub const GWEI: u128 = 1_000_000_000;
+pub const ETH: u128 = 1_000_000_000_000_000_000;
+
+#[allow(clippy::too_many_arguments)]
+pub fn signed_transfer(
+    signer: &PrivateKeySigner,
+    chain_id: u64,
+    nonce: u64,
+    to: Address,
+    value: U256,
+    max_fee_per_gas: u128,
+    max_priority_fee_per_gas: u128,
+) -> Vec<u8> {
+    let tx = TxEip1559 {
+        chain_id,
+        nonce,
+        gas_limit: 21_000,
+        max_fee_per_gas,
+        max_priority_fee_per_gas,
+        to: to.into(),
+        value,
+        access_list: Default::default(),
+        input: Default::default(),
+    };
+    let signature = signer.sign_hash_sync(&tx.signature_hash()).unwrap();
+    alloy_consensus::TxEnvelope::from(tx.into_signed(signature)).encoded_2718()
+}
+
+pub async fn dev_genesis_store() -> (Store, Genesis) {
+    let genesis = Network::LocalDevnet.get_genesis().unwrap();
+    let mut store = Store::new("memory", EngineType::InMemory).unwrap();
+    store.add_initial_state(genesis.clone()).await.unwrap();
+    (store, genesis)
+}
+
+pub fn funded_signers(genesis: &Genesis, count: usize) -> Vec<PrivateKeySigner> {
+    let signers: Vec<PrivateKeySigner> = KEYS
+        .iter()
+        .map(|key| PrivateKeySigner::from_str(key).unwrap())
+        .filter(|signer| genesis.alloc.contains_key(&eaddr(signer.address())))
+        .take(count)
+        .collect();
+    assert_eq!(signers.len(), count, "dev genesis funds too few of the fixture keys");
+    signers
+}

--- a/crates/builder/src/validation/error.rs
+++ b/crates/builder/src/validation/error.rs
@@ -1,0 +1,25 @@
+use alloy_primitives::B256;
+
+#[derive(Debug, thiserror::Error)]
+pub enum ValidationError {
+    #[error("block hash mismatch: got {got}, expected {expected}")]
+    BlockHashMismatch { got: B256, expected: B256 },
+    #[error("block parent hash mismatch: got {got}, expected {expected}")]
+    ParentHashMismatch { got: B256, expected: B256 },
+    #[error("block gas limit mismatch: got {got}, expected {expected}")]
+    GasLimitMismatch { got: u64, expected: u64 },
+    #[error("block gas used mismatch: got {got}, expected {expected}")]
+    GasUsedMismatch { got: u64, expected: u64 },
+    #[error("could not decode transaction: {0}")]
+    DecodeTransaction(String),
+    #[error("base fee per gas exceeds u64")]
+    BaseFeeTooLarge,
+    // Text matched by `BlockSimError::is_temporary`; changing it demotes builders.
+    #[error("parent block not found")]
+    MissingParentBlock,
+    // Text matched by `BlockSimError::is_too_old`.
+    #[error("block is too old, outside validation window")]
+    BlockTooOld,
+    #[error("store error: {0}")]
+    Store(String),
+}

--- a/crates/builder/src/validation/mod.rs
+++ b/crates/builder/src/validation/mod.rs
@@ -1,0 +1,114 @@
+// Reached from main once the servers land in step 9 of #527.
+#![allow(dead_code)]
+
+pub mod error;
+#[cfg(test)]
+mod tests;
+
+use alloy_primitives::B256;
+use alloy_rpc_types::{
+    beacon::{relay::BidTrace, requests::ExecutionRequestsV4},
+    engine::ExecutionPayloadV3,
+};
+use ethrex_common::types::{Block, BlockHeader};
+use ethrex_storage::Store;
+use tokio::sync::watch;
+
+use crate::{
+    engine::convert::{b256, payload_v3_to_block},
+    node::HeadInfo,
+    validation::error::ValidationError,
+};
+
+#[derive(Debug)]
+pub struct PreparedBlock {
+    pub block: Block,
+    pub parent_header: BlockHeader,
+}
+
+#[derive(Clone)]
+pub struct BlockValidator {
+    store: Store,
+    head: watch::Receiver<HeadInfo>,
+    validation_window: u64,
+}
+
+impl BlockValidator {
+    pub fn new(store: Store, head: watch::Receiver<HeadInfo>, validation_window: u64) -> Self {
+        Self { store, head, validation_window }
+    }
+
+    pub fn prepare(
+        &self,
+        payload: &ExecutionPayloadV3,
+        message: &BidTrace,
+        parent_beacon_block_root: B256,
+        requests: &ExecutionRequestsV4,
+    ) -> Result<PreparedBlock, ValidationError> {
+        let block = self.to_block(payload, parent_beacon_block_root, requests)?;
+        self.validate_message_against_header(&block, message)?;
+        let parent_header = self.parent_header(&block.header)?;
+        Ok(PreparedBlock { block, parent_header })
+    }
+
+    fn to_block(
+        &self,
+        payload: &ExecutionPayloadV3,
+        parent_beacon_block_root: B256,
+        requests: &ExecutionRequestsV4,
+    ) -> Result<Block, ValidationError> {
+        payload_v3_to_block(payload, parent_beacon_block_root, requests)
+    }
+
+    /// The relay serves the trace's fields, so a trace that misdescribes a valid
+    /// block is still rejected.
+    fn validate_message_against_header(
+        &self,
+        block: &Block,
+        message: &BidTrace,
+    ) -> Result<(), ValidationError> {
+        let header = &block.header;
+        let block_hash = b256(block.hash());
+        if block_hash != message.block_hash {
+            return Err(ValidationError::BlockHashMismatch {
+                got: message.block_hash,
+                expected: block_hash,
+            });
+        }
+        if b256(header.parent_hash) != message.parent_hash {
+            return Err(ValidationError::ParentHashMismatch {
+                got: message.parent_hash,
+                expected: b256(header.parent_hash),
+            });
+        }
+        if header.gas_limit != message.gas_limit {
+            return Err(ValidationError::GasLimitMismatch {
+                got: message.gas_limit,
+                expected: header.gas_limit,
+            });
+        }
+        if header.gas_used != message.gas_used {
+            return Err(ValidationError::GasUsedMismatch {
+                got: message.gas_used,
+                expected: header.gas_used,
+            });
+        }
+        Ok(())
+    }
+
+    /// A parent past the window is refused: its state may be gone, and that store
+    /// error would reach the relay as an unclassifiable failure.
+    fn parent_header(&self, header: &BlockHeader) -> Result<BlockHeader, ValidationError> {
+        let parent = self
+            .store
+            .get_block_header_by_hash(header.parent_hash)
+            .map_err(|e| ValidationError::Store(e.to_string()))?
+            .ok_or(ValidationError::MissingParentBlock)?;
+
+        let head = self.head.borrow().number;
+        if head.saturating_sub(parent.number) > self.validation_window {
+            return Err(ValidationError::BlockTooOld);
+        }
+        Ok(parent)
+    }
+}

--- a/crates/builder/src/validation/tests.rs
+++ b/crates/builder/src/validation/tests.rs
@@ -1,0 +1,342 @@
+use std::sync::Arc;
+
+use alloy_primitives::{Address, B256, U256};
+use alloy_rpc_types::{
+    beacon::{relay::BidTrace, requests::ExecutionRequestsV4},
+    engine::ExecutionPayloadV3,
+};
+use ethrex_blockchain::{
+    Blockchain, BlockchainOptions, BlockchainType,
+    fork_choice::apply_fork_choice,
+    payload::{BuildPayloadArgs, create_payload},
+};
+use ethrex_common::{H256, types::ELASTICITY_MULTIPLIER};
+use ethrex_storage::Store;
+use helix_common::simulator::BlockSimError;
+use tokio::sync::watch;
+
+use crate::{
+    engine::convert::{b256, block_to_payload_v3, eaddr, requests_to_v4},
+    node::HeadInfo,
+    testing::{ETH, GWEI, dev_genesis_store, funded_signers, signed_transfer},
+    validation::{BlockValidator, error::ValidationError},
+};
+
+const WINDOW: u64 = 3;
+
+struct Built {
+    payload: ExecutionPayloadV3,
+    requests: ExecutionRequestsV4,
+}
+
+impl Built {
+    fn block_hash(&self) -> B256 {
+        self.payload.payload_inner.payload_inner.block_hash
+    }
+}
+
+struct Fixture {
+    store: Store,
+    blockchain: Arc<Blockchain>,
+    genesis_hash: H256,
+    genesis_timestamp: u64,
+    chain_id: u64,
+    gas_limit: u64,
+    signers: Vec<alloy_signer_local::PrivateKeySigner>,
+    proposer: Address,
+    head: watch::Sender<HeadInfo>,
+}
+
+impl Fixture {
+    async fn new() -> Self {
+        let (store, genesis) = dev_genesis_store().await;
+        let genesis_block = genesis.get_block();
+        let blockchain: Arc<Blockchain> = Blockchain::new(store.clone(), BlockchainOptions {
+            r#type: BlockchainType::L1,
+            ..Default::default()
+        })
+        .into();
+
+        let (head, _) = watch::channel(HeadInfo {
+            number: 0,
+            hash: genesis_block.hash(),
+            timestamp: genesis_block.header.timestamp,
+            is_synced: true,
+        });
+
+        Self {
+            store,
+            blockchain,
+            head,
+            genesis_hash: genesis_block.hash(),
+            genesis_timestamp: genesis_block.header.timestamp,
+            chain_id: genesis.config.chain_id,
+            gas_limit: genesis_block.header.gas_limit,
+            signers: funded_signers(&genesis, 4),
+            proposer: Address::repeat_byte(0x77),
+        }
+    }
+
+    fn validator(&self) -> BlockValidator {
+        BlockValidator::new(self.store.clone(), self.head.subscribe(), WINDOW)
+    }
+
+    /// Builds a valid block on `parent`, paying `self.proposer` in its last tx.
+    fn build_on(&self, parent: H256, timestamp: u64, nonce: u64) -> Built {
+        let builder = &self.signers[0];
+        let txs = vec![signed_transfer(
+            builder,
+            self.chain_id,
+            nonce,
+            self.proposer,
+            U256::from(ETH / 2),
+            100 * GWEI,
+            0,
+        )];
+        let args = BuildPayloadArgs {
+            parent,
+            timestamp,
+            fee_recipient: eaddr(builder.address()),
+            random: H256::zero(),
+            withdrawals: Some(Vec::new()),
+            beacon_root: Some(H256::zero()),
+            slot_number: None,
+            version: 3,
+            elasticity_multiplier: ELASTICITY_MULTIPLIER,
+            gas_ceil: self.gas_limit,
+        };
+        let template = create_payload(&args, &self.store, Default::default()).unwrap();
+        let decoded = txs
+            .iter()
+            .map(|bytes| ethrex_common::types::Transaction::decode_canonical(bytes).unwrap())
+            .collect();
+        let built = self.blockchain.build_payload_with_transactions(template, decoded).unwrap();
+
+        Built {
+            payload: block_to_payload_v3(&built.payload),
+            requests: requests_to_v4(&built.requests).unwrap(),
+        }
+    }
+
+    /// Appends `count` canonical blocks to the chain and returns the new head.
+    async fn extend_canonical(&self, count: usize) -> H256 {
+        let mut parent = self.genesis_hash;
+        let mut timestamp = self.genesis_timestamp;
+        for i in 0..count {
+            timestamp += 12;
+            let built = self.build_on(parent, timestamp, i as u64);
+            let block = self
+                .validator()
+                .to_block(&built.payload, B256::ZERO, &built.requests)
+                .expect("the fixture builds a convertible block");
+            parent = block.hash();
+            let number = block.header.number;
+            let timestamp = block.header.timestamp;
+            self.blockchain.add_block(block).unwrap();
+            apply_fork_choice(&self.store, parent, parent, parent).await.unwrap();
+            self.head.send_replace(HeadInfo { number, hash: parent, timestamp, is_synced: true });
+        }
+        parent
+    }
+
+    fn bid_trace(&self, built: &Built) -> BidTrace {
+        let header = &built.payload.payload_inner.payload_inner;
+        BidTrace {
+            slot: 1,
+            parent_hash: header.parent_hash,
+            block_hash: header.block_hash,
+            builder_pubkey: Default::default(),
+            proposer_pubkey: Default::default(),
+            proposer_fee_recipient: self.proposer,
+            gas_limit: header.gas_limit,
+            gas_used: header.gas_used,
+            value: U256::from(ETH / 2),
+        }
+    }
+}
+
+#[tokio::test]
+async fn a_valid_submission_prepares_its_block() {
+    let fixture = Fixture::new().await;
+    let built = fixture.build_on(fixture.genesis_hash, fixture.genesis_timestamp + 12, 0);
+    let message = fixture.bid_trace(&built);
+
+    let prepared = fixture
+        .validator()
+        .prepare(&built.payload, &message, B256::ZERO, &built.requests)
+        .expect("a block the fixture built must prepare");
+
+    assert_eq!(b256(prepared.block.hash()), built.block_hash());
+    assert_eq!(prepared.parent_header.hash(), fixture.genesis_hash);
+}
+
+/// The payload carries a `block_hash`, but the validator recomputes it from the
+/// converted header. The two must agree, or the conversion has lost a field.
+#[tokio::test]
+async fn the_payload_round_trips_to_the_same_block_hash() {
+    let fixture = Fixture::new().await;
+    let built = fixture.build_on(fixture.genesis_hash, fixture.genesis_timestamp + 12, 0);
+
+    let block = fixture
+        .validator()
+        .to_block(&built.payload, B256::ZERO, &built.requests)
+        .expect("a block the fixture built must convert");
+
+    assert_eq!(b256(block.hash()), built.block_hash());
+}
+
+#[tokio::test]
+async fn a_bid_trace_with_the_wrong_block_hash_is_rejected() {
+    let fixture = Fixture::new().await;
+    let built = fixture.build_on(fixture.genesis_hash, fixture.genesis_timestamp + 12, 0);
+    let mut message = fixture.bid_trace(&built);
+    message.block_hash = B256::repeat_byte(0xaa);
+
+    let error = fixture
+        .validator()
+        .prepare(&built.payload, &message, B256::ZERO, &built.requests)
+        .expect_err("a mismatched block hash must be rejected");
+
+    assert!(matches!(error, ValidationError::BlockHashMismatch { .. }), "{error}");
+}
+
+#[tokio::test]
+async fn a_bid_trace_with_the_wrong_parent_hash_is_rejected() {
+    let fixture = Fixture::new().await;
+    let built = fixture.build_on(fixture.genesis_hash, fixture.genesis_timestamp + 12, 0);
+    let mut message = fixture.bid_trace(&built);
+    message.parent_hash = B256::repeat_byte(0xbb);
+
+    let error = fixture
+        .validator()
+        .prepare(&built.payload, &message, B256::ZERO, &built.requests)
+        .expect_err("a mismatched parent hash must be rejected");
+
+    assert!(matches!(error, ValidationError::ParentHashMismatch { .. }), "{error}");
+}
+
+#[tokio::test]
+async fn a_bid_trace_with_the_wrong_gas_limit_is_rejected() {
+    let fixture = Fixture::new().await;
+    let built = fixture.build_on(fixture.genesis_hash, fixture.genesis_timestamp + 12, 0);
+    let mut message = fixture.bid_trace(&built);
+    message.gas_limit += 1;
+
+    let error = fixture
+        .validator()
+        .prepare(&built.payload, &message, B256::ZERO, &built.requests)
+        .expect_err("a mismatched gas limit must be rejected");
+
+    assert!(matches!(error, ValidationError::GasLimitMismatch { .. }), "{error}");
+}
+
+#[tokio::test]
+async fn a_bid_trace_with_the_wrong_gas_used_is_rejected() {
+    let fixture = Fixture::new().await;
+    let built = fixture.build_on(fixture.genesis_hash, fixture.genesis_timestamp + 12, 0);
+    let mut message = fixture.bid_trace(&built);
+    message.gas_used += 1;
+
+    let error = fixture
+        .validator()
+        .prepare(&built.payload, &message, B256::ZERO, &built.requests)
+        .expect_err("a mismatched gas used must be rejected");
+
+    assert!(matches!(error, ValidationError::GasUsedMismatch { .. }), "{error}");
+}
+
+/// A payload edited after the bid was signed hashes to a different block, so it
+/// fails the block hash check rather than any per-field check.
+#[tokio::test]
+async fn a_tampered_payload_fails_the_block_hash_check() {
+    let fixture = Fixture::new().await;
+    let mut built = fixture.build_on(fixture.genesis_hash, fixture.genesis_timestamp + 12, 0);
+    let message = fixture.bid_trace(&built);
+    built.payload.payload_inner.payload_inner.gas_used += 1;
+
+    let error = fixture
+        .validator()
+        .prepare(&built.payload, &message, B256::ZERO, &built.requests)
+        .expect_err("an edited payload must be rejected");
+
+    assert!(matches!(error, ValidationError::BlockHashMismatch { .. }), "{error}");
+}
+
+#[tokio::test]
+async fn an_undecodable_transaction_is_rejected() {
+    let fixture = Fixture::new().await;
+    let mut built = fixture.build_on(fixture.genesis_hash, fixture.genesis_timestamp + 12, 0);
+    let message = fixture.bid_trace(&built);
+    built.payload.payload_inner.payload_inner.transactions = vec![vec![0xde, 0xad].into()];
+
+    let error = fixture
+        .validator()
+        .prepare(&built.payload, &message, B256::ZERO, &built.requests)
+        .expect_err("an undecodable transaction must be rejected");
+
+    assert!(matches!(error, ValidationError::DecodeTransaction(_)), "{error}");
+}
+
+#[tokio::test]
+async fn an_unknown_parent_is_rejected() {
+    let fixture = Fixture::new().await;
+    let built = fixture.build_on(fixture.genesis_hash, fixture.genesis_timestamp + 12, 0);
+    let mut message = fixture.bid_trace(&built);
+    let mut payload = built.payload.clone();
+    payload.payload_inner.payload_inner.parent_hash = B256::repeat_byte(0xcc);
+    message.parent_hash = B256::repeat_byte(0xcc);
+    message.block_hash =
+        b256(fixture.validator().to_block(&payload, B256::ZERO, &built.requests).unwrap().hash());
+
+    let error = fixture
+        .validator()
+        .prepare(&payload, &message, B256::ZERO, &built.requests)
+        .expect_err("an unknown parent must be rejected");
+
+    assert!(matches!(error, ValidationError::MissingParentBlock), "{error}");
+}
+
+#[tokio::test]
+async fn a_parent_inside_the_validation_window_is_accepted() {
+    let fixture = Fixture::new().await;
+    let head = fixture.extend_canonical(WINDOW as usize).await;
+    // extend_canonical spent one nonce per block it appended.
+    let built = fixture.build_on(head, fixture.genesis_timestamp + 1200, WINDOW);
+    let message = fixture.bid_trace(&built);
+
+    fixture
+        .validator()
+        .prepare(&built.payload, &message, B256::ZERO, &built.requests)
+        .expect("a block built on the head must prepare");
+}
+
+/// The chain moves on while a submission is in flight. A parent further back
+/// than the window is refused rather than validated against stale state.
+#[tokio::test]
+async fn a_parent_outside_the_validation_window_is_rejected() {
+    let fixture = Fixture::new().await;
+    let built = fixture.build_on(fixture.genesis_hash, fixture.genesis_timestamp + 12, 0);
+    let message = fixture.bid_trace(&built);
+    fixture.extend_canonical(WINDOW as usize + 1).await;
+
+    let error = fixture
+        .validator()
+        .prepare(&built.payload, &message, B256::ZERO, &built.requests)
+        .expect_err("a parent outside the window must be rejected");
+
+    assert!(matches!(error, ValidationError::BlockTooOld), "{error}");
+}
+
+/// The relay classifies a simulation failure by its message text. These two
+/// must keep reaching `is_temporary` and `is_too_old`, or a transient failure
+/// starts demoting builders.
+#[test]
+fn the_relay_classifies_the_parent_errors_it_must_retry() {
+    let missing =
+        BlockSimError::BlockValidationFailed(ValidationError::MissingParentBlock.to_string());
+    assert!(missing.is_temporary(), "{missing}");
+
+    let too_old = BlockSimError::BlockValidationFailed(ValidationError::BlockTooOld.to_string());
+    assert!(too_old.is_too_old(), "{too_old}");
+    assert!(!too_old.is_demotable(), "{too_old}");
+}


### PR DESCRIPTION
Issue: #527 (step 3 of 10)

Base branch: `od/sim-shared-payment-helpers-step2` (#529, step 2). Retarget as
the stack merges.

## What this PR does

Adds `BlockValidator`. It turns an `ExecutionPayloadV3` into the ethrex block
the submission describes, checks the bid trace against that block, and finds the
parent inside the validation window. `payload_v3_to_block` is the inverse of the
existing `block_to_payload_v3`.

Two departures from the reth simulator, both deliberate:

- The head comes from the node's existing `watch` channel, not a store read per
  call, so `prepare` stays synchronous. A lagging head can only shorten the
  measured distance, so it errs toward accepting, never rejecting.
- `registered_gas_limit` is not threaded in. reth's `_validate_gas_limit` is
  dead code there, so there is nothing to port.

Also extracts the merge-engine test fixture's shared primitives into
`src/testing.rs`. Every later validation step needs them, and the merge-specific
`Fixture` stays where it is.

## What this PR deliberately does not do

Nothing executes. No EVM, no state root, no payment, no blacklist. `main` does
not reach `BlockValidator` yet either, which is why the module carries an
`allow(dead_code)` until step 9 wires the servers.

Checks ethrex already performs are not reported here: the header against the
parent, the RLP block size and the per-tx chain id all live in
`validate_block_pre_execution`, which step 4 calls.

## Tests

Written first and signed off before implementation
(`src/validation/tests.rs`, 12 tests on an in-memory devnet chain):

- A fixture-built block survives the payload round trip with the same hash, and
  an undecodable transaction is rejected.
- A bid trace with the wrong block hash, parent hash, gas limit or gas used is
  each rejected, in that order. A payload edited after signing fails on the
  block hash rather than a per-field check.
- The head is accepted as a parent; an unknown parent and one outside the window
  are rejected; one inside it passes.
- `BlockSimError::BlockValidationFailed(err.to_string())` still reaches
  `is_temporary()` and `is_too_old()`. This pins the two error strings the relay
  matches on. Get them wrong and a transient failure demotes the builder.

`just fmt-check`, `just test` and `cargo clippy --all-features --no-deps -- -D warnings`
are clean. 46 tests pass in `helix-builder`, up from 34.

## Reviewer checklist
- [ ] CI (`lint`, `unit-test`) is green
- [ ] Matches the linked issue/step
- [ ] No unexplained scope creep or unrelated files touched