### PR TITLE
Stop forwarding once the merge builder is past our slot (#538 step 1)

### DIFF
--- a/crates/relay/src/block_merging/tile.rs
+++ b/crates/relay/src/block_merging/tile.rs
@@ -1206,7 +1206,7 @@ mod tests {
     use helix_tcp_types::{
         MergeType,
         merging::{
-            builder_to_relay::MergeTraceV1,
+            builder_to_relay::{MergeTraceV1, RejectCode, RejectSubject},
             order::{BundleOrderRef, TxOrderRef},
         },
     };
@@ -1504,6 +1504,132 @@ mod tests {
 
         assert!(tile.conn.activated.is_none());
         assert_eq!(tile.stats.activations_sent, 0);
+    }
+
+    fn reject(slot: u64, code: RejectCode) -> RejectV1 {
+        RejectV1 {
+            slot,
+            code,
+            subject: RejectSubject::BlockHash(B256::repeat_byte(7)),
+            msg: b"test".to_vec(),
+        }
+    }
+
+    /// Sets up a tile mid-slot with a handshaken connection, ready to forward.
+    fn tile_in_slot(bid_slot: u64) -> BlockMergingTile {
+        let mut tile = test_tile(true);
+        tile.slot.bid_slot = bid_slot;
+        tile.slot.slot_start = Some(SlotStartV1 {
+            slot: bid_slot,
+            parent_hash: B256::ZERO,
+            proposer_fee_recipient: Address::ZERO,
+            parent_beacon_block_root: B256::ZERO,
+        });
+        tile.token = Some(Token(0));
+        tile.conn.active = true;
+        // `max_frame_bytes` stays 0, so a forward that gets past the guards stops at
+        // the over-limits check and never reaches the connector, which has no real
+        // socket in tests.
+        tile
+    }
+
+    /// gattaca-com/helix#538: the merge builder validates against its own head, not
+    /// our `SlotStartV1`. Once it has refused this slot as stale, everything else we
+    /// send for the slot is refused too, so stop sending.
+    #[test]
+    fn stale_slot_reject_stops_forwarding_for_the_rest_of_the_slot() {
+        let mut tile = tile_in_slot(5);
+        tile.on_reject(Token(0), reject(5, RejectCode::StaleSlot));
+
+        let block_hash = B256::repeat_byte(1);
+        let ix = tile.decoded.push(test_submission(5, block_hash, true));
+        tile.forward_decoded(ix, None);
+
+        assert!(tile.slot.appendable.is_empty(), "nothing should be forwarded");
+        assert!(tile.slot.replay_log.is_empty());
+        assert_eq!(tile.stats.skipped_builder_ahead, 1);
+    }
+
+    /// The builder's `RejectV1.slot` is its own current slot, so a reject naming a
+    /// later slot proves we are behind whatever the code says. `tcp-types` does not
+    /// document the field and helix's own builder puts the request's slot there, so
+    /// both signals are honoured.
+    #[test]
+    fn reject_naming_a_later_slot_stops_forwarding() {
+        let mut tile = tile_in_slot(5);
+        tile.on_reject(Token(0), reject(6, RejectCode::Busy));
+
+        let ix = tile.decoded.push(test_submission(5, B256::repeat_byte(2), true));
+        tile.forward_decoded(ix, None);
+
+        assert!(tile.slot.appendable.is_empty());
+        assert_eq!(tile.stats.skipped_builder_ahead, 1);
+    }
+
+    /// A reject for the current slot that is not about staleness says nothing about
+    /// the builder's head, so forwarding must continue.
+    #[test]
+    fn other_reject_codes_for_the_current_slot_do_not_stop_forwarding() {
+        let mut tile = tile_in_slot(5);
+        tile.on_reject(Token(0), reject(5, RejectCode::Busy));
+        tile.on_reject(Token(0), reject(5, RejectCode::InvalidOrder));
+
+        let block_hash = B256::repeat_byte(3);
+        let ix = tile.decoded.push(test_submission(5, block_hash, true));
+        tile.forward_decoded(ix, None);
+
+        assert!(tile.slot.appendable.contains(&block_hash));
+        assert_eq!(tile.stats.skipped_builder_ahead, 0);
+    }
+
+    /// A reject from a connection that is not ours must not gate our forwarding.
+    #[test]
+    fn reject_from_another_token_is_ignored() {
+        let mut tile = tile_in_slot(5);
+        tile.on_reject(Token(1), reject(5, RejectCode::StaleSlot));
+
+        let block_hash = B256::repeat_byte(4);
+        let ix = tile.decoded.push(test_submission(5, block_hash, true));
+        tile.forward_decoded(ix, None);
+
+        assert!(tile.slot.appendable.contains(&block_hash));
+        assert_eq!(tile.stats.skipped_builder_ahead, 0);
+    }
+
+    /// Activating a base block while the builder is past our slot is what produces
+    /// the `UnknownBaseBlock` rejects downstream, so it must stop too.
+    #[test]
+    fn stale_slot_reject_stops_activation() {
+        let mut tile = tile_in_slot(5);
+        let block_hash = B256::repeat_byte(5);
+        tile.slot.appendable.insert(block_hash);
+        tile.conn.forwarded.insert(block_hash);
+
+        tile.on_reject(Token(0), reject(5, RejectCode::StaleSlot));
+        tile.on_top_bid(TopBidUpdate {
+            timestamp: 1,
+            slot: 5,
+            block_number: 0,
+            block_hash,
+            parent_hash: B256::ZERO,
+            builder_pubkey: BlsPublicKeyBytes::default(),
+            fee_recipient: Address::ZERO,
+            value: U256::ZERO,
+        });
+
+        assert!(tile.conn.activated.is_none());
+        assert_eq!(tile.stats.activations_sent, 0);
+    }
+
+    /// The suppression is per slot: once we catch up, forwarding resumes.
+    #[test]
+    fn slot_reset_clears_the_suppression() {
+        let mut conn = Conn::default();
+        conn.builder_ahead = true;
+
+        conn.reset_slot();
+
+        assert!(!conn.builder_ahead);
     }
 
     fn raw_plain_tx() -> Bytes {

--- a/crates/relay/src/block_merging/tile.rs
+++ b/crates/relay/src/block_merging/tile.rs
@@ -24,7 +24,7 @@ use helix_common::{
 use helix_tcp_types::merging::{
     MERGING_HEADER_SIZE, MERGING_PROTOCOL_VERSION, MergingFrameHeader, MergingHeaderError,
     MergingMsgId,
-    builder_to_relay::{FatalV1, MergedBlockV1, RejectV1},
+    builder_to_relay::{FatalV1, MergedBlockV1, RejectCode, RejectV1},
     control::{
         BuilderCollateral, MergerAckV1, MergerRegistrationV1, PingV1, PongV1, RelayConfigV1,
     },
@@ -76,6 +76,8 @@ struct Conn {
     /// Appendable block hashes forwarded on this connection this slot.
     forwarded: FxHashSet<B256>,
     activated: Option<B256>,
+    /// Builder's head is past our bid slot, so it refuses everything until we catch up.
+    builder_ahead: bool,
     /// Tx hashes already sent whole on this connection this slot; a repeat
     /// tx is forwarded as a hash reference instead. Cleared with the rest of
     /// the per-slot state so it never outlives the builder's own per-slot
@@ -95,6 +97,7 @@ impl Conn {
         self.forwarded.clear();
         self.activated = None;
         self.sent_txs.clear();
+        self.builder_ahead = false;
     }
 }
 
@@ -151,6 +154,8 @@ struct SlotStats {
     skipped_no_slot_start: usize,
     skipped_wrong_slot: usize,
     skipped_no_merging_data: usize,
+    /// Sends skipped because the builder is already past this slot.
+    skipped_builder_ahead: usize,
     /// Sends skipped over the builder's advertised limits.
     skipped_over_limits: usize,
     /// Merge orders dropped for an out of range tx index.
@@ -227,6 +232,7 @@ pub struct BlockMergingTile {
     to_register: Vec<Token>,
     handshaken: Vec<Token>,
     pongs: Vec<(Token, u64)>,
+    rejects: Vec<(Token, RejectV1)>,
     merged_ixs: Vec<usize>,
     merge_sim_ixs: Vec<usize>,
     encode_buf: Vec<u8>,
@@ -516,6 +522,7 @@ impl BlockMergingTile {
             to_register: Vec::new(),
             handshaken: Vec::new(),
             pongs: Vec::new(),
+            rejects: Vec::new(),
             merged_ixs: Vec::new(),
             merge_sim_ixs: Vec::new(),
             encode_buf: Vec::new(),
@@ -597,6 +604,7 @@ impl BlockMergingTile {
             to_register,
             handshaken,
             pongs,
+            rejects,
             merged_ixs,
             merged_blocks,
             sim_requests,
@@ -732,6 +740,7 @@ impl BlockMergingTile {
                                 msg = %String::from_utf8_lossy(&reject.msg),
                                 "merging reject"
                             );
+                            rejects.push((token, reject));
                         }
                     }
                     MergingMsgId::FatalV1 => {
@@ -770,6 +779,19 @@ impl BlockMergingTile {
             self.connector.write_or_enqueue_with(SendBehavior::Single(token), |buf| {
                 append_frame(buf, MergingMsgId::PongV1, &PongV1 { nonce });
             });
+        }
+        for (token, reject) in std::mem::take(&mut self.rejects) {
+            self.on_reject(token, reject);
+        }
+    }
+
+    /// `StaleSlot` and a later `reject.slot` both mean the builder is ahead of us.
+    fn on_reject(&mut self, token: Token, reject: RejectV1) {
+        if self.token != Some(token) {
+            return;
+        }
+        if matches!(reject.code, RejectCode::StaleSlot) || reject.slot > self.slot.bid_slot {
+            self.conn.builder_ahead = true;
         }
     }
 
@@ -851,6 +873,7 @@ impl BlockMergingTile {
             skipped_no_slot_start = stats.skipped_no_slot_start,
             skipped_wrong_slot = stats.skipped_wrong_slot,
             skipped_no_merging_data = stats.skipped_no_merging_data,
+            skipped_builder_ahead = stats.skipped_builder_ahead,
             skipped_over_limits = stats.skipped_over_limits,
             orders_dropped = stats.orders_dropped,
             replayed = stats.replayed,
@@ -900,6 +923,14 @@ impl BlockMergingTile {
         // also guards replay ixs against the auctioneer's decoded.clear()
         if sub.submission.bid_slot() != self.slot.bid_slot {
             self.stats.skipped_wrong_slot += 1;
+            if !is_replay {
+                self.feed_cache(&sub.submission);
+            }
+            return;
+        }
+        // gattaca-com/helix#538: pointless, the builder refuses this slot.
+        if self.conn.builder_ahead {
+            self.stats.skipped_builder_ahead += 1;
             if !is_replay {
                 self.feed_cache(&sub.submission);
             }
@@ -1117,6 +1148,10 @@ impl BlockMergingTile {
         if !self.slot.appendable.contains(&top_bid.block_hash) {
             return;
         }
+        // Activating past our slot is what produces the builder's `UnknownBaseBlock`.
+        if self.conn.builder_ahead {
+            return;
+        }
         let Some(token) = self.token else { return };
         if !self.conn.active ||
             !self.conn.forwarded.contains(&top_bid.block_hash) ||
@@ -1206,14 +1241,14 @@ mod tests {
     use helix_tcp_types::{
         MergeType,
         merging::{
-            builder_to_relay::{MergeTraceV1, RejectCode, RejectSubject},
+            builder_to_relay::{MergeTraceV1, RejectSubject},
             order::{BundleOrderRef, TxOrderRef},
         },
     };
     use helix_types::{
         BlobsBundle, BlockMergingData, BuilderInclusionResult, Compression, ExecutionPayload,
         ExecutionRequests, ForkName, MergedBlockTrace, SignedBidSubmission, SubmissionVersion,
-        TestRandom, TestRandomSeed,
+        TestRandom, TestRandomSeed, dehydrated_submission_with_txs_for_test, full_tx_for_test,
     };
     use rand::{SeedableRng, rngs::SmallRng};
 
@@ -1619,6 +1654,31 @@ mod tests {
 
         assert!(tile.conn.activated.is_none());
         assert_eq!(tile.stats.activations_sent, 0);
+    }
+
+    /// A skipped forward must still feed the hydration cache, exactly as the
+    /// neighbouring `skipped_no_slot_start` and `skipped_wrong_slot` guards do:
+    /// dropping the frame must not cost later submissions their tx references.
+    /// Testable since gattaca-com/helix#547 landed the submission helpers.
+    #[test]
+    fn a_suppressed_forward_still_feeds_the_hydration_cache() {
+        let tx = full_tx_for_test(1);
+        let dehydrated = dehydrated_submission_with_txs_for_test(vec![tx]);
+        // The helper randomises the slot, so match the tile to it rather than
+        // tripping the wrong-slot guard, which feeds the cache for its own reasons.
+        let bid_slot = dehydrated.slot();
+
+        let mut tile = tile_in_slot(bid_slot);
+        tile.on_reject(Token(0), reject(bid_slot, RejectCode::StaleSlot));
+
+        let mut data = test_submission(bid_slot, B256::repeat_byte(8), true);
+        data.submission_data.submission = Submission::Dehydrated(dehydrated);
+        let ix = tile.decoded.push(data);
+        tile.forward_decoded(ix, None);
+
+        assert_eq!(tile.stats.skipped_builder_ahead, 1, "the skip under test must be the reason");
+        assert_eq!(tile.stats.skipped_wrong_slot, 0);
+        assert_eq!(tile.hydration_cache.tx_count(), 1, "the skip must still feed the cache");
     }
 
     /// The suppression is per slot: once we catch up, forwarding resumes.

--- a/crates/tcp-types/src/merging/builder_to_relay.rs
+++ b/crates/tcp-types/src/merging/builder_to_relay.rs
@@ -62,6 +62,9 @@ pub struct MergeTraceV1 {
 /// Non-fatal rejection; the connection stays up.
 #[derive(Debug, Clone, PartialEq, Encode, Decode)]
 pub struct RejectV1 {
+    /// The builder's own current slot, not the slot of the rejected message.
+    /// The relay reads this to tell whether the builder's head has moved past
+    /// the slot the relay is still bidding for.
     pub slot: u64,
     pub code: RejectCode,
     pub subject: RejectSubject,


### PR DESCRIPTION
Issue: #538 (step 1 of 3)

## What this PR does

The merge builder validates mergeable blocks against its own head, not the
relay's `SlotStartV1` (`merge_tile.rs:584`, "Validate against our head
(BuildStart), not the relay's SlotStart view"). So every frame the relay sends
between the builder's head advancing and the relay's own slot transition is
refused, and that window sits exactly where submission rate peaks — just
before the slot boundary.

On mainnet (`titan_relay.log.2026-08-30`) that was **1,896,985 `StaleSlot`
rejects in a day**, about 263 per slot, and the largest single source of log
volume on the relay.

This tracks the builder's position from the rejects themselves. A `StaleSlot`
code, or any reject naming a later slot, sets `Conn::builder_ahead`. While it
is set, `forward_decoded` skips and counts, `on_top_bid` skips activation, and
`Conn::reset_slot` clears it on the next slot.

Activation is included here rather than deferred, because activating a base
block the builder discarded is precisely what produces its `UnknownBaseBlock`
rejects (332,748/day). Step 2 handles the other half of that: a hash rejected
while the builder is *on* our slot still stays in `conn.forwarded`.

Reject handling moves out of the `poll_with` closure into `on_reject`,
buffered like `pongs`, since the closure destructures `self` and cannot call a
`&mut self` method. That also makes it reachable from a test.

## What this PR deliberately does not do

- It does not remove rejected hashes from `conn.forwarded`. That is step 2.
- It does not replace the per-frame `merging reject` WARN with a
  `rejects_by_code` counter. That is step 3, and worth doing after these
  volumes drop so the residual is meaningful.
- It does not close the window, only detect it. #538's open question asks
  whether aligning the relay's slot transition to the same head signal the
  builder uses would be the better fix. That touches the auctioneer's slot
  handling, so it stays a separate decision.
- It does not touch the smaller reject codes — `InvalidBaseBlock` (25,670/day),
  `InvalidOrder` (19,717/day) — which have separate causes, listed on the
  issue.

## A protocol inconsistency worth a reviewer's eye

`RejectV1.slot` was undocumented, and the two implementations disagree:

- the production merge builder sends **its own current slot**
  (`RejectV1 { slot: self.state.slot, ... }`),
- helix's own `crates/builder` sends **the rejected request's slot**
  (`EngineOutput::reject(self.generation, slot, ...)`, where `slot` came off
  the inbound event).

So the trigger here deliberately honours both readings: the `StaleSlot` code
alone is enough, and a later `reject.slot` is treated as proof independently.
This PR documents the field as the production semantics, since that is the
de-facto protocol. That leaves `crates/builder` out of spec — happy to file
that separately if you agree it should change.

## Tests

Tests were written first, in commit `e154dba5`, and compile-failed on exactly
the three items the fix adds: `on_reject`,
`SlotStats::skipped_builder_ahead`, `Conn::builder_ahead`.

- `stale_slot_reject_stops_forwarding_for_the_rest_of_the_slot`
- `reject_naming_a_later_slot_stops_forwarding` — a `Busy` reject naming slot 6 while we are on 5
- `other_reject_codes_for_the_current_slot_do_not_stop_forwarding` — `Busy` and `InvalidOrder` say nothing about the head
- `reject_from_another_token_is_ignored`
- `stale_slot_reject_stops_activation`
- `slot_reset_clears_the_suppression`

All 26 tests in the module pass, including the 20 that predate this change.

One gap: there is no test that the new skip still feeds the hydration cache on
the way out, the way the neighbouring `skipped_no_slot_start` and
`skipped_wrong_slot` guards do. Asserting it needs a dehydrated submission
with chosen transactions, and that helper only exists on #547's branch. I did
not want to stack this PR on that one. So that one line rests on review, and
becomes testable once #547 lands.

`just fmt-check`, `cargo clippy --all-features --no-deps -- -D warnings` and
`just test` are green locally (232 passed, 0 failed, 8 pre-existing ignored).

## Reviewer checklist
- [ ] CI (`lint`, `unit-test`) is green
- [ ] Matches the linked issue/step
- [ ] No unexplained scope creep or unrelated files touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)