### PR TITLE
Remove sticky simulator selection (#551 step 1)

### DIFF
--- a/crates/relay/src/simulator/tile.rs
+++ b/crates/relay/src/simulator/tile.rs
@@ -238,7 +238,7 @@ impl SimulatorTile {
 
         self.local_telemetry.sims_reqs += 1;
 
-        let sim_id = self.select_simulator(&builder_pubkey);
+        let sim_id = self.select_simulator();
 
         if let Some(id) = sim_id {
             self.local_telemetry.sims_sent_immediately += 1;
@@ -610,28 +610,16 @@ impl SimulatorTile {
     }
 
     /// Selection priority:
-    /// 1. Sticky sim with SSZ endpoint (state locality + binary protocol)
-    /// 2. Any SSZ-capable sim, least pending (binary protocol)
-    /// 3. Any sim, least pending (JSON-RPC fallback; stickiness irrelevant without SSZ)
+    /// 1. Any SSZ-capable sim, least pending (binary protocol)
+    /// 2. Any sim, least pending (JSON-RPC fallback)
     #[timed]
-    fn select_simulator(&self, builder_pubkey: &BlsPublicKeyBytes) -> Option<usize> {
-        if !self.ssz_sim_indices.is_empty() {
-            let sticky =
-                self.ssz_sim_indices[sticky_sim_index(self.ssz_sim_indices.len(), builder_pubkey)];
-            if self.simulators[sticky].can_simulate() {
-                return Some(sticky);
-            }
-            if let Some(id) = self
-                .ssz_sim_indices
-                .iter()
-                .filter(|&&i| self.simulators[i].can_simulate())
-                .min_by_key(|&&i| self.simulators[i].pending)
-                .copied()
-            {
-                return Some(id);
-            }
-        }
-        self.next_client(|s| s.can_simulate())
+    fn select_simulator(&self) -> Option<usize> {
+        self.ssz_sim_indices
+            .iter()
+            .filter(|&&i| self.simulators[i].can_simulate())
+            .min_by_key(|&&i| self.simulators[i].pending)
+            .copied()
+            .or_else(|| self.next_client(|s| s.can_simulate()))
     }
 
     fn next_client(&self, pred: impl Fn(&SimEntry) -> bool) -> Option<usize> {
@@ -804,29 +792,6 @@ pub(super) enum SimTileInternalEvent {
 struct SimSlotStats {
     count: u32,
     total_time: Duration,
-}
-
-/// Jump consistent hash — maps a builder pubkey to a simulator index with
-/// minimal reassignment when the set size changes.
-fn sticky_sim_index(num_simulators: usize, builder_pubkey: &BlsPublicKeyBytes) -> usize {
-    if num_simulators <= 1 {
-        return 0;
-    }
-    let key = u64::from_le_bytes(builder_pubkey.0[..8].try_into().unwrap());
-    jump_hash(key, num_simulators)
-}
-
-/// Stateless consistent hash — minimises slot reassignment as `n` changes.
-/// <https://arxiv.org/abs/1406.2294>
-fn jump_hash(mut key: u64, n: usize) -> usize {
-    let mut b: i64 = -1;
-    let mut j: i64 = 0;
-    while j < n as i64 {
-        b = j;
-        key = key.wrapping_mul(2862933555777941757).wrapping_add(1);
-        j = ((b + 1) as f64 * ((1u64 << 31) as f64) / ((key >> 33) + 1) as f64) as i64;
-    }
-    b as usize
 }
 
 /// Pending requests, we only keep the last one for each builder.

--- a/crates/relay/src/simulator/tile.rs
+++ b/crates/relay/src/simulator/tile.rs
@@ -1060,6 +1060,78 @@ mod tests {
         }
     }
 
+    /// A tile with one `SimEntry` per spec: `(has_ssz, is_synced, pending)`.
+    fn test_tile_with_sims(specs: &[(bool, bool, usize)]) -> SimulatorTile {
+        let mut tile = test_tile();
+        for &(has_ssz, is_synced, pending) in specs {
+            let client = SimulatorClient::new(reqwest::Client::new(), SimulatorConfig {
+                url: "http://localhost:8545".into(),
+                namespace: "relay".into(),
+                max_concurrent_tasks: 10,
+                ssz_url: has_ssz.then(|| "http://localhost:8546".to_string()),
+            });
+            let mut entry = SimEntry::new(client);
+            entry.is_synced = is_synced;
+            entry.pending = pending;
+            tile.simulators.push(entry);
+        }
+        tile.ssz_sim_indices = tile
+            .simulators
+            .iter()
+            .enumerate()
+            .filter(|(_, s)| s.client.ssz_url.is_some())
+            .map(|(i, _)| i)
+            .collect();
+        tile.sim_slot_stats = vec![SimSlotStats::default(); tile.simulators.len()];
+        tile
+    }
+
+    /// gattaca-com/helix#551: selection follows pending count, not a pubkey hash.
+    #[test]
+    fn select_simulator_picks_the_least_pending_ssz_sim() {
+        let tile = test_tile_with_sims(&[(false, true, 0), (true, true, 5), (true, true, 1)]);
+
+        assert_eq!(tile.select_simulator(), Some(2));
+    }
+
+    /// SSZ is still preferred over JSON-RPC even when a JSON sim is idler.
+    #[test]
+    fn select_simulator_prefers_ssz_over_a_less_loaded_json_sim() {
+        let tile = test_tile_with_sims(&[(false, true, 0), (true, true, 4)]);
+
+        assert_eq!(tile.select_simulator(), Some(1));
+    }
+
+    #[test]
+    fn select_simulator_falls_back_to_a_json_sim_when_no_ssz_sim_is_available() {
+        let tile = test_tile_with_sims(&[(false, true, 3), (true, false, 0)]);
+
+        assert_eq!(tile.select_simulator(), Some(0));
+    }
+
+    #[test]
+    fn select_simulator_skips_saturated_sims() {
+        // max_concurrent_tasks is 10, so the first SSZ sim cannot take more work.
+        let tile = test_tile_with_sims(&[(true, true, 10), (true, true, 9)]);
+
+        assert_eq!(tile.select_simulator(), Some(1));
+    }
+
+    #[test]
+    fn select_simulator_skips_paused_sims() {
+        let mut tile = test_tile_with_sims(&[(true, true, 0), (true, true, 8)]);
+        tile.simulators[0].paused_until = Some(Instant::now() + Duration::from_secs(60));
+
+        assert_eq!(tile.select_simulator(), Some(1));
+    }
+
+    #[test]
+    fn select_simulator_none_when_nothing_can_simulate() {
+        let tile = test_tile_with_sims(&[(true, false, 0), (false, false, 0)]);
+
+        assert_eq!(tile.select_simulator(), None);
+    }
+
     /// gattaca-com/helix#537: a submission the tile queues instead of simulating
     /// must still put its full transactions in the cache, so a later submission
     /// that references them can be hydrated whatever order the two arrive in.


### PR DESCRIPTION
Issue: #551 (step 1 of 1)

> Stacked on #547, which added the `test_tile()` helper these tests use. Base
> is `od/sim_hydration_cache_feed`, so this diff shows only the removal. Merge
> #547 first and this retargets to `develop`.

## What this PR does

`select_simulator` pinned each builder to one SSZ simulator with a jump
consistent hash of its pubkey. The stated reason was "state locality + binary
protocol", and the state locality was a **simulator-side hydration cache**: the
relay would send dehydrated submissions and the simulator would resolve the
8-byte transaction references from full transactions the same builder had sent
it earlier, so a builder's submissions had to keep landing on the same
simulator.

That cache was never built, and neither end asks for it:

- `crates/simulator/src/ssz_server.rs:55` returns HTTP 424 for every dehydrated
  submission — "Simulator-side hydration cache not yet implemented. Return 424
  so the relay retries with full SSZ bytes."
- `ssz_request` (`simulator/tile.rs:960`) hardcodes `decoder_params: None` and
  `signed_bid_submission: submission.as_ssz_bytes()`, so the relay hydrates
  locally and ships the full payload. The 424 is unreachable as `/validate` is
  currently called.

So the affinity bought nothing it was designed for, while still costing: the
first choice ignored load. `can_simulate()` is `is_synced && !paused && pending
< max_concurrent_tasks`, so the sticky simulator was used until it saturated
and only then did selection fall back to least-pending. Load was distributed by
pubkey hash rather than by work, and one high-volume builder always
concentrated on one simulator.

Selection is now least-pending SSZ-capable, falling back to least-pending of
any kind:

```rust
fn select_simulator(&self) -> Option<usize> {
    self.ssz_sim_indices
        .iter()
        .filter(|&&i| self.simulators[i].can_simulate())
        .min_by_key(|&&i| self.simulators[i].pending)
        .copied()
        .or_else(|| self.next_client(|s| s.can_simulate()))
}
```

Dropping the `builder_pubkey` parameter makes the change structural — the
function can no longer see the pubkey — rather than a property a test has to
assert. `sticky_sim_index` and `jump_hash` had no other callers and go with it.
Net 47 lines of production code removed.

## Behaviour does change

Which simulator receives a given submission changes. Validation results do not:
every simulator runs the same validation, and the SSZ-before-JSON preference is
unchanged. What changes is that selection follows pending count instead of
pubkey hash.

## What this PR deliberately does not do

It does not build the simulator-side hydration cache. That is the larger prize
— it would stop the relay serialising full payloads to the simulator on every
submission — but it is a change to `crates/simulator` and wants its own issue
and a measurement. The affinity can come back then, with numbers attached. The
424 → `HydrationMiss` → retry-with-full-SSZ path is left in place for it.

## Tests

Tests were written first and compile-failed on the signature change alone.

- `select_simulator_picks_the_least_pending_ssz_sim`
- `select_simulator_prefers_ssz_over_a_less_loaded_json_sim` — SSZ still wins
  over an idler JSON sim
- `select_simulator_falls_back_to_a_json_sim_when_no_ssz_sim_is_available`
- `select_simulator_skips_saturated_sims`
- `select_simulator_skips_paused_sims`
- `select_simulator_none_when_nothing_can_simulate`

Adds a `test_tile_with_sims(&[(has_ssz, is_synced, pending)])` helper, since
the previous `test_tile()` builds a tile with no simulators at all.

`just fmt-check`, `cargo clippy --all-features --no-deps -- -D warnings` and
`just test` are green locally (238 passed, 0 failed, 8 pre-existing ignored).

## Reviewer checklist
- [ ] CI (`lint`, `unit-test`) is green
- [ ] Matches the linked issue/step
- [ ] No unexplained scope creep or unrelated files touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)