### PR TITLE
Verify the blobs bundle against the block's blob hashes

### DIFF
--- a/crates/builder/src/testing.rs
+++ b/crates/builder/src/testing.rs
@@ -130,3 +130,41 @@ pub fn funded_signers(genesis: &Genesis, count: usize) -> Vec<PrivateKeySigner> 
     assert_eq!(signers.len(), count, "dev genesis funds too few of the fixture keys");
     signers
 }
+
+/// Blobs with real commitments and EIP-7594 cell proofs. Each blob differs, so
+/// no two commitments collide.
+pub fn blob_bundle(count: usize) -> ethrex_common::types::BlobsBundle {
+    let blobs = (0..count)
+        .map(|i| {
+            let mut blob = [0u8; ethrex_common::types::BYTES_PER_BLOB];
+            blob[0] = i as u8 + 1;
+            blob
+        })
+        .collect();
+    ethrex_common::types::BlobsBundle::create_from_blobs(&blobs, Some(1)).unwrap()
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn signed_blob_transfer(
+    signer: &PrivateKeySigner,
+    chain_id: u64,
+    nonce: u64,
+    to: Address,
+    versioned_hashes: Vec<alloy_primitives::B256>,
+) -> Vec<u8> {
+    let tx = alloy_consensus::TxEip4844 {
+        chain_id,
+        nonce,
+        gas_limit: 100_000,
+        max_fee_per_gas: 100_000_000_000,
+        max_priority_fee_per_gas: 0,
+        to,
+        value: U256::ZERO,
+        access_list: Default::default(),
+        blob_versioned_hashes: versioned_hashes,
+        max_fee_per_blob_gas: 1_000_000_000,
+        input: Default::default(),
+    };
+    let signature = signer.sign_hash_sync(&tx.signature_hash()).unwrap();
+    alloy_consensus::TxEnvelope::from(tx.into_signed(signature)).encoded_2718()
+}

--- a/crates/builder/src/validation/error.rs
+++ b/crates/builder/src/validation/error.rs
@@ -36,4 +36,6 @@ pub enum ValidationError {
     ProposerPayment,
     #[error("block accesses blacklisted address: {0}")]
     Blacklist(Address),
+    #[error("invalid blobs bundle")]
+    InvalidBlobsBundle,
 }

--- a/crates/builder/src/validation/mod.rs
+++ b/crates/builder/src/validation/mod.rs
@@ -16,7 +16,10 @@ use dashmap::DashSet;
 use ethrex_blockchain::{BlockchainType, new_evm, vm::StoreVmDatabase};
 use ethrex_common::{
     Address as EAddress, U256 as EU256,
-    types::{AccountUpdate, Block, BlockHeader, ELASTICITY_MULTIPLIER, Receipt},
+    types::{
+        AccountUpdate, BlobsBundle, Block, BlockHeader, CELLS_PER_EXT_BLOB, ELASTICITY_MULTIPLIER,
+        Receipt, Transaction,
+    },
     validation::{
         validate_block_pre_execution, validate_gas_used, validate_receipts_root_and_logs_bloom,
         validate_requests_hash,
@@ -88,9 +91,11 @@ impl BlockValidator {
         message: &BidTrace,
         parent_beacon_block_root: B256,
         requests: &ExecutionRequestsV4,
+        blobs: &BlobsBundle,
         apply_blacklist: bool,
     ) -> Result<ExecutedBlock, ValidationError> {
         let prepared = self.prepare(payload, message, parent_beacon_block_root, requests)?;
+        self.validate_blobs_bundle(&prepared.block, blobs)?;
         let executed = self.execute(prepared)?;
         if apply_blacklist {
             self.ensure_not_blacklisted(&executed, message)?;
@@ -107,16 +112,64 @@ impl BlockValidator {
         message: &BidTrace,
         parent_beacon_block_root: B256,
         requests: &ExecutionRequestsV4,
+        blobs: &BlobsBundle,
         apply_blacklist: bool,
         base_payment_tx_index: u64,
     ) -> Result<ExecutedBlock, ValidationError> {
         let prepared = self.prepare(payload, message, parent_beacon_block_root, requests)?;
+        self.validate_blobs_bundle(&prepared.block, blobs)?;
         let executed = self.execute(prepared)?;
         if apply_blacklist {
             self.ensure_not_blacklisted(&executed, message)?;
         }
         self.ensure_merged_payment(&executed, message, base_payment_tx_index as usize)?;
         Ok(executed)
+    }
+
+    /// The submission carries one bundle for the whole block, so the block's
+    /// blob hashes must match its commitments in order. ethrex's own
+    /// `BlobsBundle::validate` is per transaction and does not fit that shape.
+    fn validate_blobs_bundle(
+        &self,
+        block: &Block,
+        blobs: &BlobsBundle,
+    ) -> Result<(), ValidationError> {
+        let versioned_hashes: Vec<_> = block
+            .body
+            .transactions
+            .iter()
+            .filter_map(|tx| match tx {
+                Transaction::EIP4844Transaction(tx) => Some(tx.blob_versioned_hashes.clone()),
+                _ => None,
+            })
+            .flatten()
+            .collect();
+
+        if versioned_hashes.is_empty() && blobs.is_empty() {
+            return Ok(());
+        }
+
+        if blobs.blobs.len() != blobs.commitments.len() ||
+            blobs.blobs.len() * CELLS_PER_EXT_BLOB != blobs.proofs.len()
+        {
+            return Err(ValidationError::InvalidBlobsBundle);
+        }
+
+        blobs
+            .validate_blob_commitment_hashes(&versioned_hashes)
+            .map_err(|_| ValidationError::InvalidBlobsBundle)?;
+
+        let valid = ethrex_crypto::kzg::verify_cell_kzg_proof_batch(
+            &blobs.blobs,
+            &blobs.commitments,
+            &blobs.proofs,
+        )
+        .map_err(|_| ValidationError::InvalidBlobsBundle)?;
+        if !valid {
+            return Err(ValidationError::InvalidBlobsBundle);
+        }
+
+        Ok(())
     }
 
     /// Rejects a block that interacts with a listed address. Interaction means

--- a/crates/builder/src/validation/tests.rs
+++ b/crates/builder/src/validation/tests.rs
@@ -22,13 +22,18 @@ use crate::{
     },
     node::HeadInfo,
     testing::{
-        ETH, GWEI, deploy_balance_probe, deploy_payment_forwarder, dev_genesis_store_with,
-        funded_signers, signed_transfer, signed_unprotected_transfer,
+        ETH, GWEI, blob_bundle, deploy_balance_probe, deploy_payment_forwarder,
+        dev_genesis_store_with, funded_signers, signed_blob_transfer, signed_transfer,
+        signed_unprotected_transfer,
     },
     validation::{BlockValidator, error::ValidationError},
 };
 
 const WINDOW: u64 = 3;
+
+fn empty_bundle() -> ethrex_common::types::BlobsBundle {
+    ethrex_common::types::BlobsBundle::default()
+}
 
 struct Built {
     payload: ExecutionPayloadV3,
@@ -479,7 +484,7 @@ async fn a_valid_block_passes_execution() {
 
     let executed = fixture
         .validator()
-        .validate(&built.payload, &message, B256::ZERO, &built.requests, false)
+        .validate(&built.payload, &message, B256::ZERO, &built.requests, &empty_bundle(), false)
         .expect("a block the fixture built must validate");
 
     assert_eq!(executed.receipts.len(), 1);
@@ -496,7 +501,7 @@ async fn validating_a_block_does_not_store_it() {
 
     fixture
         .validator()
-        .validate(&built.payload, &message, B256::ZERO, &built.requests, false)
+        .validate(&built.payload, &message, B256::ZERO, &built.requests, &empty_bundle(), false)
         .expect("a block the fixture built must validate");
 
     assert_eq!(fixture.store.get_latest_block_number().await.unwrap(), 0);
@@ -515,7 +520,7 @@ async fn a_tampered_state_root_is_rejected() {
 
     let error = fixture
         .validator()
-        .validate(&built.payload, &message, B256::ZERO, &built.requests, false)
+        .validate(&built.payload, &message, B256::ZERO, &built.requests, &empty_bundle(), false)
         .expect_err("a wrong state root must be rejected");
 
     assert!(matches!(error, ValidationError::StateRootMismatch { .. }), "{error}");
@@ -530,7 +535,7 @@ async fn a_tampered_gas_used_is_rejected() {
 
     let error = fixture
         .validator()
-        .validate(&built.payload, &message, B256::ZERO, &built.requests, false)
+        .validate(&built.payload, &message, B256::ZERO, &built.requests, &empty_bundle(), false)
         .expect_err("a wrong gas used must be rejected");
 
     assert!(matches!(error, ValidationError::PostExecution(_)), "{error}");
@@ -545,7 +550,7 @@ async fn a_tampered_receipts_root_is_rejected() {
 
     let error = fixture
         .validator()
-        .validate(&built.payload, &message, B256::ZERO, &built.requests, false)
+        .validate(&built.payload, &message, B256::ZERO, &built.requests, &empty_bundle(), false)
         .expect_err("a wrong receipts root must be rejected");
 
     assert!(matches!(error, ValidationError::PostExecution(_)), "{error}");
@@ -563,7 +568,14 @@ async fn execution_requests_that_the_block_did_not_produce_are_rejected() {
 
     let error = fixture
         .validator()
-        .validate(&tampered.payload, &message, B256::ZERO, &tampered.requests, false)
+        .validate(
+            &tampered.payload,
+            &message,
+            B256::ZERO,
+            &tampered.requests,
+            &empty_bundle(),
+            false,
+        )
         .expect_err("unproduced requests must be rejected");
 
     assert!(matches!(error, ValidationError::PostExecution(_)), "{error}");
@@ -580,7 +592,7 @@ async fn a_tampered_base_fee_is_rejected_before_execution() {
 
     let error = fixture
         .validator()
-        .validate(&built.payload, &message, B256::ZERO, &built.requests, false)
+        .validate(&built.payload, &message, B256::ZERO, &built.requests, &empty_bundle(), false)
         .expect_err("a wrong base fee must be rejected");
 
     assert!(matches!(error, ValidationError::PreExecution(_)), "{error}");
@@ -604,7 +616,7 @@ async fn a_block_with_an_unexecutable_transaction_is_rejected() {
 
     let error = fixture
         .validator()
-        .validate(&built.payload, &message, B256::ZERO, &built.requests, false)
+        .validate(&built.payload, &message, B256::ZERO, &built.requests, &empty_bundle(), false)
         .expect_err("an unexecutable transaction must be rejected");
 
     assert!(matches!(error, ValidationError::Execution(_)), "{error}");
@@ -643,7 +655,7 @@ async fn a_payment_by_balance_delta_is_accepted() {
 
     fixture
         .validator()
-        .validate(&built.payload, &message, B256::ZERO, &built.requests, false)
+        .validate(&built.payload, &message, B256::ZERO, &built.requests, &empty_bundle(), false)
         .expect("a balance delta covering the bid must be accepted");
 }
 
@@ -670,7 +682,7 @@ async fn a_trailing_direct_transfer_is_accepted() {
 
     fixture
         .validator()
-        .validate(&built.payload, &message, B256::ZERO, &built.requests, false)
+        .validate(&built.payload, &message, B256::ZERO, &built.requests, &empty_bundle(), false)
         .expect("a trailing direct transfer must be accepted");
 }
 
@@ -697,7 +709,7 @@ async fn an_underpaid_block_is_rejected() {
 
     let error = fixture
         .validator()
-        .validate(&built.payload, &message, B256::ZERO, &built.requests, false)
+        .validate(&built.payload, &message, B256::ZERO, &built.requests, &empty_bundle(), false)
         .expect_err("paying less than the bid must be rejected");
 
     assert!(matches!(error, ValidationError::ProposerPayment), "{error}");
@@ -728,7 +740,7 @@ async fn a_payment_tx_with_a_priority_fee_is_rejected() {
 
     let error = fixture
         .validator()
-        .validate(&built.payload, &message, B256::ZERO, &built.requests, false)
+        .validate(&built.payload, &message, B256::ZERO, &built.requests, &empty_bundle(), false)
         .expect_err("a tipping payment tx must be rejected");
 
     assert!(matches!(error, ValidationError::ProposerPayment), "{error}");
@@ -751,7 +763,7 @@ async fn an_unprotected_payment_tx_is_rejected() {
 
     let error = fixture
         .validator()
-        .validate(&built.payload, &message, B256::ZERO, &built.requests, false)
+        .validate(&built.payload, &message, B256::ZERO, &built.requests, &empty_bundle(), false)
         .expect_err("an unprotected payment tx must be rejected");
 
     assert!(matches!(error, ValidationError::ProposerPayment), "{error}");
@@ -780,7 +792,7 @@ async fn a_withdrawal_does_not_pay_the_bid() {
 
     let error = fixture
         .validator()
-        .validate(&built.payload, &message, B256::ZERO, &built.requests, false)
+        .validate(&built.payload, &message, B256::ZERO, &built.requests, &empty_bundle(), false)
         .expect_err("a withdrawal must not count as the bid payment");
 
     assert!(matches!(error, ValidationError::ProposerPayment), "{error}");
@@ -813,7 +825,7 @@ async fn a_payment_through_the_forwarder_is_accepted() {
 
     fixture
         .validator()
-        .validate(&built.payload, &message, B256::ZERO, &built.requests, false)
+        .validate(&built.payload, &message, B256::ZERO, &built.requests, &empty_bundle(), false)
         .expect("a forwarder payment must be accepted where the forwarder is deployed");
 }
 
@@ -840,7 +852,7 @@ async fn a_forwarder_payment_is_rejected_where_the_forwarder_is_absent() {
 
     let error = fixture
         .validator()
-        .validate(&built.payload, &message, B256::ZERO, &built.requests, false)
+        .validate(&built.payload, &message, B256::ZERO, &built.requests, &empty_bundle(), false)
         .expect_err("an undeployed forwarder must not be trusted");
 
     assert!(matches!(error, ValidationError::ProposerPayment), "{error}");
@@ -869,7 +881,7 @@ async fn a_reverted_payment_tx_is_rejected() {
 
     let error = fixture
         .validator()
-        .validate(&built.payload, &message, B256::ZERO, &built.requests, false)
+        .validate(&built.payload, &message, B256::ZERO, &built.requests, &empty_bundle(), false)
         .expect_err("a reverted payment must be rejected");
 
     assert!(matches!(error, ValidationError::ProposerPayment), "{error}");
@@ -920,7 +932,15 @@ async fn a_merged_payment_split_across_two_txs_is_accepted() {
 
     fixture
         .validator()
-        .validate_merged(&built.payload, &message, B256::ZERO, &built.requests, false, 1)
+        .validate_merged(
+            &built.payload,
+            &message,
+            B256::ZERO,
+            &built.requests,
+            &empty_bundle(),
+            false,
+            1,
+        )
         .expect("both payment positions must count");
 }
 
@@ -968,7 +988,15 @@ async fn a_merged_payment_with_a_wrong_base_index_is_rejected() {
 
     let error = fixture
         .validator()
-        .validate_merged(&built.payload, &message, B256::ZERO, &built.requests, false, 2)
+        .validate_merged(
+            &built.payload,
+            &message,
+            B256::ZERO,
+            &built.requests,
+            &empty_bundle(),
+            false,
+            2,
+        )
         .expect_err("a wrong base payment index must fail closed");
 
     assert!(matches!(error, ValidationError::ProposerPayment), "{error}");
@@ -1009,7 +1037,7 @@ async fn a_split_payment_is_not_accepted_on_the_regular_path() {
 
     let error = fixture
         .validator()
-        .validate(&built.payload, &message, B256::ZERO, &built.requests, false)
+        .validate(&built.payload, &message, B256::ZERO, &built.requests, &empty_bundle(), false)
         .expect_err("the regular path must not sum two positions");
 
     assert!(matches!(error, ValidationError::ProposerPayment), "{error}");
@@ -1038,7 +1066,7 @@ async fn a_blacklisted_sender_is_rejected() {
 
     let error = fixture
         .validator()
-        .validate(&built.payload, &message, B256::ZERO, &built.requests, true)
+        .validate(&built.payload, &message, B256::ZERO, &built.requests, &empty_bundle(), true)
         .expect_err("a listed sender must be rejected");
 
     assert!(matches!(error, ValidationError::Blacklist(_)), "{error}");
@@ -1062,7 +1090,7 @@ async fn a_blacklisted_recipient_is_rejected() {
 
     let error = fixture
         .validator()
-        .validate(&built.payload, &message, B256::ZERO, &built.requests, true)
+        .validate(&built.payload, &message, B256::ZERO, &built.requests, &empty_bundle(), true)
         .expect_err("a listed recipient must be rejected");
 
     assert!(matches!(error, ValidationError::Blacklist(_)), "{error}");
@@ -1088,7 +1116,7 @@ async fn a_blacklisted_coinbase_is_rejected() {
 
     let error = fixture
         .validator()
-        .validate(&built.payload, &message, B256::ZERO, &built.requests, true)
+        .validate(&built.payload, &message, B256::ZERO, &built.requests, &empty_bundle(), true)
         .expect_err("a listed coinbase must be rejected");
 
     assert!(matches!(error, ValidationError::Blacklist(_)), "{error}");
@@ -1103,7 +1131,7 @@ async fn a_blacklisted_proposer_fee_recipient_is_rejected() {
 
     let error = fixture
         .validator()
-        .validate(&built.payload, &message, B256::ZERO, &built.requests, true)
+        .validate(&built.payload, &message, B256::ZERO, &built.requests, &empty_bundle(), true)
         .expect_err("a listed fee recipient must be rejected");
 
     assert!(matches!(error, ValidationError::Blacklist(_)), "{error}");
@@ -1127,7 +1155,7 @@ async fn a_blacklisted_internal_value_target_is_rejected() {
 
     let error = fixture
         .validator()
-        .validate(&built.payload, &message, B256::ZERO, &built.requests, true)
+        .validate(&built.payload, &message, B256::ZERO, &built.requests, &empty_bundle(), true)
         .expect_err("a listed internal value target must be rejected");
 
     assert!(matches!(error, ValidationError::Blacklist(_)), "{error}");
@@ -1145,7 +1173,7 @@ async fn a_blacklisted_created_account_is_rejected() {
 
     let error = fixture
         .validator()
-        .validate(&built.payload, &message, B256::ZERO, &built.requests, true)
+        .validate(&built.payload, &message, B256::ZERO, &built.requests, &empty_bundle(), true)
         .expect_err("a listed created account must be rejected");
 
     assert!(matches!(error, ValidationError::Blacklist(_)), "{error}");
@@ -1167,7 +1195,7 @@ async fn an_account_that_is_only_read_is_not_blacklisted() {
 
     let executed = fixture
         .validator()
-        .validate(&built.payload, &message, B256::ZERO, &built.requests, true)
+        .validate(&built.payload, &message, B256::ZERO, &built.requests, &empty_bundle(), true)
         .expect("a read alone must not reject the block");
 
     assert!(executed.receipts[0].succeeded, "the probe must have run for this to prove anything");
@@ -1181,7 +1209,7 @@ async fn a_block_touching_no_listed_account_passes() {
 
     fixture
         .validator()
-        .validate(&built.payload, &message, B256::ZERO, &built.requests, true)
+        .validate(&built.payload, &message, B256::ZERO, &built.requests, &empty_bundle(), true)
         .expect("a block touching nothing listed must pass");
 }
 
@@ -1206,6 +1234,138 @@ async fn a_non_filtering_proposer_bypasses_the_blacklist() {
 
     fixture
         .validator()
-        .validate(&built.payload, &message, B256::ZERO, &built.requests, false)
+        .validate(&built.payload, &message, B256::ZERO, &built.requests, &empty_bundle(), false)
         .expect("apply_blacklist = false must skip the check");
+}
+
+/// Proves a blob block builds and validates at all, before the negative cases
+/// below rely on that.
+#[tokio::test]
+async fn a_block_with_a_valid_blobs_bundle_passes() {
+    let fixture = Fixture::new().await;
+    let bundle = blob_bundle(1);
+    let hashes: Vec<B256> = bundle.generate_versioned_hashes().iter().map(|h| b256(*h)).collect();
+    let txs = vec![signed_blob_transfer(
+        &fixture.signers[1],
+        fixture.chain_id,
+        0,
+        Address::repeat_byte(0x66),
+        hashes,
+    )];
+    let built =
+        fixture.build_block(fixture.genesis_hash, fixture.genesis_timestamp + 12, txs, Vec::new());
+    let mut message = fixture.bid_trace(&built);
+    message.value = U256::ZERO;
+
+    let executed = fixture
+        .validator()
+        .validate(&built.payload, &message, B256::ZERO, &built.requests, &bundle, false)
+        .expect("a valid blobs bundle must pass");
+
+    assert!(
+        executed.block.header.blob_gas_used.unwrap_or_default() > 0,
+        "the blob tx must be in the block for this to prove anything"
+    );
+}
+
+/// Builds a one-blob block whose bundle the test then damages.
+async fn blob_block(fixture: &Fixture) -> (Built, BidTrace, ethrex_common::types::BlobsBundle) {
+    let bundle = blob_bundle(1);
+    let hashes: Vec<B256> = bundle.generate_versioned_hashes().iter().map(|h| b256(*h)).collect();
+    let txs = vec![signed_blob_transfer(
+        &fixture.signers[1],
+        fixture.chain_id,
+        0,
+        Address::repeat_byte(0x66),
+        hashes,
+    )];
+    let built =
+        fixture.build_block(fixture.genesis_hash, fixture.genesis_timestamp + 12, txs, Vec::new());
+    let mut message = fixture.bid_trace(&built);
+    message.value = U256::ZERO;
+    (built, message, bundle)
+}
+
+#[tokio::test]
+async fn a_bundle_whose_commitments_do_not_match_the_block_is_rejected() {
+    let fixture = Fixture::new().await;
+    let (built, message, mut bundle) = blob_block(&fixture).await;
+    bundle.commitments[0] = blob_bundle(2).commitments[1];
+
+    let error = fixture
+        .validator()
+        .validate(&built.payload, &message, B256::ZERO, &built.requests, &bundle, false)
+        .expect_err("commitments not matching the block's hashes must be rejected");
+
+    assert!(matches!(error, ValidationError::InvalidBlobsBundle), "{error}");
+}
+
+#[tokio::test]
+async fn a_bundle_with_a_wrong_proof_count_is_rejected() {
+    let fixture = Fixture::new().await;
+    let (built, message, mut bundle) = blob_block(&fixture).await;
+    bundle.proofs.pop();
+
+    let error = fixture
+        .validator()
+        .validate(&built.payload, &message, B256::ZERO, &built.requests, &bundle, false)
+        .expect_err("a short proof list must be rejected");
+
+    assert!(matches!(error, ValidationError::InvalidBlobsBundle), "{error}");
+}
+
+#[tokio::test]
+async fn a_bundle_with_an_invalid_cell_proof_is_rejected() {
+    let fixture = Fixture::new().await;
+    let (built, message, mut bundle) = blob_block(&fixture).await;
+    bundle.proofs[0] = ethrex_common::types::Proof::from([0u8; 48]);
+
+    let error = fixture
+        .validator()
+        .validate(&built.payload, &message, B256::ZERO, &built.requests, &bundle, false)
+        .expect_err("a corrupt cell proof must be rejected");
+
+    assert!(matches!(error, ValidationError::InvalidBlobsBundle), "{error}");
+}
+
+#[tokio::test]
+async fn a_bundle_carrying_more_blobs_than_the_block_is_rejected() {
+    let fixture = Fixture::new().await;
+    let (built, message, _) = blob_block(&fixture).await;
+    let bundle = blob_bundle(2);
+
+    let error = fixture
+        .validator()
+        .validate(&built.payload, &message, B256::ZERO, &built.requests, &bundle, false)
+        .expect_err("a bundle with a spare blob must be rejected");
+
+    assert!(matches!(error, ValidationError::InvalidBlobsBundle), "{error}");
+}
+
+#[tokio::test]
+async fn a_blob_tx_with_an_empty_bundle_is_rejected() {
+    let fixture = Fixture::new().await;
+    let (built, message, _) = blob_block(&fixture).await;
+
+    let error = fixture
+        .validator()
+        .validate(&built.payload, &message, B256::ZERO, &built.requests, &empty_bundle(), false)
+        .expect_err("a blob tx without its blobs must be rejected");
+
+    assert!(matches!(error, ValidationError::InvalidBlobsBundle), "{error}");
+}
+
+/// Blobs the block never referenced are not free to attach.
+#[tokio::test]
+async fn a_bundle_for_a_block_with_no_blob_txs_is_rejected() {
+    let fixture = Fixture::new().await;
+    let built = fixture.build_on(fixture.genesis_hash, fixture.genesis_timestamp + 12, 0);
+    let message = fixture.bid_trace(&built);
+
+    let error = fixture
+        .validator()
+        .validate(&built.payload, &message, B256::ZERO, &built.requests, &blob_bundle(1), false)
+        .expect_err("a bundle for a blobless block must be rejected");
+
+    assert!(matches!(error, ValidationError::InvalidBlobsBundle), "{error}");
 }


### PR DESCRIPTION
Issue: #527 (step 8 of 10)

Base branch: `od/builder-sim-blacklist-step6` (#535, step 6). Retarget as the
stack merges.

## What this PR does

`validate` and `validate_merged` take the submission's `BlobsBundle` and check
it against the block:

- blob, commitment and cell-proof counts agree (`blobs * CELLS_PER_EXT_BLOB`);
- the block's blob versioned hashes, gathered in order across every blob
  transaction, match the bundle's commitments;
- `verify_cell_kzg_proof_batch` accepts the proofs.

ethrex's own `BlobsBundle::validate` is per transaction, and a submission
carries one bundle for the whole block, so it does not fit that shape. The parts
that do fit — `validate_blob_commitment_hashes` and the KZG batch verify — are
called directly rather than reimplemented.

Blob *gas* accounting needs nothing here: `verify_blob_gas_usage` already runs
inside `validate_block_pre_execution`, which step 4 calls.

## What this PR deliberately does not do

No pre-Fulu bundle format. Only EIP-7594 cell proofs are accepted, matching the
decision to serve V5 and the merged method only.

## Tests

Written first and signed off before implementation. 7 new, 48 in the file:

- A valid one-blob block passes. It asserts `blob_gas_used > 0`, so it cannot
  pass by the blob transaction having been dropped from the block.
- Commitments that do not match the block's hashes, a short proof list, a
  corrupt cell proof, a spare blob, and an empty bundle for a block that has a
  blob transaction are each rejected.
- A bundle attached to a block with no blob transactions is rejected.

The bundles are real: `BlobsBundle::create_from_blobs` computes genuine
commitments and cell proofs, and `verify_cell_kzg_proof_batch` is doing actual
work in these tests.

One fixture note: the blobs differ from each other by construction. With
all-zero blobs every commitment is identical, which silently turned the
commitment-mismatch test into a no-op — it passed while testing nothing.

`just fmt-check`, `just test` and `cargo clippy --all-features --no-deps -- -D warnings`
are clean. 82 tests pass in `helix-builder`, up from 75.

## Reviewer checklist
- [ ] CI (`lint`, `unit-test`) is green
- [ ] Matches the linked issue/step
- [ ] No unexplained scope creep or unrelated files touched