### PR TITLE
Execute a submitted block and check it against its header

### DIFF
--- a/crates/builder/src/validation/error.rs
+++ b/crates/builder/src/validation/error.rs
@@ -22,4 +22,14 @@ pub enum ValidationError {
     BlockTooOld,
     #[error("store error: {0}")]
     Store(String),
+    #[error("invalid block: {0}")]
+    PreExecution(String),
+    #[error("execution failed: {0}")]
+    Execution(String),
+    #[error("invalid block: {0}")]
+    PostExecution(String),
+    #[error("block state root mismatch: got {got}, expected {expected}")]
+    StateRootMismatch { got: B256, expected: B256 },
+    #[error("parent state is not available")]
+    MissingParentState,
 }

--- a/crates/builder/src/validation/mod.rs
+++ b/crates/builder/src/validation/mod.rs
@@ -10,7 +10,15 @@ use alloy_rpc_types::{
     beacon::{relay::BidTrace, requests::ExecutionRequestsV4},
     engine::ExecutionPayloadV3,
 };
-use ethrex_common::types::{Block, BlockHeader};
+use ethrex_blockchain::{BlockchainType, new_evm, vm::StoreVmDatabase};
+use ethrex_common::{
+    types::{AccountUpdate, Block, BlockHeader, ELASTICITY_MULTIPLIER, Receipt},
+    validation::{
+        validate_block_pre_execution, validate_gas_used, validate_receipts_root_and_logs_bloom,
+        validate_requests_hash,
+    },
+};
+use ethrex_crypto::NativeCrypto;
 use ethrex_storage::Store;
 use tokio::sync::watch;
 
@@ -24,6 +32,13 @@ use crate::{
 pub struct PreparedBlock {
     pub block: Block,
     pub parent_header: BlockHeader,
+}
+
+#[derive(Debug)]
+pub struct ExecutedBlock {
+    pub block: Block,
+    pub receipts: Vec<Receipt>,
+    pub account_updates: Vec<AccountUpdate>,
 }
 
 #[derive(Clone)]
@@ -49,6 +64,60 @@ impl BlockValidator {
         self.validate_message_against_header(&block, message)?;
         let parent_header = self.parent_header(&block.header)?;
         Ok(PreparedBlock { block, parent_header })
+    }
+
+    pub fn validate(
+        &self,
+        payload: &ExecutionPayloadV3,
+        message: &BidTrace,
+        parent_beacon_block_root: B256,
+        requests: &ExecutionRequestsV4,
+    ) -> Result<ExecutedBlock, ValidationError> {
+        let prepared = self.prepare(payload, message, parent_beacon_block_root, requests)?;
+        self.execute(prepared)
+    }
+
+    /// Executes against the parent state and checks the header against what
+    /// execution produced. Writes nothing to the store.
+    pub fn execute(&self, prepared: PreparedBlock) -> Result<ExecutedBlock, ValidationError> {
+        let PreparedBlock { block, parent_header } = prepared;
+        let chain_config = self.store.get_chain_config();
+
+        validate_block_pre_execution(&block, &parent_header, &chain_config, ELASTICITY_MULTIPLIER)
+            .map_err(|e| ValidationError::PreExecution(e.to_string()))?;
+
+        let vm_db = StoreVmDatabase::new(self.store.clone(), parent_header)
+            .map_err(|e| ValidationError::Execution(e.to_string()))?;
+        let mut vm = new_evm(&BlockchainType::L1, vm_db)
+            .map_err(|e| ValidationError::Execution(e.to_string()))?;
+
+        let (result, _bal) =
+            vm.execute_block(&block).map_err(|e| ValidationError::Execution(e.to_string()))?;
+
+        validate_gas_used(result.block_gas_used, &block.header)
+            .map_err(|e| ValidationError::PostExecution(e.to_string()))?;
+        validate_receipts_root_and_logs_bloom(&block.header, &result.receipts, &NativeCrypto)
+            .map_err(|e| ValidationError::PostExecution(e.to_string()))?;
+        validate_requests_hash(&block.header, &chain_config, &result.requests)
+            .map_err(|e| ValidationError::PostExecution(e.to_string()))?;
+
+        let account_updates =
+            vm.get_state_transitions().map_err(|e| ValidationError::Execution(e.to_string()))?;
+        let state_root = self
+            .store
+            .apply_account_updates_batch(block.header.parent_hash, &account_updates)
+            .map_err(|e| ValidationError::Store(e.to_string()))?
+            .ok_or(ValidationError::MissingParentState)?
+            .state_trie_hash;
+
+        if state_root != block.header.state_root {
+            return Err(ValidationError::StateRootMismatch {
+                got: b256(block.header.state_root),
+                expected: b256(state_root),
+            });
+        }
+
+        Ok(ExecutedBlock { block, receipts: result.receipts, account_updates })
     }
 
     fn to_block(

--- a/crates/builder/src/validation/tests.rs
+++ b/crates/builder/src/validation/tests.rs
@@ -16,7 +16,9 @@ use helix_common::simulator::BlockSimError;
 use tokio::sync::watch;
 
 use crate::{
-    engine::convert::{b256, block_to_payload_v3, eaddr, requests_to_v4},
+    engine::convert::{
+        b256, block_to_payload_v3, eaddr, h256, payload_v3_to_block, requests_to_v4,
+    },
     node::HeadInfo,
     testing::{ETH, GWEI, dev_genesis_store, funded_signers, signed_transfer},
     validation::{BlockValidator, error::ValidationError},
@@ -141,10 +143,12 @@ impl Fixture {
 
     fn bid_trace(&self, built: &Built) -> BidTrace {
         let header = &built.payload.payload_inner.payload_inner;
+        let block = payload_v3_to_block(&built.payload, B256::ZERO, &built.requests)
+            .expect("the fixture builds a convertible payload");
         BidTrace {
             slot: 1,
             parent_hash: header.parent_hash,
-            block_hash: header.block_hash,
+            block_hash: b256(block.hash()),
             builder_pubkey: Default::default(),
             proposer_pubkey: Default::default(),
             proposer_fee_recipient: self.proposer,
@@ -339,4 +343,154 @@ fn the_relay_classifies_the_parent_errors_it_must_retry() {
     let too_old = BlockSimError::BlockValidationFailed(ValidationError::BlockTooOld.to_string());
     assert!(too_old.is_too_old(), "{too_old}");
     assert!(!too_old.is_demotable(), "{too_old}");
+}
+
+fn withdrawal_request() -> ExecutionRequestsV4 {
+    ExecutionRequestsV4 {
+        withdrawals: vec![alloy_eips::eip7002::WithdrawalRequest {
+            source_address: Address::repeat_byte(0x11),
+            validator_pubkey: alloy_primitives::FixedBytes::repeat_byte(0x22),
+            amount: 1,
+        }],
+        ..Default::default()
+    }
+}
+
+#[tokio::test]
+async fn a_valid_block_passes_execution() {
+    let fixture = Fixture::new().await;
+    let built = fixture.build_on(fixture.genesis_hash, fixture.genesis_timestamp + 12, 0);
+    let message = fixture.bid_trace(&built);
+
+    let executed = fixture
+        .validator()
+        .validate(&built.payload, &message, B256::ZERO, &built.requests)
+        .expect("a block the fixture built must validate");
+
+    assert_eq!(executed.receipts.len(), 1);
+    assert!(!executed.account_updates.is_empty());
+}
+
+/// A simulator must never persist what it validates. The submitted block is not
+/// stored, and the chain does not move.
+#[tokio::test]
+async fn validating_a_block_does_not_store_it() {
+    let fixture = Fixture::new().await;
+    let built = fixture.build_on(fixture.genesis_hash, fixture.genesis_timestamp + 12, 0);
+    let message = fixture.bid_trace(&built);
+
+    fixture
+        .validator()
+        .validate(&built.payload, &message, B256::ZERO, &built.requests)
+        .expect("a block the fixture built must validate");
+
+    assert_eq!(fixture.store.get_latest_block_number().await.unwrap(), 0);
+    assert!(
+        fixture.store.get_block_header_by_hash(h256(message.block_hash)).unwrap().is_none(),
+        "the validated block must not be in the store"
+    );
+}
+
+#[tokio::test]
+async fn a_tampered_state_root_is_rejected() {
+    let fixture = Fixture::new().await;
+    let mut built = fixture.build_on(fixture.genesis_hash, fixture.genesis_timestamp + 12, 0);
+    built.payload.payload_inner.payload_inner.state_root = B256::repeat_byte(0xaa);
+    let message = fixture.bid_trace(&built);
+
+    let error = fixture
+        .validator()
+        .validate(&built.payload, &message, B256::ZERO, &built.requests)
+        .expect_err("a wrong state root must be rejected");
+
+    assert!(matches!(error, ValidationError::StateRootMismatch { .. }), "{error}");
+}
+
+#[tokio::test]
+async fn a_tampered_gas_used_is_rejected() {
+    let fixture = Fixture::new().await;
+    let mut built = fixture.build_on(fixture.genesis_hash, fixture.genesis_timestamp + 12, 0);
+    built.payload.payload_inner.payload_inner.gas_used += 1;
+    let message = fixture.bid_trace(&built);
+
+    let error = fixture
+        .validator()
+        .validate(&built.payload, &message, B256::ZERO, &built.requests)
+        .expect_err("a wrong gas used must be rejected");
+
+    assert!(matches!(error, ValidationError::PostExecution(_)), "{error}");
+}
+
+#[tokio::test]
+async fn a_tampered_receipts_root_is_rejected() {
+    let fixture = Fixture::new().await;
+    let mut built = fixture.build_on(fixture.genesis_hash, fixture.genesis_timestamp + 12, 0);
+    built.payload.payload_inner.payload_inner.receipts_root = B256::repeat_byte(0xbb);
+    let message = fixture.bid_trace(&built);
+
+    let error = fixture
+        .validator()
+        .validate(&built.payload, &message, B256::ZERO, &built.requests)
+        .expect_err("a wrong receipts root must be rejected");
+
+    assert!(matches!(error, ValidationError::PostExecution(_)), "{error}");
+}
+
+/// The requests are submitted alongside the payload and commit into the header,
+/// so a bundle execution did not produce must fail.
+#[tokio::test]
+async fn execution_requests_that_the_block_did_not_produce_are_rejected() {
+    let fixture = Fixture::new().await;
+    let built = fixture.build_on(fixture.genesis_hash, fixture.genesis_timestamp + 12, 0);
+    let requests = withdrawal_request();
+    let tampered = Built { payload: built.payload.clone(), requests };
+    let message = fixture.bid_trace(&tampered);
+
+    let error = fixture
+        .validator()
+        .validate(&tampered.payload, &message, B256::ZERO, &tampered.requests)
+        .expect_err("unproduced requests must be rejected");
+
+    assert!(matches!(error, ValidationError::PostExecution(_)), "{error}");
+}
+
+/// Proves the pre-execution checks run: a bad base fee is caught by
+/// `validate_block_pre_execution`, before any transaction executes.
+#[tokio::test]
+async fn a_tampered_base_fee_is_rejected_before_execution() {
+    let fixture = Fixture::new().await;
+    let mut built = fixture.build_on(fixture.genesis_hash, fixture.genesis_timestamp + 12, 0);
+    built.payload.payload_inner.payload_inner.base_fee_per_gas += U256::from(1);
+    let message = fixture.bid_trace(&built);
+
+    let error = fixture
+        .validator()
+        .validate(&built.payload, &message, B256::ZERO, &built.requests)
+        .expect_err("a wrong base fee must be rejected");
+
+    assert!(matches!(error, ValidationError::PreExecution(_)), "{error}");
+}
+
+#[tokio::test]
+async fn a_block_with_an_unexecutable_transaction_is_rejected() {
+    let fixture = Fixture::new().await;
+    let mut built = fixture.build_on(fixture.genesis_hash, fixture.genesis_timestamp + 12, 0);
+    let bad_nonce = signed_transfer(
+        &fixture.signers[1],
+        fixture.chain_id,
+        99,
+        fixture.proposer,
+        U256::from(1),
+        100 * GWEI,
+        0,
+    );
+    built.payload.payload_inner.payload_inner.transactions.push(bad_nonce.into());
+    let message = fixture.bid_trace(&built);
+
+    let error = fixture
+        .validator()
+        .validate(&built.payload, &message, B256::ZERO, &built.requests)
+        .expect_err("an unexecutable transaction must be rejected");
+
+    assert!(matches!(error, ValidationError::Execution(_)), "{error}");
 }


### PR DESCRIPTION
Issue: #527 (step 4 of 10)

Base branch: `od/builder-sim-validation-step3` (#531, step 3). Retarget as the
stack merges.

## What this PR does

`BlockValidator::execute` runs `validate_block_pre_execution`, executes the
block on its parent state through ethrex's `Evm`, then checks gas used, the
receipts root and logs bloom, the requests hash and the state root. `validate`
chains it onto `prepare`.

The store is read-only throughout. `apply_account_updates_batch` computes the
post-state root in memory without committing, and nothing calls
`Blockchain::add_block`.

## What this PR deliberately does not do

No payment check, no blacklist. Two checks the reth simulator performs are
deliberately absent, both verified rather than assumed:

- `validate_block_body`. It compares the transactions and withdrawals roots
  against the body, but the conversion computes both roots from that body, so it
  cannot fail. The relay checks the transactions root itself.
- Block access lists. `ExecutionPayloadV3` carries no BAL hash, so Amsterdam
  needs a newer payload version before this is checkable at all.

Inclusion lists are now out of scope for this simulator entirely; the issue's
step 7 is struck out. A block that violates a submitted list passes here and
fails on the reth simulator.

## Tests

Written first and signed off before implementation. 8 new, 20 in the file:

- A valid block executes and yields receipts and account updates.
- **Validating does not store the block.** The latest block number stays at 0
  and the block is absent from the store afterwards. This guards the property
  that makes this a simulator and not a node.
- Tampered state root, gas used and receipts root are each rejected.
- Execution requests the block did not produce are rejected.
- A bad base fee is rejected before execution, proving the pre-execution checks
  actually run.
- A transaction with an unusable nonce fails execution.

One fixture change: `bid_trace` recomputes the block hash from the converted
block, so a payload-tampering test reaches execution instead of stopping at the
step 3 bid-trace check.

`just fmt-check`, `just test` and `cargo clippy --all-features --no-deps -- -D warnings`
are clean. 54 tests pass in `helix-builder`, up from 46.

## Reviewer checklist
- [ ] CI (`lint`, `unit-test`) is green
- [ ] Matches the linked issue/step
- [ ] No unexplained scope creep or unrelated files touched