### PR TITLE
Select the building role from a supplied config

### DIFF
--- a/crates/builder/build-config.example.yml
+++ b/crates/builder/build-config.example.yml
@@ -1,0 +1,30 @@
+# helix-builder building configuration (--build.config)
+#
+# Needs two keys in the environment:
+#   BUILDER_BLS_KEY     signs the submission; register this pubkey with the relay
+#   BUILDER_PAYOUT_KEY  pays the proposer; fund this address
+
+# Relay base URL. Serves proposer duties and accepts block submissions.
+relay_url: "http://localhost:4040"
+
+# Sent as X-Api-Key on every submission.
+api_key: "00000000-0000-0000-0000-000000000001"
+
+# Beacon node base URL. Its payload_attributes SSE topic drives building.
+beacon_url: "http://localhost:3500"
+
+# Added to every bid, so an idle chain still produces a non-zero one. The relay
+# rejects a zero-value block. Set to 0 to bid only what the block really earns.
+subsidy_wei: 1000000000
+
+# Gas held back from the fill for the trailing payout transaction. A contract
+# fee recipient that needs more than this makes the payout fail.
+payout_gas_reserve: 21000
+
+extra_data: "helix-builder"
+
+# Points into the slot, in milliseconds, at which to build and submit.
+submit_offsets_ms: [500, 2000]
+
+# Validate our own block before submitting it.
+self_validate: true

--- a/crates/builder/src/building/keys.rs
+++ b/crates/builder/src/building/keys.rs
@@ -1,0 +1,91 @@
+use alloy_primitives::Address;
+use alloy_signer_local::PrivateKeySigner;
+use helix_types::{BlsKeypair, BlsPublicKeyBytes, BlsSecretKey};
+
+/// BLS secret that signs the submission. Distinct from the merging role's
+/// `RELAY_KEY`, which is a secp256k1 secret.
+pub const BUILDER_BLS_KEY_ENV: &str = "BUILDER_BLS_KEY";
+/// secp256k1 secret that signs the payout to the proposer. Must be funded.
+pub const BUILDER_PAYOUT_KEY_ENV: &str = "BUILDER_PAYOUT_KEY";
+
+#[derive(Debug)]
+pub struct BuildingKeys {
+    pub bls: BlsKeypair,
+    pub payout: PrivateKeySigner,
+}
+
+impl BuildingKeys {
+    pub fn load() -> eyre::Result<Self> {
+        let bls = std::env::var(BUILDER_BLS_KEY_ENV)
+            .map_err(|_| eyre::eyre!("{BUILDER_BLS_KEY_ENV} env var not set"))?;
+        let payout = std::env::var(BUILDER_PAYOUT_KEY_ENV)
+            .map_err(|_| eyre::eyre!("{BUILDER_PAYOUT_KEY_ENV} env var not set"))?;
+        Self::parse(&bls, &payout)
+    }
+
+    /// Split from [`Self::load`] so tests never touch process-wide env vars.
+    pub fn parse(bls_hex: &str, payout_hex: &str) -> eyre::Result<Self> {
+        let bytes = hex::decode(bls_hex.trim().trim_start_matches("0x"))
+            .map_err(|e| eyre::eyre!("invalid {BUILDER_BLS_KEY_ENV}: {e}"))?;
+        let secret = BlsSecretKey::deserialize(&bytes)
+            .map_err(|e| eyre::eyre!("invalid {BUILDER_BLS_KEY_ENV}: {e:?}"))?;
+        let bls = BlsKeypair::from_components(secret.public_key(), secret);
+
+        let payout: PrivateKeySigner = payout_hex
+            .trim()
+            .parse()
+            .map_err(|e| eyre::eyre!("invalid {BUILDER_PAYOUT_KEY_ENV}: {e}"))?;
+
+        Ok(Self { bls, payout })
+    }
+
+    pub fn pubkey(&self) -> BlsPublicKeyBytes {
+        self.bls.pk.serialize().into()
+    }
+
+    pub fn payout_address(&self) -> Address {
+        self.payout.address()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Non-zero, canonical-range scalars.
+    const BLS_HEX: &str = "3535353535353535353535353535353535353535353535353535353535353535";
+    const PAYOUT_HEX: &str = "4646464646464646464646464646464646464646464646464646464646464646";
+
+    #[test]
+    fn parses_a_hex_keypair() {
+        let bare = BuildingKeys::parse(BLS_HEX, PAYOUT_HEX).expect("bare hex must parse");
+        let prefixed = BuildingKeys::parse(&format!("0x{BLS_HEX}"), &format!("0x{PAYOUT_HEX}"))
+            .expect("0x-prefixed hex must parse");
+
+        assert_eq!(bare.pubkey(), prefixed.pubkey());
+        assert_eq!(bare.payout_address(), prefixed.payout_address());
+    }
+
+    #[test]
+    fn rejects_a_malformed_bls_key() {
+        let err = BuildingKeys::parse("nothex", PAYOUT_HEX).expect_err("must not start");
+
+        assert!(err.to_string().contains(BUILDER_BLS_KEY_ENV), "got: {err}");
+    }
+
+    #[test]
+    fn rejects_a_malformed_payout_key() {
+        let err = BuildingKeys::parse(BLS_HEX, "nothex").expect_err("must not start");
+
+        assert!(err.to_string().contains(BUILDER_PAYOUT_KEY_ENV), "got: {err}");
+    }
+
+    #[test]
+    fn derives_the_pubkey_and_payout_address() {
+        let keys = BuildingKeys::parse(BLS_HEX, PAYOUT_HEX).unwrap();
+
+        // Both are logged at boot: the operator registers one and funds the other.
+        assert_ne!(keys.pubkey(), BlsPublicKeyBytes::default());
+        assert_ne!(keys.payout_address(), Address::ZERO);
+    }
+}

--- a/crates/builder/src/building/mod.rs
+++ b/crates/builder/src/building/mod.rs
@@ -1,0 +1,6 @@
+//! The building role: builds a block for the next slot and submits it to the
+//! relay. Shares the embedded ethrex node with the other roles.
+
+mod keys;
+
+pub use keys::BuildingKeys;

--- a/crates/builder/src/cli.rs
+++ b/crates/builder/src/cli.rs
@@ -25,6 +25,10 @@ pub struct BuilderCli {
     /// Path to the simulation YAML config. Activates the simulation role.
     #[arg(long = "sim.config", env = "HELIX_BUILDER_SIM_CONFIG")]
     pub sim_config: Option<PathBuf>,
+
+    /// Path to the building YAML config. Activates the building role.
+    #[arg(long = "build.config", env = "HELIX_BUILDER_BUILD_CONFIG")]
+    pub build_config: Option<PathBuf>,
 }
 
 /// Embedded-ethrex node options. Flag and env names match the upstream `ethrex`

--- a/crates/builder/src/config.rs
+++ b/crates/builder/src/config.rs
@@ -3,6 +3,11 @@ use std::{net::SocketAddr, path::Path};
 use serde::Deserialize;
 use uuid::Uuid;
 
+/// Intrinsic gas of a plain transfer, the floor for the payout reserve.
+const TX_GAS_COST: u64 = 21_000;
+/// Consensus limit on the header's `extra_data`.
+const MAX_EXTRA_DATA_BYTES: usize = 32;
+
 /// Builder-owned merging configuration, loaded from YAML (`--merging.config`).
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -128,43 +133,125 @@ impl SimulationConfig {
     }
 }
 
+/// Builder-owned building configuration, loaded from YAML (`--build.config`).
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct BuildingConfig {
+    /// Relay base URL. Serves proposer duties and accepts submissions.
+    pub relay_url: String,
+    /// Sent as `X-Api-Key` on every submission.
+    pub api_key: String,
+    /// Beacon node base URL, for the `payload_attributes` SSE topic.
+    pub beacon_url: String,
+    /// Added to every bid. The relay rejects a zero-value block, so without
+    /// this an idle chain produces nothing.
+    // Read once the payout is built.
+    #[allow(dead_code)]
+    #[serde(default = "default_subsidy_wei")]
+    pub subsidy_wei: u128,
+    /// Gas held back from the fill for the trailing payout transaction.
+    #[serde(default = "default_payout_gas_reserve")]
+    pub payout_gas_reserve: u64,
+    #[serde(default = "default_extra_data")]
+    pub extra_data: String,
+    /// Points into the slot, in milliseconds, at which to build and submit.
+    #[serde(default = "default_submit_offsets_ms")]
+    pub submit_offsets_ms: Vec<u64>,
+    /// Validate our own block before submitting it.
+    // Read once the slot loop exists.
+    #[allow(dead_code)]
+    #[serde(default = "default_true")]
+    pub self_validate: bool,
+}
+
+impl BuildingConfig {
+    pub fn load(path: &Path) -> eyre::Result<Self> {
+        let raw = std::fs::read_to_string(path)
+            .map_err(|e| eyre::eyre!("failed to read building config {}: {e}", path.display()))?;
+        let config: Self = serde_yaml::from_str(&raw)
+            .map_err(|e| eyre::eyre!("failed to parse building config {}: {e}", path.display()))?;
+        config.validate()?;
+        Ok(config)
+    }
+
+    fn validate(&self) -> eyre::Result<()> {
+        check_http_url("relay_url", &self.relay_url)?;
+        check_http_url("beacon_url", &self.beacon_url)?;
+        if self.api_key.is_empty() {
+            eyre::bail!("building config: api_key must not be empty");
+        }
+        // A plain transfer cannot cost less than the intrinsic gas.
+        if self.payout_gas_reserve < TX_GAS_COST {
+            eyre::bail!("building config: payout_gas_reserve must be at least {TX_GAS_COST}");
+        }
+        if self.submit_offsets_ms.is_empty() {
+            eyre::bail!("building config: submit_offsets_ms must not be empty");
+        }
+        if self.extra_data.len() > MAX_EXTRA_DATA_BYTES {
+            eyre::bail!("building config: extra_data must be at most {MAX_EXTRA_DATA_BYTES} bytes");
+        }
+        Ok(())
+    }
+}
+
+/// The roles the builder runs, one per supplied config. At least one is
+/// required; any combination is allowed.
 #[derive(Debug, Clone)]
-pub enum Roles {
-    Merging(MergingConfig),
-    Simulation(SimulationConfig),
-    Both { merging: MergingConfig, simulation: SimulationConfig },
+pub struct Roles {
+    merging: Option<MergingConfig>,
+    simulation: Option<SimulationConfig>,
+    building: Option<BuildingConfig>,
 }
 
 impl Roles {
     pub fn resolve(
         merging: Option<MergingConfig>,
         simulation: Option<SimulationConfig>,
+        building: Option<BuildingConfig>,
     ) -> eyre::Result<Self> {
-        match (merging, simulation) {
-            (Some(merging), Some(simulation)) => Ok(Self::Both { merging, simulation }),
-            (Some(merging), None) => Ok(Self::Merging(merging)),
-            (None, Some(simulation)) => Ok(Self::Simulation(simulation)),
-            (None, None) => {
-                eyre::bail!("no role selected: supply --merging.config, --sim.config, or both")
-            }
+        if merging.is_none() && simulation.is_none() && building.is_none() {
+            eyre::bail!(
+                "no role selected: supply --merging.config, --sim.config, --build.config, or any combination"
+            );
         }
+        Ok(Self { merging, simulation, building })
     }
 
     pub fn merging(&self) -> Option<&MergingConfig> {
-        match self {
-            Self::Merging(merging) | Self::Both { merging, .. } => Some(merging),
-            Self::Simulation(_) => None,
-        }
+        self.merging.as_ref()
     }
 
     pub fn simulation(&self) -> Option<&SimulationConfig> {
-        match self {
-            Self::Simulation(simulation) | Self::Both { simulation, .. } => Some(simulation),
-            Self::Merging(_) => None,
-        }
+        self.simulation.as_ref()
+    }
+
+    pub fn building(&self) -> Option<&BuildingConfig> {
+        self.building.as_ref()
     }
 }
 
+/// `Url::parse` alone accepts `localhost:4040`, reading the host as a scheme.
+fn check_http_url(field: &str, raw: &str) -> eyre::Result<()> {
+    let url = reqwest::Url::parse(raw)
+        .map_err(|e| eyre::eyre!("building config: {field} is not a URL: {e}"))?;
+    if !matches!(url.scheme(), "http" | "https") || url.host().is_none() {
+        eyre::bail!("building config: {field} must be an http(s) URL with a host");
+    }
+    Ok(())
+}
+
+fn default_subsidy_wei() -> u128 {
+    1_000_000_000
+}
+fn default_payout_gas_reserve() -> u64 {
+    TX_GAS_COST
+}
+fn default_extra_data() -> String {
+    "helix-builder".to_string()
+}
+fn default_submit_offsets_ms() -> Vec<u64> {
+    vec![500, 2000]
+}
 fn default_blacklist_endpoint() -> String {
     "http://localhost:3520/blacklist".to_string()
 }
@@ -230,6 +317,13 @@ mod tests {
 }
 
 #[cfg(test)]
+const MINIMAL_BUILDING_YAML: &str = concat!(
+    "relay_url: \"http://localhost:4040\"\n",
+    "api_key: \"key\"\n",
+    "beacon_url: \"http://localhost:3500\"\n",
+);
+
+#[cfg(test)]
 mod simulation_config_tests {
     use super::*;
 
@@ -243,6 +337,10 @@ mod simulation_config_tests {
     fn minimal_simulation_config() -> SimulationConfig {
         serde_yaml::from_str("ssz_addr: \"0.0.0.0:8552\"\n")
             .expect("the minimal simulation config must parse")
+    }
+
+    fn minimal_building_config() -> BuildingConfig {
+        serde_yaml::from_str(MINIMAL_BUILDING_YAML).expect("the minimal building config must parse")
     }
 
     #[test]
@@ -269,32 +367,156 @@ mod simulation_config_tests {
 
     #[test]
     fn a_merging_config_alone_selects_the_merging_role() {
-        let roles = Roles::resolve(Some(minimal_merging_config()), None).unwrap();
+        let roles = Roles::resolve(Some(minimal_merging_config()), None, None).unwrap();
 
         assert!(roles.merging().is_some());
         assert!(roles.simulation().is_none());
+        assert!(roles.building().is_none());
     }
 
     #[test]
     fn a_sim_config_alone_selects_the_simulation_role() {
-        let roles = Roles::resolve(None, Some(minimal_simulation_config())).unwrap();
+        let roles = Roles::resolve(None, Some(minimal_simulation_config()), None).unwrap();
 
         assert!(roles.simulation().is_some());
         assert!(roles.merging().is_none(), "no merging role means no RELAY_KEY is needed");
+        assert!(roles.building().is_none());
     }
 
     #[test]
     fn both_configs_select_both_roles() {
         let roles =
-            Roles::resolve(Some(minimal_merging_config()), Some(minimal_simulation_config()))
+            Roles::resolve(Some(minimal_merging_config()), Some(minimal_simulation_config()), None)
                 .unwrap();
 
         assert!(roles.merging().is_some());
         assert!(roles.simulation().is_some());
+        assert!(roles.building().is_none());
+    }
+
+    #[test]
+    fn a_build_config_alone_selects_the_building_role() {
+        let roles = Roles::resolve(None, None, Some(minimal_building_config())).unwrap();
+
+        assert!(roles.building().is_some());
+        assert!(roles.merging().is_none(), "no merging role means no RELAY_KEY is needed");
+        assert!(roles.simulation().is_none());
+    }
+
+    #[test]
+    fn all_three_configs_select_all_three_roles() {
+        let roles = Roles::resolve(
+            Some(minimal_merging_config()),
+            Some(minimal_simulation_config()),
+            Some(minimal_building_config()),
+        )
+        .unwrap();
+
+        assert!(roles.merging().is_some());
+        assert!(roles.simulation().is_some());
+        assert!(roles.building().is_some());
     }
 
     #[test]
     fn neither_config_is_a_startup_error() {
-        assert!(Roles::resolve(None, None).is_err(), "the builder must run at least one role");
+        assert!(
+            Roles::resolve(None, None, None).is_err(),
+            "the builder must run at least one role"
+        );
+    }
+}
+
+#[cfg(test)]
+mod building_config_tests {
+    use super::*;
+
+    fn with_line(extra: &str) -> BuildingConfig {
+        serde_yaml::from_str(&format!("{MINIMAL_BUILDING_YAML}{extra}\n"))
+            .expect("the config must parse")
+    }
+
+    #[test]
+    fn parses_the_example_build_config() {
+        let example = include_str!("../build-config.example.yml");
+        let config: BuildingConfig = serde_yaml::from_str(example).unwrap();
+        config.validate().unwrap();
+
+        assert_eq!(config.relay_url, "http://localhost:4040");
+        assert_eq!(config.beacon_url, "http://localhost:3500");
+        assert_eq!(config.subsidy_wei, 1_000_000_000);
+        assert_eq!(config.payout_gas_reserve, 21_000);
+        assert_eq!(config.extra_data, "helix-builder");
+        assert_eq!(config.submit_offsets_ms, vec![500, 2000]);
+        assert!(config.self_validate);
+    }
+
+    #[test]
+    fn minimal_build_config_gets_defaults() {
+        let config: BuildingConfig = serde_yaml::from_str(MINIMAL_BUILDING_YAML).unwrap();
+        config.validate().unwrap();
+
+        assert_eq!(config.subsidy_wei, 1_000_000_000, "an idle chain still gets a non-zero bid");
+        assert_eq!(config.payout_gas_reserve, 21_000);
+        assert_eq!(config.extra_data, "helix-builder");
+        assert_eq!(config.submit_offsets_ms, vec![500, 2000]);
+        assert!(config.self_validate);
+    }
+
+    #[test]
+    fn rejects_an_unknown_field() {
+        let err = serde_yaml::from_str::<BuildingConfig>(&format!(
+            "{MINIMAL_BUILDING_YAML}subsidy_we: 1\n"
+        ))
+        .expect_err("a misspelled field must not be silently ignored");
+
+        assert!(err.to_string().contains("unknown field"), "got: {err}");
+    }
+
+    #[test]
+    fn rejects_a_payout_gas_reserve_below_the_intrinsic_cost() {
+        let err = with_line("payout_gas_reserve: 20999")
+            .validate()
+            .expect_err("a reserve below the intrinsic gas can never pay for a transfer");
+
+        assert!(err.to_string().contains("payout_gas_reserve"), "got: {err}");
+    }
+
+    #[test]
+    fn rejects_empty_submit_offsets() {
+        let err = with_line("submit_offsets_ms: []")
+            .validate()
+            .expect_err("without an offset the role would start and never build");
+
+        assert!(err.to_string().contains("submit_offsets_ms"), "got: {err}");
+    }
+
+    #[test]
+    fn rejects_a_malformed_relay_url() {
+        let config: BuildingConfig = serde_yaml::from_str(concat!(
+            "relay_url: \"localhost:4040\"\n",
+            "api_key: \"key\"\n",
+            "beacon_url: \"http://localhost:3500\"\n",
+        ))
+        .unwrap();
+
+        let err = config.validate().expect_err("fail at boot, not on first submission");
+        assert!(err.to_string().contains("relay_url"), "got: {err}");
+    }
+
+    #[test]
+    fn rejects_extra_data_over_32_bytes() {
+        let err = with_line(&format!("extra_data: \"{}\"", "x".repeat(33)))
+            .validate()
+            .expect_err("extra_data must fit the header field");
+
+        assert!(err.to_string().contains("extra_data"), "got: {err}");
+    }
+
+    #[test]
+    fn a_zero_subsidy_is_allowed() {
+        let config = with_line("subsidy_wei: 0");
+        config.validate().expect("an operator may bid only what the block earns");
+
+        assert_eq!(config.subsidy_wei, 0);
     }
 }

--- a/crates/builder/src/main.rs
+++ b/crates/builder/src/main.rs
@@ -7,6 +7,7 @@ use flux::{
 use tracing::info;
 use tracing_subscriber::EnvFilter;
 
+mod building;
 mod cli;
 mod config;
 mod engine;
@@ -18,8 +19,9 @@ mod testing;
 mod utils;
 mod validation;
 
+use building::BuildingKeys;
 use cli::BuilderCli;
-use config::{MergingConfig, Roles, SimulationConfig};
+use config::{BuildingConfig, MergingConfig, Roles, SimulationConfig};
 use engine::{MergeEngine, types::EngineConfig};
 use server::MergingServerTile;
 use spine::BuilderSpine;
@@ -34,13 +36,26 @@ fn main() -> eyre::Result<()> {
 
     let merging_config = cli.merging_config.as_deref().map(MergingConfig::load).transpose()?;
     let simulation_config = cli.sim_config.as_deref().map(SimulationConfig::load).transpose()?;
-    let roles = Roles::resolve(merging_config, simulation_config)?;
+    let building_config = cli.build_config.as_deref().map(BuildingConfig::load).transpose()?;
+    let roles = Roles::resolve(merging_config, simulation_config, building_config)?;
 
     // Fail fast on a missing/invalid RELAY_KEY, before the node boots.
     let relay_signer = roles.merging().map(|merging_config| {
         info!(listen_addr = %merging_config.listen_addr, "Loaded merging config");
         EngineConfig::load_relay_signer()
     });
+
+    // Same, for the building role's own two keys. The role itself arrives in a
+    // later step; this only proves the keys are usable before the node boots.
+    if let Some(building_config) = roles.building() {
+        let keys = BuildingKeys::load()?;
+        info!(
+            relay_url = %building_config.relay_url,
+            builder_pubkey = %keys.pubkey(),
+            payout_address = %keys.payout_address(),
+            "Loaded building config; register the pubkey and fund the payout address",
+        );
+    }
 
     let runtime = tokio::runtime::Builder::new_multi_thread().enable_all().build()?;
 

--- a/crates/builder/src/validation/server_tests.rs
+++ b/crates/builder/src/validation/server_tests.rs
@@ -5,7 +5,7 @@ use axum::{
     body::Body,
     http::{Request, StatusCode},
 };
-use helix_common::simulator::{SszMergedValidationRequest, SszValidationRequest};
+use helix_common::simulator::SszMergedValidationRequest;
 use ssz::Encode;
 use tower::ServiceExt;
 


### PR DESCRIPTION
Issue: #550 (step 1 of 6)

## What this PR does

Adds `BuildingConfig` (`--build.config`) and turns `Roles` from an enum into a
struct of three optional configs. As an enum, a third role needs seven
variants.

The building role reads its own two keys, `BUILDER_BLS_KEY` (signs the
submission) and `BUILDER_PAYOUT_KEY` (pays the proposer). `RELAY_KEY` cannot
serve: the merging role parses it as secp256k1, and
`helix_common::config::load_keypair` parses it as BLS. Both are loaded and
logged before the node boots, so a bad key fails immediately and the operator
sees which pubkey to register and which address to fund.

## What this PR deliberately does not do

It does not build or submit anything. Nothing is spawned. Steps 2-5 add the
slot context, block assembly, submission and the slot loop. `subsidy_wei` and
`self_validate` carry `#[allow(dead_code)]` until steps 3 and 5 read them.

## Tests

14 new, all written before the implementation and signed off first.

- `BuildingConfig` (8): the shipped example parses; the three required fields
  alone yield every default; an unknown field is rejected; a payout reserve
  below the intrinsic 21 000 gas is rejected, as is an empty
  `submit_offsets_ms`, a schemeless `relay_url`, and `extra_data` over 32
  bytes. `a_zero_subsidy_is_allowed` pins the opt-out.
- `Roles` (2 new, 4 updated): a build config alone selects the building role;
  all three configs select all three; supplying none is still an error.
- `BuildingKeys` (4): hex parses with and without `0x`; each malformed key is
  named in its own error; the pubkey and payout address are derived.
  `parse()` is split from `load()` so tests never touch process-wide env vars.

103 pass in the crate.

## Notes for the reviewer

Two things found rather than introduced, neither fixed here:

- `cargo clippy -p helix-builder` reports **6 pre-existing errors** in
  `engine/*` and `validation/mod.rs`. The documented command,
  `cargo clippy --all-features --no-deps`, lints only `crates/relay` because
  that is the workspace's `default-members` — so this crate has never been
  linted in CI. `--all-targets` finds 4 more in test code. Worth a follow-up.
- One unused import in `validation/server_tests.rs` is removed here as a
  drive-by; it arrived with #543 and blocked a clean build of this crate.

## Reviewer checklist
- [ ] CI (`lint`, `unit-test`) is green
- [ ] Matches the linked issue/step
- [ ] No unexplained scope creep or unrelated files touched
