### PR TITLE
Drop rejected blocks from conn.forwarded (#538 step 2)

### DIFF
--- a/crates/relay/src/block_merging/tile.rs
+++ b/crates/relay/src/block_merging/tile.rs
@@ -24,7 +24,7 @@ use helix_common::{
 use helix_tcp_types::merging::{
     MERGING_HEADER_SIZE, MERGING_PROTOCOL_VERSION, MergingFrameHeader, MergingHeaderError,
     MergingMsgId,
-    builder_to_relay::{FatalV1, MergedBlockV1, RejectCode, RejectV1},
+    builder_to_relay::{FatalV1, MergedBlockV1, RejectCode, RejectSubject, RejectV1},
     control::{
         BuilderCollateral, MergerAckV1, MergerRegistrationV1, PingV1, PongV1, RelayConfigV1,
     },
@@ -793,6 +793,10 @@ impl BlockMergingTile {
         if matches!(reject.code, RejectCode::StaleSlot) || reject.slot > self.slot.bid_slot {
             self.conn.builder_ahead = true;
         }
+        // A named block is one the builder does not hold, so it must not be activated.
+        if let RejectSubject::BlockHash(hash) = reject.subject {
+            self.conn.forwarded.remove(&hash);
+        }
     }
 
     fn on_slot_msg(&mut self, msg: SlotMsg) {
@@ -1241,7 +1245,7 @@ mod tests {
     use helix_tcp_types::{
         MergeType,
         merging::{
-            builder_to_relay::{MergeTraceV1, RejectSubject},
+            builder_to_relay::MergeTraceV1,
             order::{BundleOrderRef, TxOrderRef},
         },
     };

--- a/crates/relay/src/block_merging/tile.rs
+++ b/crates/relay/src/block_merging/tile.rs
@@ -1550,6 +1550,19 @@ mod tests {
         }
     }
 
+    fn top_bid(slot: u64, block_hash: B256) -> TopBidUpdate {
+        TopBidUpdate {
+            timestamp: 1,
+            slot,
+            block_number: 0,
+            block_hash,
+            parent_hash: B256::ZERO,
+            builder_pubkey: BlsPublicKeyBytes::default(),
+            fee_recipient: Address::ZERO,
+            value: U256::ZERO,
+        }
+    }
+
     /// Sets up a tile mid-slot with a handshaken connection, ready to forward.
     fn tile_in_slot(bid_slot: u64) -> BlockMergingTile {
         let mut tile = test_tile(true);
@@ -1641,16 +1654,7 @@ mod tests {
         tile.conn.forwarded.insert(block_hash);
 
         tile.on_reject(Token(0), reject(5, RejectCode::StaleSlot));
-        tile.on_top_bid(TopBidUpdate {
-            timestamp: 1,
-            slot: 5,
-            block_number: 0,
-            block_hash,
-            parent_hash: B256::ZERO,
-            builder_pubkey: BlsPublicKeyBytes::default(),
-            fee_recipient: Address::ZERO,
-            value: U256::ZERO,
-        });
+        tile.on_top_bid(top_bid(5, block_hash));
 
         assert!(tile.conn.activated.is_none());
         assert_eq!(tile.stats.activations_sent, 0);
@@ -1690,6 +1694,111 @@ mod tests {
         conn.reset_slot();
 
         assert!(!conn.builder_ahead);
+    }
+
+    fn reject_with(slot: u64, code: RejectCode, subject: RejectSubject) -> RejectV1 {
+        RejectV1 { slot, code, subject, msg: b"test".to_vec() }
+    }
+
+    /// gattaca-com/helix#538: `conn.forwarded` records what we sent, not what the
+    /// builder accepted, so a rejected block stayed activatable and the activation
+    /// came back as `UnknownBaseBlock`.
+    #[test]
+    fn reject_naming_a_block_hash_stops_it_being_activated() {
+        let mut tile = tile_in_slot(5);
+        let block_hash = B256::repeat_byte(1);
+        tile.slot.appendable.insert(block_hash);
+        tile.conn.forwarded.insert(block_hash);
+
+        // Not StaleSlot: this must work while the builder is still on our slot,
+        // where the `builder_ahead` guard does not apply.
+        tile.on_reject(
+            Token(0),
+            reject_with(5, RejectCode::InvalidBaseBlock, RejectSubject::BlockHash(block_hash)),
+        );
+        tile.on_top_bid(top_bid(5, block_hash));
+
+        assert!(!tile.conn.builder_ahead, "this reject says nothing about the builder's head");
+        assert!(tile.conn.activated.is_none());
+        assert_eq!(tile.stats.activations_sent, 0);
+    }
+
+    /// A reject naming a block means the builder does not hold it, whatever the
+    /// code says, so it must leave `forwarded`.
+    #[test]
+    fn reject_naming_a_block_hash_drops_only_that_block() {
+        let mut tile = tile_in_slot(5);
+        let rejected = B256::repeat_byte(2);
+        let kept = B256::repeat_byte(3);
+        tile.conn.forwarded.insert(rejected);
+        tile.conn.forwarded.insert(kept);
+
+        tile.on_reject(
+            Token(0),
+            reject_with(5, RejectCode::InvalidOrder, RejectSubject::BlockHash(rejected)),
+        );
+
+        assert!(!tile.conn.forwarded.contains(&rejected));
+        assert!(tile.conn.forwarded.contains(&kept));
+    }
+
+    /// `NotSynced` is documented as resendable, and a resend re-inserts the hash
+    /// when it is forwarded again.
+    #[test]
+    fn a_block_dropped_by_a_reject_is_restored_by_forwarding_it_again() {
+        let mut tile = tile_in_slot(5);
+        tile.conn.max_frame_bytes = u32::MAX;
+        tile.conn.max_orders_per_slot = u32::MAX;
+        let block_hash = B256::repeat_byte(4);
+
+        let ix = tile.decoded.push(test_submission(5, block_hash, true));
+        tile.forward_decoded(ix, None);
+        assert!(tile.conn.forwarded.contains(&block_hash));
+
+        tile.on_reject(
+            Token(0),
+            reject_with(5, RejectCode::NotSynced, RejectSubject::BlockHash(block_hash)),
+        );
+        assert!(!tile.conn.forwarded.contains(&block_hash));
+
+        tile.forward_decoded(ix, None);
+        assert!(tile.conn.forwarded.contains(&block_hash));
+    }
+
+    /// An order-level reject is not about the base block, and a subjectless one
+    /// names nothing, so neither may touch `forwarded`.
+    #[test]
+    fn rejects_without_a_block_subject_leave_forwarded_alone() {
+        let mut tile = tile_in_slot(5);
+        let block_hash = B256::repeat_byte(5);
+        tile.conn.forwarded.insert(block_hash);
+
+        tile.on_reject(
+            Token(0),
+            reject_with(
+                5,
+                RejectCode::InvalidOrder,
+                RejectSubject::OrderHash(B256::repeat_byte(9)),
+            ),
+        );
+        tile.on_reject(Token(0), reject_with(5, RejectCode::Busy, RejectSubject::None(0)));
+
+        assert!(tile.conn.forwarded.contains(&block_hash));
+    }
+
+    /// State for our connection must not be edited by another connection's reject.
+    #[test]
+    fn reject_from_another_token_leaves_forwarded_alone() {
+        let mut tile = tile_in_slot(5);
+        let block_hash = B256::repeat_byte(6);
+        tile.conn.forwarded.insert(block_hash);
+
+        tile.on_reject(
+            Token(1),
+            reject_with(5, RejectCode::InvalidBaseBlock, RejectSubject::BlockHash(block_hash)),
+        );
+
+        assert!(tile.conn.forwarded.contains(&block_hash));
     }
 
     fn raw_plain_tx() -> Bytes {


### PR DESCRIPTION
Issue: #538 (step 2 of 3)

> Stacked on #548. Base is `od/merging_builder_slot_tracking`, so this diff
> shows only step 2. Merge #548 first and this retargets to `develop`.

## What this PR does

`conn.forwarded` records what the relay *sent*, not what the builder
*accepted*. `forward_decoded` inserts a hash on send, and nothing ever removes
it, so a block the builder rejected stayed activatable — and when it became
the top bid, `on_top_bid` passed its `conn.forwarded.contains(...)` guard and
sent `ActivateBaseBlockV1` for a block the builder had discarded. That comes
straight back as `UnknownBaseBlock`: **332,748 rejects in a day** on mainnet
(`titan_relay.log.2026-08-30`), about 46 per slot.

Step 1 (#548) stops the ones caused by the relay being behind the builder's
head. This handles the rest — a reject naming a block while the builder is
still on our slot, where the `builder_ahead` guard does not apply.

The fix is three lines in `on_reject`:

```rust
// A named block is one the builder does not hold, so it must not be activated.
if let RejectSubject::BlockHash(hash) = reject.subject {
    self.conn.forwarded.remove(&hash);
}
```

## A judgement call for the reviewer

This removes on **any** `BlockHash`-subject reject, whatever the code.
`forwarded` is meant to track what the builder holds, and a reject naming a
block means it does not hold that one.

Two codes are arguably transient, though: `NotSynced` is documented as
"Builder is behind; the relay may resend", and `Busy` may mean "try later".
For those, removal costs a re-send of the frame when the next submission for
that block arrives — which
`a_block_dropped_by_a_reject_is_restored_by_forwarding_it_again` pins as the
intended behaviour.

I took the conservative direction on purpose. Worst case here is a re-sent
frame, or one skipped activation for a block the builder actually holds, which
loses that merge. Keeping the hash instead guarantees a wasted activation and
a reject, which is today's behaviour. Happy to narrow it to the definitely
permanent codes (`InvalidBaseBlock`, `InvalidOrder`, `InvalidPayment`,
`UnknownBaseBlock`, `UnknownCollateral`, `StaleSlot`, `LimitExceeded`) if you
would rather — one line in the match plus one test.

## What this PR deliberately does not do

- It does not remove the hash from `slot.appendable`. That is per-slot relay
  state feeding replay bookkeeping and the merged-block staleness check, not a
  claim about what this connection holds. Removing from `conn.forwarded` is
  sufficient to stop the activation.
- It does not replace the per-frame `merging reject` WARN with a
  `rejects_by_code` counter — step 3, best done once these volumes drop.
- It does not touch the smaller reject codes with separate causes
  (`InvalidBaseBlock` 25,670/day, `InvalidOrder` 19,717/day), listed on the
  issue.

## Tests

Tests were written first, in `e1a10416`. They needed no new API, so they
compiled and failed rather than compile-failing — the red state was:

```
reject_naming_a_block_hash_stops_it_being_activated ... FAILED
  assertion failed: tile.conn.activated.is_none()
reject_naming_a_block_hash_drops_only_that_block ... FAILED
  assertion failed: !tile.conn.forwarded.contains(&rejected)
a_block_dropped_by_a_reject_is_restored_by_forwarding_it_again ... FAILED
```

That first assertion is the bug itself: the relay activating a block the
builder had rejected.

- `reject_naming_a_block_hash_stops_it_being_activated` — uses
  `InvalidBaseBlock` for our own slot, so `builder_ahead` stays false and only
  the removal is under test
- `reject_naming_a_block_hash_drops_only_that_block`
- `a_block_dropped_by_a_reject_is_restored_by_forwarding_it_again`
- `rejects_without_a_block_subject_leave_forwarded_alone` — `OrderHash` and
  `None(0)` subjects touch nothing (passed before the fix, as it should)
- `reject_from_another_token_leaves_forwarded_alone` (likewise)

All 31 tests in the module pass. `just fmt-check`, `cargo clippy
--all-features --no-deps -- -D warnings` and `just test` are green locally
(237 passed, 0 failed, 8 pre-existing ignored).

Also folds step 1's inline `TopBidUpdate` literal into a shared
`top_bid(slot, hash)` helper, now that two tests need it.

## Reviewer checklist
- [ ] CI (`lint`, `unit-test`) is green
- [ ] Matches the linked issue/step
- [ ] No unexplained scope creep or unrelated files touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)