### PR TITLE
Feed the sim tile's hydration cache on arrival (#537 step 1)

### DIFF
--- a/crates/relay/src/simulator/tile.rs
+++ b/crates/relay/src/simulator/tile.rs
@@ -999,7 +999,8 @@ mod tests {
     use alloy_primitives::{Address, U256};
     use helix_types::{
         BlobWithMetadata, BlobsBundle, ExecutionPayload, ExecutionRequests, MergedBlockTrace,
-        TestRandom,
+        TestRandom, dehydrated_submission_with_txs_for_test, full_tx_for_test, tx_cache_key,
+        tx_hash_ref_for_test,
     };
     use rand::{SeedableRng, rngs::SmallRng};
 
@@ -1026,6 +1027,68 @@ mod tests {
             base_payment_tx_index: 0,
             trace: MergedBlockTrace::default(),
         }
+    }
+
+    fn test_tile() -> SimulatorTile {
+        let (task_tx, rx) = crossbeam_channel::unbounded();
+        SimulatorTile {
+            simulators: vec![],
+            ssz_sim_indices: vec![],
+            requests: PendingRequests::with_capacity(4),
+            priority_requests: PendingRequests::with_capacity(4),
+            merge_requests: PendingMergeRequests::with_capacity(4),
+            last_bid_slot: 0,
+            local_telemetry: LocalTelemetry::default(),
+            sim_slot_stats: vec![],
+            task_tx,
+            rx,
+            sim_requests: Arc::new(SharedVector::default()),
+            sim_results: Arc::new(SharedVector::default()),
+            decoded: Arc::new(SharedVector::default()),
+            merged_blocks: Arc::new(SharedVector::default()),
+            hydration_cache: SimHydrationCache::new(),
+            chain_info: ChainInfo::default(),
+            accept_optimistic: Arc::new(AtomicBool::new(true)),
+            failsafe_triggered: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    /// gattaca-com/helix#537: a submission the tile queues instead of simulating
+    /// must still put its full transactions in the cache, so a later submission
+    /// that references them can be hydrated whatever order the two arrive in.
+    #[test]
+    fn feed_cache_fills_from_a_submission_that_is_not_simulated() {
+        let tx = full_tx_for_test(1);
+        let earlier = dehydrated_submission_with_txs_for_test(vec![tx.clone()]);
+        let later =
+            dehydrated_submission_with_txs_for_test(vec![tx_hash_ref_for_test(tx_cache_key(&tx))]);
+
+        let mut tile = test_tile();
+        tile.feed_cache(&Submission::Dehydrated(earlier));
+
+        let max_blobs = tile.chain_info.max_blobs_per_block();
+        assert!(
+            tile.hydration_cache.can_hydrate(&later, max_blobs),
+            "a queued submission's transactions must be usable by the next submission"
+        );
+    }
+
+    /// A full submission carries no hash references, so feeding it is a no-op for
+    /// the cache: only dehydrated submissions contribute keys.
+    #[test]
+    fn feed_cache_ignores_full_submissions() {
+        let mut tile = test_tile();
+        let before = tile.hydration_cache.tx_count();
+
+        let mut rng = SmallRng::seed_from_u64(7);
+        let payload = ExecutionPayload::random_for_test(&mut rng);
+        let response = merge_response(payload, U256::ZERO, vec![]);
+        let req = merge_request(response.base_block_hash, 0);
+        let full = merged_block_to_submission(&response, &req).unwrap();
+
+        tile.feed_cache(&Submission::Full(full));
+
+        assert_eq!(tile.hydration_cache.tx_count(), before);
     }
 
     fn merge_request(base_block_hash: B256, receive_ns: u64) -> MergedValidationRequest {

--- a/crates/relay/src/simulator/tile.rs
+++ b/crates/relay/src/simulator/tile.rs
@@ -231,6 +231,11 @@ impl SimulatorTile {
         let builder_pubkey = *decoded_data.submission_data.submission.builder_pubkey();
         assert_eq!(decoded_data.submission_data.submission.bid_slot(), self.last_bid_slot);
 
+        // Before deciding whether to simulate or queue: a queued submission would
+        // otherwise leave no trace in the cache, and the next submission to
+        // reference its transactions could not be hydrated.
+        self.feed_cache(&decoded_data.submission_data.submission);
+
         self.local_telemetry.sims_reqs += 1;
 
         let sim_id = self.select_simulator(&builder_pubkey);
@@ -240,19 +245,12 @@ impl SimulatorTile {
             self.spawn_sim(id, req)
         } else {
             self.local_telemetry.queued += 1;
-            let evicted = if fast_track {
-                self.priority_requests.store(req, builder_pubkey, &mut self.local_telemetry)
+            // Every request feeds the cache on arrival, so an evicted one has
+            // already contributed its transactions.
+            if fast_track {
+                self.priority_requests.store(req, builder_pubkey, &mut self.local_telemetry);
             } else {
-                self.requests.store(req, builder_pubkey, &mut self.local_telemetry)
-            };
-            // A dropped dehydrated request may carry full transactions that haven't
-            // been inserted into the cache yet. Hydrate it now so subsequent
-            // dehydrated submissions from this builder can resolve their tx hashes.
-            if let Some(evicted_req) = evicted &&
-                let Some(data) = self.decoded.get(evicted_req.decoded_ix) &&
-                let Submission::Dehydrated(d) = data.submission_data.submission.clone()
-            {
-                let _ = self.hydration_cache.hydrate(d, self.chain_info.max_blobs_per_block());
+                self.requests.store(req, builder_pubkey, &mut self.local_telemetry);
             }
         }
     }
@@ -310,6 +308,15 @@ impl SimulatorTile {
             } else if let Some(req) = self.merge_requests.next_req() {
                 self.spawn_merge_sim(id, req);
             }
+        }
+    }
+
+    /// Even when a submission is queued instead of simulated, its full
+    /// transactions and blobs must enter the cache so later dehydrated
+    /// submissions can resolve their references.
+    fn feed_cache(&mut self, submission: &Submission) {
+        if let Submission::Dehydrated(d) = submission {
+            self.hydration_cache.feed(d);
         }
     }
 

--- a/crates/types/src/hydration.rs
+++ b/crates/types/src/hydration.rs
@@ -566,6 +566,17 @@ impl SimHydrationCache {
         }
     }
 
+    /// Inserts the submission's full transactions and new blobs into the cache
+    /// without building the hydrated payload, so a submission the sim tile will
+    /// not hydrate still lets later submissions resolve their references.
+    pub fn feed(&mut self, submission: &DehydratedBidSubmission) {
+        match submission {
+            DehydratedBidSubmission::Fulu(s) => {
+                s.feed_inner(&mut self.transactions, &mut self.blobs_fulu);
+            }
+        }
+    }
+
     pub fn clear(&mut self) {
         self.transactions.clear();
         self.blobs_fulu.clear();

--- a/crates/types/src/hydration.rs
+++ b/crates/types/src/hydration.rs
@@ -15,7 +15,7 @@ use crate::{
     BlsSignatureBytes, ExecutionPayload, SignedBidSubmission, TestRandom,
     bid_adjustment_data::{BidAdjData, BidAdjustmentData, BidAdjustmentDataV1},
     bid_submission,
-    fields::{ExecutionRequests, KzgCommitment, KzgProof, Transaction},
+    fields::{ExecutionRequests, KzgCommitment, KzgProof, Transaction, Transactions},
 };
 
 /// A bid submission where transactions and blobs may be replaced by hashes instead of payload
@@ -681,11 +681,128 @@ pub enum HydrationError {
     TooManyBlobs { blobs: usize, max: usize },
 }
 
+/// Test helpers. These live here because `DehydratedBidSubmissionFulu`'s fields are
+/// private to this module, and the relay's tile tests need control over which
+/// transactions a submission carries in full and which it carries by reference.
+/// A transaction long enough to be keyed, rather than read as a hash reference.
+pub fn full_tx_for_test(fill: u8) -> Transaction {
+    Transaction(vec![fill; TX_KEY_SIZE + 5].into())
+}
+
+/// The cache key a full transaction is stored under.
+pub fn tx_cache_key(tx: &Transaction) -> u64 {
+    let mut hasher = FxHasher::default();
+    hasher.write(&tx[tx.len() - TX_KEY_SIZE..]);
+    hasher.finish()
+}
+
+/// The 8-byte stand-in a builder sends once the relay has seen the full transaction.
+pub fn tx_hash_ref_for_test(key: u64) -> Transaction {
+    Transaction(key.to_le_bytes().to_vec().into())
+}
+
+/// A dehydrated submission whose payload holds exactly `txs` and no blobs.
+pub fn dehydrated_submission_with_txs_for_test(txs: Vec<Transaction>) -> DehydratedBidSubmission {
+    let (dehydrated, _) =
+        DehydratedBidSubmissionFuluWithMergingData::random_for_test(&mut rand::rng()).split();
+    let DehydratedBidSubmission::Fulu(mut s) = dehydrated;
+    s.execution_payload.transactions = Transactions::new(txs).expect("tx list within limits");
+    s.blobs_bundle = DehydratedBlobsFulu { commitments: vec![], new_items: vec![] };
+    DehydratedBidSubmission::Fulu(s)
+}
+
 #[cfg(test)]
 mod tests {
     use ssz::Encode;
 
     use super::*;
+
+    const MAX_BLOBS: usize = 9;
+
+    fn full_tx(fill: u8) -> Transaction {
+        full_tx_for_test(fill)
+    }
+
+    fn tx_key(tx: &Transaction) -> u64 {
+        tx_cache_key(tx)
+    }
+
+    fn tx_ref(key: u64) -> Transaction {
+        tx_hash_ref_for_test(key)
+    }
+
+    fn submission_with(txs: Vec<Transaction>) -> DehydratedBidSubmission {
+        dehydrated_submission_with_txs_for_test(txs)
+    }
+
+    /// Documents the failure behind gattaca-com/helix#537: the sim tile's cache is
+    /// populated only by `hydrate`, so a submission that arrived and was queued
+    /// without being simulated leaves no trace, and the next submission that
+    /// references its transactions cannot be hydrated.
+    #[test]
+    fn sim_cache_misses_when_the_earlier_submission_was_only_queued() {
+        let tx = full_tx(1);
+        let earlier = submission_with(vec![tx.clone()]);
+        let later = submission_with(vec![tx_ref(tx_key(&tx))]);
+
+        let mut cache = SimHydrationCache::new();
+
+        assert!(!cache.can_hydrate(&later, MAX_BLOBS));
+        assert!(matches!(
+            cache.hydrate(later, MAX_BLOBS),
+            Err(HydrationError::UnknownTxHash { .. })
+        ));
+
+        // Building the earlier payload is currently the only way to fill the cache.
+        assert!(cache.hydrate(earlier, MAX_BLOBS).is_ok());
+    }
+
+    /// `feed` must fill the cache from a submission the tile is not going to
+    /// hydrate, so arrival order stops deciding whether a later submission can be
+    /// simulated. Mirrors `HydrationCache::feed`, used by the merging tile.
+    #[test]
+    fn sim_cache_feed_enables_later_hydration_without_building_a_payload() {
+        let tx = full_tx(2);
+        let earlier = submission_with(vec![tx.clone()]);
+        let later = submission_with(vec![tx_ref(tx_key(&tx))]);
+
+        let mut cache = SimHydrationCache::new();
+        cache.feed(&earlier);
+
+        assert_eq!(cache.tx_count(), 1);
+        assert!(cache.can_hydrate(&later, MAX_BLOBS));
+
+        let hydrated = cache.hydrate(later, MAX_BLOBS).expect("hydration should succeed");
+        assert_eq!(hydrated.tx_cache_hits, 1, "the reference must resolve from the cache");
+        assert_eq!(hydrated.submission.execution_payload.transactions.len(), 1);
+    }
+
+    /// Feeding the same submission twice must not change what the cache holds,
+    /// since every arriving submission is fed and retries re-send the same bid.
+    #[test]
+    fn sim_cache_feed_is_idempotent() {
+        let tx = full_tx(3);
+        let submission = submission_with(vec![tx.clone()]);
+
+        let mut cache = SimHydrationCache::new();
+        cache.feed(&submission);
+        cache.feed(&submission);
+
+        assert_eq!(cache.tx_count(), 1);
+    }
+
+    /// A hash reference carries no transaction bytes, so feeding a submission that
+    /// holds only references must add nothing.
+    #[test]
+    fn sim_cache_feed_ignores_hash_references() {
+        let tx = full_tx(4);
+        let only_refs = submission_with(vec![tx_ref(tx_key(&tx))]);
+
+        let mut cache = SimHydrationCache::new();
+        cache.feed(&only_refs);
+
+        assert_eq!(cache.tx_count(), 0);
+    }
 
     #[test]
     fn dehydrated_with_merging_data_ssz_round_trip() {


### PR DESCRIPTION
Issue: #537 (step 1 of 2)

## What this PR does

`SimHydrationCache` was filled only by `hydrate()`, so a submission the sim
tile queued instead of simulating left no trace in the cache, and the next
submission to reference its transactions could not be hydrated. This feeds the
cache when a request arrives, before the spawn-or-queue branch, so arrival
order no longer decides whether a submission can be simulated.

On mainnet (`titan_relay.log.2026-08-30`) that failure dropped 632,589
simulations in a day, about 88 per slot. Optimistic bids were already sorted
into the auction and acknowledged, so they stayed eligible with no validation
behind them; non-optimistic builders got `InternalError` for well-formed
submissions.

`BlockMergingTile::feed_cache` already does exactly this, with a comment
explaining why. This mirrors it in the sim tile, and removes the
eviction-time hydrate that was a partial workaround for the same problem.

## What this PR deliberately does not do

- It does not construct `BlockSimError::HydrationMiss`, which is defined in
  `crates/common/src/simulator.rs:92` but never built — hydration failures
  still report `RpcError`. That is #537 step 2, together with the `unkown tx`
  typo in `crates/types/src/hydration.rs`.
- It does not make `SimHydrationCache` per-builder. It stays keyed globally by
  an `FxHash` of a transaction's last 67 bytes, while `HydrationCache` is keyed
  per builder pubkey. The open question on #537 covers whether that should
  change.
- It does not touch the ordering itself: `handle_task_response` still drains
  `priority_requests` before `requests`. Feeding on arrival makes that
  ordering harmless rather than removing it.

## Tests

Tests were written first, in commit `b34f920e`, before any implementation.
`sim_cache_misses_when_the_earlier_submission_was_only_queued` passed against
the unfixed code and is kept as the control.

`crates/types/src/hydration.rs`:
- `sim_cache_misses_when_the_earlier_submission_was_only_queued` — the failure
  this fixes, and still the behaviour when nothing feeds the cache
- `sim_cache_feed_enables_later_hydration_without_building_a_payload` — after
  `feed`, the reference resolves and `tx_cache_hits == 1`
- `sim_cache_feed_is_idempotent` — retries re-send the same bid
- `sim_cache_feed_ignores_hash_references` — a submission of only references
  adds nothing

`crates/relay/src/simulator/tile.rs`:
- `feed_cache_fills_from_a_submission_that_is_not_simulated`
- `feed_cache_ignores_full_submissions`

Two notes for the reviewer. The tests cover `feed_cache` directly rather than
through `handle_sim_request`, because that takes `&mut HelixSpineProducers`,
which is not constructible in a unit test — the same trade-off the merging
tile's tests make, so the one-line call site rests on review. And the tests
needed four `pub` helpers in `hydration.rs`
(`full_tx_for_test`, `tx_cache_key`, `tx_hash_ref_for_test`,
`dehydrated_submission_with_txs_for_test`), because
`DehydratedBidSubmissionFulu`'s fields are private to that module and the
relay crate cannot otherwise build a submission with chosen transactions. Say
if you would rather they sat behind a `test-utils` feature.

`just fmt-check`, `cargo clippy --all-features --no-deps -- -D warnings` and
`just test` are all green locally (232 passed, 0 failed, 8 pre-existing
ignored).

## Reviewer checklist
- [ ] CI (`lint`, `unit-test`) is green
- [ ] Matches the linked issue/step
- [ ] No unexplained scope creep or unrelated files touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)