### PR TITLE
Check the proposer payment on both the regular and merged paths

### DIFF
--- a/crates/builder/Cargo.toml
+++ b/crates/builder/Cargo.toml
@@ -34,6 +34,7 @@ flux.workspace = true
 hex.workspace = true
 flux-network.workspace = true
 flux-utils.workspace = true
+helix-common.workspace = true
 helix-tcp-types.workspace = true
 num_cpus.workspace = true
 rand.workspace = true
@@ -53,5 +54,4 @@ uuid = { workspace = true, features = ["serde"] }
 zstd.workspace = true
 
 [dev-dependencies]
-helix-common.workspace = true
 rand_xorshift.workspace = true

--- a/crates/builder/src/engine/convert.rs
+++ b/crates/builder/src/engine/convert.rs
@@ -40,6 +40,10 @@ pub fn au256(v: EU256) -> AU256 {
     AU256::from_be_bytes(v.to_big_endian())
 }
 
+pub fn eu256(v: AU256) -> EU256 {
+    EU256::from_big_endian(&v.to_be_bytes::<32>())
+}
+
 pub fn ewithdrawal(w: &alloy_eips::eip4895::Withdrawal) -> Withdrawal {
     Withdrawal {
         index: w.index,

--- a/crates/builder/src/testing.rs
+++ b/crates/builder/src/testing.rs
@@ -5,7 +5,7 @@ use alloy_eips::eip2718::Encodable2718;
 use alloy_primitives::{Address, U256};
 use alloy_signer::SignerSync;
 use alloy_signer_local::PrivateKeySigner;
-use ethrex_common::types::Genesis;
+use ethrex_common::types::{Genesis, GenesisAccount};
 use ethrex_config::networks::Network;
 use ethrex_storage::{EngineType, Store};
 
@@ -65,10 +65,48 @@ pub fn signed_transfer(
 }
 
 pub async fn dev_genesis_store() -> (Store, Genesis) {
-    let genesis = Network::LocalDevnet.get_genesis().unwrap();
+    dev_genesis_store_with(|_| {}).await
+}
+
+/// `edit` may add allocations before the genesis state root is computed.
+pub async fn dev_genesis_store_with(edit: impl FnOnce(&mut Genesis)) -> (Store, Genesis) {
+    let mut genesis = Network::LocalDevnet.get_genesis().unwrap();
+    edit(&mut genesis);
     let mut store = Store::new("memory", EngineType::InMemory).unwrap();
     store.add_initial_state(genesis.clone()).await.unwrap();
     (store, genesis)
+}
+
+/// The `PaymentForwarder` runtime, from contracts/README.md.
+pub fn deploy_payment_forwarder(genesis: &mut Genesis) {
+    genesis.alloc.insert(eaddr(helix_common::PAYMENT_FORWARDER), GenesisAccount {
+        code: hex::decode("5f358060e01c4218600f5760401cff5b5f5ffd00").unwrap().into(),
+        storage: Default::default(),
+        balance: ethrex_common::U256::zero(),
+        nonce: 0,
+    });
+}
+
+/// A legacy transaction with no chain id, which EIP-155 replay protection does
+/// not cover.
+pub fn signed_unprotected_transfer(
+    signer: &PrivateKeySigner,
+    nonce: u64,
+    to: Address,
+    value: U256,
+    gas_price: u128,
+) -> Vec<u8> {
+    let tx = alloy_consensus::TxLegacy {
+        chain_id: None,
+        nonce,
+        gas_price,
+        gas_limit: 21_000,
+        to: to.into(),
+        value,
+        input: Default::default(),
+    };
+    let signature = signer.sign_hash_sync(&tx.signature_hash()).unwrap();
+    alloy_consensus::TxEnvelope::from(tx.into_signed(signature)).encoded_2718()
 }
 
 pub fn funded_signers(genesis: &Genesis, count: usize) -> Vec<PrivateKeySigner> {

--- a/crates/builder/src/validation/error.rs
+++ b/crates/builder/src/validation/error.rs
@@ -32,4 +32,6 @@ pub enum ValidationError {
     StateRootMismatch { got: B256, expected: B256 },
     #[error("parent state is not available")]
     MissingParentState,
+    #[error("could not verify proposer payment")]
+    ProposerPayment,
 }

--- a/crates/builder/src/validation/mod.rs
+++ b/crates/builder/src/validation/mod.rs
@@ -12,6 +12,7 @@ use alloy_rpc_types::{
 };
 use ethrex_blockchain::{BlockchainType, new_evm, vm::StoreVmDatabase};
 use ethrex_common::{
+    Address as EAddress, U256 as EU256,
     types::{AccountUpdate, Block, BlockHeader, ELASTICITY_MULTIPLIER, Receipt},
     validation::{
         validate_block_pre_execution, validate_gas_used, validate_receipts_root_and_logs_bloom,
@@ -20,10 +21,15 @@ use ethrex_common::{
 };
 use ethrex_crypto::NativeCrypto;
 use ethrex_storage::Store;
+use ethrex_vm::VmDatabase;
+use helix_common::{
+    PAYMENT_FORWARDER, PAYMENT_FORWARDER_CODE_HASH, payment::multisend_paid_amount,
+    payment_forwarder_recipient,
+};
 use tokio::sync::watch;
 
 use crate::{
-    engine::convert::{b256, payload_v3_to_block},
+    engine::convert::{b256, eaddr, eu256, h256, payload_v3_to_block},
     node::HeadInfo,
     validation::error::ValidationError,
 };
@@ -37,6 +43,7 @@ pub struct PreparedBlock {
 #[derive(Debug)]
 pub struct ExecutedBlock {
     pub block: Block,
+    pub parent_header: BlockHeader,
     pub receipts: Vec<Receipt>,
     pub account_updates: Vec<AccountUpdate>,
 }
@@ -74,7 +81,25 @@ impl BlockValidator {
         requests: &ExecutionRequestsV4,
     ) -> Result<ExecutedBlock, ValidationError> {
         let prepared = self.prepare(payload, message, parent_beacon_block_root, requests)?;
-        self.execute(prepared)
+        let executed = self.execute(prepared)?;
+        self.ensure_payment(&executed, message)?;
+        Ok(executed)
+    }
+
+    /// Relay-internal merged-block path. A merged block's payment is split
+    /// across the base block's own payment tx and the appended distribution tx.
+    pub fn validate_merged(
+        &self,
+        payload: &ExecutionPayloadV3,
+        message: &BidTrace,
+        parent_beacon_block_root: B256,
+        requests: &ExecutionRequestsV4,
+        base_payment_tx_index: u64,
+    ) -> Result<ExecutedBlock, ValidationError> {
+        let prepared = self.prepare(payload, message, parent_beacon_block_root, requests)?;
+        let executed = self.execute(prepared)?;
+        self.ensure_merged_payment(&executed, message, base_payment_tx_index as usize)?;
+        Ok(executed)
     }
 
     /// Executes against the parent state and checks the header against what
@@ -86,6 +111,7 @@ impl BlockValidator {
         validate_block_pre_execution(&block, &parent_header, &chain_config, ELASTICITY_MULTIPLIER)
             .map_err(|e| ValidationError::PreExecution(e.to_string()))?;
 
+        let parent_header_for_reads = parent_header.clone();
         let vm_db = StoreVmDatabase::new(self.store.clone(), parent_header)
             .map_err(|e| ValidationError::Execution(e.to_string()))?;
         let mut vm = new_evm(&BlockchainType::L1, vm_db)
@@ -117,7 +143,171 @@ impl BlockValidator {
             });
         }
 
-        Ok(ExecutedBlock { block, receipts: result.receipts, account_updates })
+        Ok(ExecutedBlock {
+            block,
+            parent_header: parent_header_for_reads,
+            receipts: result.receipts,
+            account_updates,
+        })
+    }
+
+    /// The balance delta is the ground truth. It falls short when the proposer
+    /// also spends, and then the last transaction must be a payment.
+    fn ensure_payment(
+        &self,
+        executed: &ExecutedBlock,
+        message: &BidTrace,
+    ) -> Result<(), ValidationError> {
+        if self.paid_by_balance(executed, message)? {
+            return Ok(());
+        }
+
+        let last_ix = executed
+            .block
+            .body
+            .transactions
+            .len()
+            .checked_sub(1)
+            .ok_or(ValidationError::ProposerPayment)?;
+
+        let paid = self.recognized_payment_at(executed, message.proposer_fee_recipient, last_ix)?;
+        // The regular path is a single trailing payment for exactly the bid.
+        if paid != eu256(message.value) {
+            return Err(ValidationError::ProposerPayment);
+        }
+        Ok(())
+    }
+
+    /// Merged counterpart of [`Self::ensure_payment`]. `base_payment_tx_index`
+    /// comes from the relay; a wrong one finds no payment and fails closed.
+    fn ensure_merged_payment(
+        &self,
+        executed: &ExecutedBlock,
+        message: &BidTrace,
+        base_payment_tx_index: usize,
+    ) -> Result<(), ValidationError> {
+        if self.paid_by_balance(executed, message)? {
+            return Ok(());
+        }
+
+        let last_ix = executed
+            .block
+            .body
+            .transactions
+            .len()
+            .checked_sub(1)
+            .ok_or(ValidationError::ProposerPayment)?;
+
+        let recipient = message.proposer_fee_recipient;
+        let mut total = self.recognized_payment_at(executed, recipient, last_ix)?;
+        if base_payment_tx_index != last_ix {
+            total += self.recognized_payment_at(executed, recipient, base_payment_tx_index)?;
+        }
+
+        if total >= eu256(message.value) {
+            return Ok(());
+        }
+        Err(ValidationError::ProposerPayment)
+    }
+
+    /// Withdrawals are consensus-layer income, so they count against the rise
+    /// rather than towards it.
+    fn paid_by_balance(
+        &self,
+        executed: &ExecutedBlock,
+        message: &BidTrace,
+    ) -> Result<bool, ValidationError> {
+        let recipient = eaddr(message.proposer_fee_recipient);
+        let mut before = self.balance_at_parent(&executed.parent_header, recipient)?;
+        let after = executed
+            .account_updates
+            .iter()
+            .find(|update| update.address == recipient)
+            .and_then(|update| update.info.as_ref().map(|info| info.balance))
+            .unwrap_or(before);
+
+        for withdrawal in executed.block.body.withdrawals.iter().flatten() {
+            if withdrawal.address == recipient {
+                before += EU256::from(withdrawal.amount) * EU256::from(1_000_000_000u64);
+            }
+        }
+
+        Ok(after >= before + eu256(message.value))
+    }
+
+    fn balance_at_parent(
+        &self,
+        parent_header: &BlockHeader,
+        address: EAddress,
+    ) -> Result<EU256, ValidationError> {
+        let db = StoreVmDatabase::new(self.store.clone(), parent_header.clone())
+            .map_err(|e| ValidationError::Store(e.to_string()))?;
+        Ok(db
+            .get_account_state(address)
+            .map_err(|e| ValidationError::Store(e.to_string()))?
+            .map(|account| account.balance)
+            .unwrap_or_default())
+    }
+
+    /// What the transaction at `ix` pays `recipient`. Zero rather than an error
+    /// for anything unrecognised: one bad position must not fail the block.
+    fn recognized_payment_at(
+        &self,
+        executed: &ExecutedBlock,
+        recipient: alloy_primitives::Address,
+        ix: usize,
+    ) -> Result<EU256, ValidationError> {
+        let (Some(tx), Some(receipt)) =
+            (executed.block.body.transactions.get(ix), executed.receipts.get(ix))
+        else {
+            return Ok(EU256::zero());
+        };
+        if !receipt.succeeded {
+            return Ok(EU256::zero());
+        }
+
+        let to = match tx.to() {
+            ethrex_common::types::TxKind::Call(to) => Some(to),
+            ethrex_common::types::TxKind::Create => None,
+        };
+        let paid_directly = to == Some(eaddr(recipient)) && tx.data().is_empty();
+        let paid_via_forwarder = to == Some(eaddr(PAYMENT_FORWARDER)) &&
+            payment_forwarder_recipient(tx.data()) == Some(recipient) &&
+            self.forwarder_is_deployed(&executed.parent_header)?;
+
+        let contributed = if paid_directly || paid_via_forwarder {
+            tx.value()
+        } else {
+            eu256(multisend_paid_amount(tx.data(), recipient))
+        };
+        if contributed.is_zero() {
+            return Ok(EU256::zero());
+        }
+
+        // A legacy transaction with no chain id is replayable on another chain.
+        if tx.chain_id() != Some(self.store.get_chain_config().chain_id) {
+            return Ok(EU256::zero());
+        }
+        if !tx
+            .effective_gas_tip(executed.block.header.base_fee_per_gas)
+            .unwrap_or_default()
+            .is_zero()
+        {
+            return Ok(EU256::zero());
+        }
+
+        Ok(contributed)
+    }
+
+    /// A value call to an address with no code succeeds and keeps the value, so
+    /// the forwarder shape only pays where its runtime is present.
+    fn forwarder_is_deployed(&self, parent_header: &BlockHeader) -> Result<bool, ValidationError> {
+        let db = StoreVmDatabase::new(self.store.clone(), parent_header.clone())
+            .map_err(|e| ValidationError::Store(e.to_string()))?;
+        Ok(db
+            .get_account_state(eaddr(PAYMENT_FORWARDER))
+            .map_err(|e| ValidationError::Store(e.to_string()))?
+            .is_some_and(|account| account.code_hash == h256(PAYMENT_FORWARDER_CODE_HASH)))
     }
 
     fn to_block(

--- a/crates/builder/src/validation/tests.rs
+++ b/crates/builder/src/validation/tests.rs
@@ -20,7 +20,10 @@ use crate::{
         b256, block_to_payload_v3, eaddr, h256, payload_v3_to_block, requests_to_v4,
     },
     node::HeadInfo,
-    testing::{ETH, GWEI, dev_genesis_store, funded_signers, signed_transfer},
+    testing::{
+        ETH, GWEI, deploy_payment_forwarder, dev_genesis_store_with, funded_signers,
+        signed_transfer, signed_unprotected_transfer,
+    },
     validation::{BlockValidator, error::ValidationError},
 };
 
@@ -51,7 +54,16 @@ struct Fixture {
 
 impl Fixture {
     async fn new() -> Self {
-        let (store, genesis) = dev_genesis_store().await;
+        Self::with_genesis(|_| {}).await
+    }
+
+    async fn with_forwarder() -> Self {
+        Self::with_genesis(deploy_payment_forwarder).await
+    }
+
+    async fn with_genesis(edit: impl FnOnce(&mut ethrex_common::types::Genesis)) -> Self {
+        let (store, genesis) = dev_genesis_store_with(edit).await;
+        let signers = funded_signers(&genesis, 4);
         let genesis_block = genesis.get_block();
         let blockchain: Arc<Blockchain> = Blockchain::new(store.clone(), BlockchainOptions {
             r#type: BlockchainType::L1,
@@ -74,8 +86,8 @@ impl Fixture {
             genesis_timestamp: genesis_block.header.timestamp,
             chain_id: genesis.config.chain_id,
             gas_limit: genesis_block.header.gas_limit,
-            signers: funded_signers(&genesis, 4),
-            proposer: Address::repeat_byte(0x77),
+            proposer: signers[3].address(),
+            signers,
         }
     }
 
@@ -95,12 +107,37 @@ impl Fixture {
             100 * GWEI,
             0,
         )];
+        self.build_block(parent, timestamp, txs, Vec::new())
+    }
+
+    /// The proposer spends, so its whole-block balance delta falls short of the
+    /// bid value and the payment must be recognised from a transaction.
+    fn proposer_spend(&self, nonce: u64) -> Vec<u8> {
+        signed_transfer(
+            &self.signers[3],
+            self.chain_id,
+            nonce,
+            Address::repeat_byte(0x55),
+            U256::from(GWEI),
+            100 * GWEI,
+            0,
+        )
+    }
+
+    fn build_block(
+        &self,
+        parent: H256,
+        timestamp: u64,
+        txs: Vec<Vec<u8>>,
+        withdrawals: Vec<ethrex_common::types::Withdrawal>,
+    ) -> Built {
+        let builder = &self.signers[0];
         let args = BuildPayloadArgs {
             parent,
             timestamp,
             fee_recipient: eaddr(builder.address()),
             random: H256::zero(),
-            withdrawals: Some(Vec::new()),
+            withdrawals: Some(withdrawals),
             beacon_root: Some(H256::zero()),
             slot_number: None,
             version: 3,
@@ -139,6 +176,33 @@ impl Fixture {
             self.head.send_replace(HeadInfo { number, hash: parent, timestamp, is_synced: true });
         }
         parent
+    }
+
+    fn signed_call(
+        &self,
+        signer: &alloy_signer_local::PrivateKeySigner,
+        nonce: u64,
+        to: Address,
+        value: U256,
+        input: Vec<u8>,
+    ) -> Vec<u8> {
+        use alloy_consensus::SignableTransaction;
+        use alloy_signer::SignerSync;
+        let tx = alloy_consensus::TxEip1559 {
+            chain_id: self.chain_id,
+            nonce,
+            gas_limit: 100_000,
+            max_fee_per_gas: 100 * GWEI,
+            max_priority_fee_per_gas: 0,
+            to: to.into(),
+            value,
+            access_list: Default::default(),
+            input: input.into(),
+        };
+        let signature = signer.sign_hash_sync(&tx.signature_hash()).unwrap();
+        alloy_eips::eip2718::Encodable2718::encoded_2718(&alloy_consensus::TxEnvelope::from(
+            tx.into_signed(signature),
+        ))
     }
 
     fn bid_trace(&self, built: &Built) -> BidTrace {
@@ -493,4 +557,409 @@ async fn a_block_with_an_unexecutable_transaction_is_rejected() {
         .expect_err("an unexecutable transaction must be rejected");
 
     assert!(matches!(error, ValidationError::Execution(_)), "{error}");
+}
+
+/// A block whose transactions raise the proposer's balance by the bid value
+/// needs no recognisable payment transaction.
+#[tokio::test]
+async fn a_payment_by_balance_delta_is_accepted() {
+    let fixture = Fixture::new().await;
+    let value = U256::from(ETH / 2);
+    let txs = vec![
+        signed_transfer(
+            &fixture.signers[1],
+            fixture.chain_id,
+            0,
+            fixture.proposer,
+            value,
+            100 * GWEI,
+            0,
+        ),
+        signed_transfer(
+            &fixture.signers[2],
+            fixture.chain_id,
+            0,
+            Address::repeat_byte(0x66),
+            U256::from(1),
+            100 * GWEI,
+            0,
+        ),
+    ];
+    let built =
+        fixture.build_block(fixture.genesis_hash, fixture.genesis_timestamp + 12, txs, Vec::new());
+    let mut message = fixture.bid_trace(&built);
+    message.value = value;
+
+    fixture
+        .validator()
+        .validate(&built.payload, &message, B256::ZERO, &built.requests)
+        .expect("a balance delta covering the bid must be accepted");
+}
+
+#[tokio::test]
+async fn a_trailing_direct_transfer_is_accepted() {
+    let fixture = Fixture::new().await;
+    let value = U256::from(ETH / 2);
+    let txs = vec![
+        fixture.proposer_spend(0),
+        signed_transfer(
+            &fixture.signers[0],
+            fixture.chain_id,
+            0,
+            fixture.proposer,
+            value,
+            100 * GWEI,
+            0,
+        ),
+    ];
+    let built =
+        fixture.build_block(fixture.genesis_hash, fixture.genesis_timestamp + 12, txs, Vec::new());
+    let mut message = fixture.bid_trace(&built);
+    message.value = value;
+
+    fixture
+        .validator()
+        .validate(&built.payload, &message, B256::ZERO, &built.requests)
+        .expect("a trailing direct transfer must be accepted");
+}
+
+#[tokio::test]
+async fn an_underpaid_block_is_rejected() {
+    let fixture = Fixture::new().await;
+    let paid = U256::from(ETH / 2);
+    let txs = vec![
+        fixture.proposer_spend(0),
+        signed_transfer(
+            &fixture.signers[0],
+            fixture.chain_id,
+            0,
+            fixture.proposer,
+            paid,
+            100 * GWEI,
+            0,
+        ),
+    ];
+    let built =
+        fixture.build_block(fixture.genesis_hash, fixture.genesis_timestamp + 12, txs, Vec::new());
+    let mut message = fixture.bid_trace(&built);
+    message.value = paid + U256::from(1);
+
+    let error = fixture
+        .validator()
+        .validate(&built.payload, &message, B256::ZERO, &built.requests)
+        .expect_err("paying less than the bid must be rejected");
+
+    assert!(matches!(error, ValidationError::ProposerPayment), "{error}");
+}
+
+/// A payment transaction that tips the builder is extracting value the bid did
+/// not account for.
+#[tokio::test]
+async fn a_payment_tx_with_a_priority_fee_is_rejected() {
+    let fixture = Fixture::new().await;
+    let value = U256::from(ETH / 2);
+    let txs = vec![
+        fixture.proposer_spend(0),
+        signed_transfer(
+            &fixture.signers[0],
+            fixture.chain_id,
+            0,
+            fixture.proposer,
+            value,
+            100 * GWEI,
+            GWEI,
+        ),
+    ];
+    let built =
+        fixture.build_block(fixture.genesis_hash, fixture.genesis_timestamp + 12, txs, Vec::new());
+    let mut message = fixture.bid_trace(&built);
+    message.value = value;
+
+    let error = fixture
+        .validator()
+        .validate(&built.payload, &message, B256::ZERO, &built.requests)
+        .expect_err("a tipping payment tx must be rejected");
+
+    assert!(matches!(error, ValidationError::ProposerPayment), "{error}");
+}
+
+/// EIP-155 replay protection binds the payment to this chain. A legacy
+/// transaction carrying no chain id is replayable, so it is not a payment.
+#[tokio::test]
+async fn an_unprotected_payment_tx_is_rejected() {
+    let fixture = Fixture::new().await;
+    let value = U256::from(ETH / 2);
+    let txs = vec![
+        fixture.proposer_spend(0),
+        signed_unprotected_transfer(&fixture.signers[0], 0, fixture.proposer, value, 100 * GWEI),
+    ];
+    let built =
+        fixture.build_block(fixture.genesis_hash, fixture.genesis_timestamp + 12, txs, Vec::new());
+    let mut message = fixture.bid_trace(&built);
+    message.value = value;
+
+    let error = fixture
+        .validator()
+        .validate(&built.payload, &message, B256::ZERO, &built.requests)
+        .expect_err("an unprotected payment tx must be rejected");
+
+    assert!(matches!(error, ValidationError::ProposerPayment), "{error}");
+}
+
+/// A withdrawal is consensus-layer income, not the builder's payment, so it is
+/// added to the balance the payment is measured against.
+#[tokio::test]
+async fn a_withdrawal_does_not_pay_the_bid() {
+    let fixture = Fixture::new().await;
+    let value = U256::from(ETH / 2);
+    let withdrawal = ethrex_common::types::Withdrawal {
+        index: 0,
+        validator_index: 0,
+        address: eaddr(fixture.proposer),
+        amount: 500_000_000, // gwei, == ETH / 2
+    };
+    let built = fixture.build_block(
+        fixture.genesis_hash,
+        fixture.genesis_timestamp + 12,
+        vec![fixture.proposer_spend(0)],
+        vec![withdrawal],
+    );
+    let mut message = fixture.bid_trace(&built);
+    message.value = value;
+
+    let error = fixture
+        .validator()
+        .validate(&built.payload, &message, B256::ZERO, &built.requests)
+        .expect_err("a withdrawal must not count as the bid payment");
+
+    assert!(matches!(error, ValidationError::ProposerPayment), "{error}");
+}
+
+fn forwarder_calldata(timestamp: u64, recipient: Address) -> Vec<u8> {
+    let mut calldata = (timestamp as u32).to_be_bytes().to_vec();
+    calldata.extend_from_slice(recipient.as_slice());
+    calldata
+}
+
+#[tokio::test]
+async fn a_payment_through_the_forwarder_is_accepted() {
+    let fixture = Fixture::with_forwarder().await;
+    let value = U256::from(ETH / 2);
+    let timestamp = fixture.genesis_timestamp + 12;
+    let txs = vec![
+        fixture.proposer_spend(0),
+        fixture.signed_call(
+            &fixture.signers[0],
+            0,
+            helix_common::PAYMENT_FORWARDER,
+            value,
+            forwarder_calldata(timestamp, fixture.proposer),
+        ),
+    ];
+    let built = fixture.build_block(fixture.genesis_hash, timestamp, txs, Vec::new());
+    let mut message = fixture.bid_trace(&built);
+    message.value = value;
+
+    fixture
+        .validator()
+        .validate(&built.payload, &message, B256::ZERO, &built.requests)
+        .expect("a forwarder payment must be accepted where the forwarder is deployed");
+}
+
+/// A value call to an address with no code succeeds and keeps the value, so the
+/// forwarder shape only counts where the forwarder runtime is actually present.
+#[tokio::test]
+async fn a_forwarder_payment_is_rejected_where_the_forwarder_is_absent() {
+    let fixture = Fixture::new().await;
+    let value = U256::from(ETH / 2);
+    let timestamp = fixture.genesis_timestamp + 12;
+    let txs = vec![
+        fixture.proposer_spend(0),
+        fixture.signed_call(
+            &fixture.signers[0],
+            0,
+            helix_common::PAYMENT_FORWARDER,
+            value,
+            forwarder_calldata(timestamp, fixture.proposer),
+        ),
+    ];
+    let built = fixture.build_block(fixture.genesis_hash, timestamp, txs, Vec::new());
+    let mut message = fixture.bid_trace(&built);
+    message.value = value;
+
+    let error = fixture
+        .validator()
+        .validate(&built.payload, &message, B256::ZERO, &built.requests)
+        .expect_err("an undeployed forwarder must not be trusted");
+
+    assert!(matches!(error, ValidationError::ProposerPayment), "{error}");
+}
+
+/// The forwarder reverts unless the calldata timestamp matches the block, and a
+/// reverted payment pays nothing.
+#[tokio::test]
+async fn a_reverted_payment_tx_is_rejected() {
+    let fixture = Fixture::with_forwarder().await;
+    let value = U256::from(ETH / 2);
+    let timestamp = fixture.genesis_timestamp + 12;
+    let txs = vec![
+        fixture.proposer_spend(0),
+        fixture.signed_call(
+            &fixture.signers[0],
+            0,
+            helix_common::PAYMENT_FORWARDER,
+            value,
+            forwarder_calldata(timestamp + 1, fixture.proposer),
+        ),
+    ];
+    let built = fixture.build_block(fixture.genesis_hash, timestamp, txs, Vec::new());
+    let mut message = fixture.bid_trace(&built);
+    message.value = value;
+
+    let error = fixture
+        .validator()
+        .validate(&built.payload, &message, B256::ZERO, &built.requests)
+        .expect_err("a reverted payment must be rejected");
+
+    assert!(matches!(error, ValidationError::ProposerPayment), "{error}");
+}
+
+/// A merged block pays in two places: the base block's own payment transaction,
+/// kept at `base_payment_tx_index`, and the distribution transaction appended
+/// last.
+#[tokio::test]
+async fn a_merged_payment_split_across_two_txs_is_accepted() {
+    let fixture = Fixture::new().await;
+    let base = U256::from(ETH / 4);
+    let added = U256::from(ETH / 4);
+    let txs = vec![
+        fixture.proposer_spend(0),
+        signed_transfer(
+            &fixture.signers[0],
+            fixture.chain_id,
+            0,
+            fixture.proposer,
+            base,
+            100 * GWEI,
+            0,
+        ),
+        signed_transfer(
+            &fixture.signers[1],
+            fixture.chain_id,
+            0,
+            Address::repeat_byte(0x66),
+            U256::from(1),
+            100 * GWEI,
+            0,
+        ),
+        signed_transfer(
+            &fixture.signers[2],
+            fixture.chain_id,
+            0,
+            fixture.proposer,
+            added,
+            100 * GWEI,
+            0,
+        ),
+    ];
+    let built =
+        fixture.build_block(fixture.genesis_hash, fixture.genesis_timestamp + 12, txs, Vec::new());
+    let mut message = fixture.bid_trace(&built);
+    message.value = base + added;
+
+    fixture
+        .validator()
+        .validate_merged(&built.payload, &message, B256::ZERO, &built.requests, 1)
+        .expect("both payment positions must count");
+}
+
+/// The relay supplies `base_payment_tx_index`. A wrong one must fail closed
+/// rather than let an underpaid block through.
+#[tokio::test]
+async fn a_merged_payment_with_a_wrong_base_index_is_rejected() {
+    let fixture = Fixture::new().await;
+    let base = U256::from(ETH / 4);
+    let added = U256::from(ETH / 4);
+    let txs = vec![
+        fixture.proposer_spend(0),
+        signed_transfer(
+            &fixture.signers[0],
+            fixture.chain_id,
+            0,
+            fixture.proposer,
+            base,
+            100 * GWEI,
+            0,
+        ),
+        signed_transfer(
+            &fixture.signers[1],
+            fixture.chain_id,
+            0,
+            Address::repeat_byte(0x66),
+            U256::from(1),
+            100 * GWEI,
+            0,
+        ),
+        signed_transfer(
+            &fixture.signers[2],
+            fixture.chain_id,
+            0,
+            fixture.proposer,
+            added,
+            100 * GWEI,
+            0,
+        ),
+    ];
+    let built =
+        fixture.build_block(fixture.genesis_hash, fixture.genesis_timestamp + 12, txs, Vec::new());
+    let mut message = fixture.bid_trace(&built);
+    message.value = base + added;
+
+    let error = fixture
+        .validator()
+        .validate_merged(&built.payload, &message, B256::ZERO, &built.requests, 2)
+        .expect_err("a wrong base payment index must fail closed");
+
+    assert!(matches!(error, ValidationError::ProposerPayment), "{error}");
+}
+
+/// The regular path only looks at the last transaction, so the same block that
+/// passes as a merged submission fails as a regular one.
+#[tokio::test]
+async fn a_split_payment_is_not_accepted_on_the_regular_path() {
+    let fixture = Fixture::new().await;
+    let base = U256::from(ETH / 4);
+    let added = U256::from(ETH / 4);
+    let txs = vec![
+        fixture.proposer_spend(0),
+        signed_transfer(
+            &fixture.signers[0],
+            fixture.chain_id,
+            0,
+            fixture.proposer,
+            base,
+            100 * GWEI,
+            0,
+        ),
+        signed_transfer(
+            &fixture.signers[2],
+            fixture.chain_id,
+            0,
+            fixture.proposer,
+            added,
+            100 * GWEI,
+            0,
+        ),
+    ];
+    let built =
+        fixture.build_block(fixture.genesis_hash, fixture.genesis_timestamp + 12, txs, Vec::new());
+    let mut message = fixture.bid_trace(&built);
+    message.value = base + added;
+
+    let error = fixture
+        .validator()
+        .validate(&built.payload, &message, B256::ZERO, &built.requests)
+        .expect_err("the regular path must not sum two positions");
+
+    assert!(matches!(error, ValidationError::ProposerPayment), "{error}");
 }


### PR DESCRIPTION
Issue: #527 (step 5 of 10)

Base branch: `od/builder-sim-execute-step4` (#532, step 4). Retarget as the
stack merges.

## What this PR does

`validate` now checks the proposer was paid, and `validate_merged` adds the
relay-internal merged path.

The recipient's whole-block balance delta decides first. It falls short only
when the proposer also spends in the block, and then the payment must be
recognisable in the last transaction: a direct transfer, or a
`PAYMENT_FORWARDER` call where that runtime is actually deployed. Merged blocks
sum two positions, the base block's payment transaction at
`base_payment_tx_index` and the appended distribution transaction.

`helix-common` moves from a dev-dependency to a real one, for the payment
constants and the shared `multisend_paid_amount`. That settles the issue's open
question about when the builder takes that dependency.

## What this PR deliberately does not do

This ports the reth behavior unchanged, including the multiSend weakness in
#533: a payment is credited from calldata rather than from effect. Porting it
as-is keeps both simulators agreeing on what counts as a payment, so no merged
block is accepted by one relay simulator and rejected by another. #533 fixes
both at once in `helix-common`.

No test asserts that a fake multiSend is accepted, so nothing here has to be
un-asserted when #533 lands.

One check reth performs is absent: comparing every payment transaction's chain
id. `validate_block_pre_execution` already rejects a wrong chain id for every
transaction in the block. What survives is the case ethrex exempts — a legacy
transaction carrying no chain id at all — which the payment path still rejects.

## Tests

Written first and signed off before implementation. 12 new, 32 in the file:

- A balance delta covering the bid is accepted with no payment transaction.
- A trailing direct transfer is accepted when the delta falls short.
- Underpayment by one wei, a payment that tips the builder, and an unprotected
  pre-EIP-155 payment are each rejected.
- A withdrawal does not pay the bid: it is consensus-layer income, so it counts
  against the rise rather than towards it.
- A forwarder payment is accepted where the runtime is deployed and rejected
  where it is absent, since a value call to a codeless address succeeds and
  keeps the value. The genesis deploys the real 20-byte runtime from
  `contracts/README.md`, so this executes rather than mocks.
- A reverted payment is rejected, driven by the forwarder's own timestamp check.
- A merged payment split across two positions is accepted; a wrong base index
  fails closed; the same block fails on the regular path, which pins the
  difference between the two entry points.

The fixture's proposer is now a funded signer so it can spend. Without that the
balance delta covers every case and the fallback is never exercised.

`just fmt-check`, `just test` and `cargo clippy --all-features --no-deps -- -D warnings`
are clean. 66 tests pass in `helix-builder`, up from 54.

## Reviewer checklist
- [ ] CI (`lint`, `unit-test`) is green
- [ ] Matches the linked issue/step
- [ ] No unexplained scope creep or unrelated files touched