### PR TITLE
Build a block for each slot from the node's mempool

### DIFF
--- a/crates/builder/build-config.example.yml
+++ b/crates/builder/build-config.example.yml
@@ -14,8 +14,10 @@ api_key: "00000000-0000-0000-0000-000000000001"
 beacon_url: "http://localhost:3500"
 
 # Added to every bid, so an idle chain still produces a non-zero one. The relay
-# rejects a zero-value block. Set to 0 to bid only what the block really earns.
-subsidy_wei: 1000000000
+# rejects a zero-value block. Must exceed the payout's own gas
+# (payout_gas_reserve * base fee) or the slot is skipped. Set to 0 to bid only
+# what the block really earns.
+subsidy_wei: 1000000000000000
 
 # Gas held back from the fill for the trailing payout transaction. A contract
 # fee recipient that needs more than this makes the payout fail.

--- a/crates/builder/src/building/assemble.rs
+++ b/crates/builder/src/building/assemble.rs
@@ -1,0 +1,237 @@
+use alloy_consensus::{SignableTransaction, TxEip1559};
+use alloy_eips::eip2718::Encodable2718;
+use alloy_primitives::{Address, U256};
+use alloy_signer::SignerSync;
+use alloy_signer_local::PrivateKeySigner;
+use ethrex_blockchain::{
+    Blockchain,
+    payload::{BuildPayloadArgs, HeadTransaction, PayloadBuildContext, create_payload},
+};
+use ethrex_common::{
+    U256 as EU256,
+    types::{
+        AccountUpdate, BlobsBundle, Block, ELASTICITY_MULTIPLIER, MempoolTransaction, Transaction,
+        requests::EncodedRequests,
+    },
+};
+use ethrex_crypto::native::NativeCrypto;
+use ethrex_storage::Store;
+use thiserror::Error;
+
+use crate::{
+    building::slot::SlotContext,
+    config::BuildingConfig,
+    engine::convert::{au256, eaddr, eu256, h256},
+};
+
+#[derive(Debug, Error)]
+pub enum BuildError {
+    #[error("parent block not found")]
+    MissingParent,
+    /// Nothing to bid: the relay rejects a zero-value block.
+    #[error("no payout: tips and subsidy do not cover the payout gas")]
+    NoPayout,
+    #[error("the builder cannot afford the payout")]
+    PayoutUnaffordable,
+    #[error("the payout transaction reverted")]
+    PayoutReverted,
+    #[error("the payout recipient is the builder itself")]
+    PayoutToSelf,
+    #[error("build failed: {0}")]
+    Internal(String),
+}
+
+/// A finalized block and the bid it backs.
+#[derive(Debug)]
+pub struct BuiltBlock {
+    pub block: Block,
+    // These three are read by the submission.
+    #[allow(dead_code)]
+    pub blobs_bundle: BlobsBundle,
+    #[allow(dead_code)]
+    pub requests: Vec<EncodedRequests>,
+    /// The changed accounts, for checking the payment the way the relay does.
+    #[allow(dead_code)]
+    pub account_updates: Vec<AccountUpdate>,
+    /// Paid to the proposer by the trailing transaction, and the value the
+    /// `BidTrace` claims.
+    pub value: U256,
+}
+
+/// Builds a block for `slot` from the node's mempool, ending with a transfer
+/// that pays the proposer.
+///
+/// The coinbase is the builder, so tips accrue here and the bid is funded from
+/// them plus the configured subsidy.
+pub fn build(
+    store: &Store,
+    blockchain: &Blockchain,
+    slot: &SlotContext,
+    config: &BuildingConfig,
+    payout_signer: &PrivateKeySigner,
+    chain_id: u64,
+) -> Result<BuiltBlock, BuildError> {
+    let builder = payout_signer.address();
+    if builder == slot.proposer_fee_recipient {
+        return Err(BuildError::PayoutToSelf);
+    }
+    if store
+        .get_block_header_by_hash(h256(slot.parent_hash))
+        .map_err(|e| BuildError::Internal(e.to_string()))?
+        .is_none()
+    {
+        return Err(BuildError::MissingParent);
+    }
+
+    let args = BuildPayloadArgs {
+        parent: h256(slot.parent_hash),
+        timestamp: slot.timestamp,
+        fee_recipient: eaddr(builder),
+        random: h256(slot.prev_randao),
+        withdrawals: Some(slot.withdrawals.iter().map(ewithdrawal_lh).collect()),
+        beacon_root: Some(h256(slot.parent_beacon_block_root)),
+        slot_number: None,
+        version: 3,
+        elasticity_multiplier: ELASTICITY_MULTIPLIER,
+        // `create_payload` runs this through `calc_gas_limit`, which applies
+        // the 1/1024 clamp against the parent.
+        gas_ceil: slot.registered_gas_limit,
+    };
+    let template = create_payload(&args, store, config.extra_data.clone().into())
+        .map_err(|e| BuildError::Internal(format!("create_payload: {e}")))?;
+
+    let mut ctx = PayloadBuildContext::new(template, store, &blockchain.options.r#type)
+        .map_err(|e| BuildError::Internal(format!("payload context: {e}")))?;
+    blockchain
+        .apply_system_operations(&mut ctx)
+        .map_err(|e| BuildError::Internal(format!("system operations: {e}")))?;
+
+    // `fill_transactions` spends every last drop of `remaining_gas`, so hold
+    // the payout's share back and restore it once the fill is done.
+    let reserve = config.payout_gas_reserve.min(ctx.remaining_gas);
+    ctx.remaining_gas -= reserve;
+    blockchain
+        .fill_transactions(&mut ctx)
+        .map_err(|e| BuildError::Internal(format!("fill transactions: {e}")))?;
+    ctx.remaining_gas += reserve;
+
+    let base_fee = ctx.payload.header.base_fee_per_gas.unwrap_or_default();
+    let payout = payout_value(&ctx, config, base_fee)?;
+
+    let nonce = ctx
+        .vm
+        .db
+        .get_account(eaddr(builder))
+        .map_err(|e| BuildError::Internal(e.to_string()))?
+        .info
+        .nonce;
+    let balance = ctx
+        .vm
+        .db
+        .get_account(eaddr(builder))
+        .map_err(|e| BuildError::Internal(e.to_string()))?
+        .info
+        .balance;
+    let gas_cost = EU256::from(config.payout_gas_reserve) * EU256::from(base_fee);
+    if balance < eu256(payout) + gas_cost {
+        return Err(BuildError::PayoutUnaffordable);
+    }
+
+    let payout_tx = signed_payout(
+        payout_signer,
+        chain_id,
+        nonce,
+        slot.proposer_fee_recipient,
+        payout,
+        config.payout_gas_reserve,
+        base_fee as u128,
+    )?;
+    let sender = payout_tx
+        .sender(&NativeCrypto)
+        .map_err(|e| BuildError::Internal(format!("payout sender: {e}")))?;
+    blockchain
+        .apply_tx_to_payload(
+            HeadTransaction { tx: MempoolTransaction::new(payout_tx, sender), tip: EU256::zero() },
+            &mut ctx,
+        )
+        .map_err(|e| BuildError::Internal(format!("payout tx: {e}")))?;
+    if !ctx.receipts.last().is_some_and(|receipt| receipt.succeeded) {
+        return Err(BuildError::PayoutReverted);
+    }
+
+    blockchain
+        .extract_requests(&mut ctx)
+        .map_err(|e| BuildError::Internal(format!("extract requests: {e}")))?;
+    blockchain
+        .apply_withdrawals(&mut ctx)
+        .map_err(|e| BuildError::Internal(format!("apply withdrawals: {e}")))?;
+    blockchain
+        .finalize_payload(&mut ctx)
+        .map_err(|e| BuildError::Internal(format!("finalize: {e}")))?;
+
+    Ok(BuiltBlock {
+        block: ctx.payload,
+        blobs_bundle: ctx.blobs_bundle,
+        requests: ctx.requests.unwrap_or_default(),
+        account_updates: ctx.account_updates,
+        value: payout,
+    })
+}
+
+/// Tips earned plus the subsidy, less the gas the payout itself will burn.
+fn payout_value(
+    ctx: &PayloadBuildContext,
+    config: &BuildingConfig,
+    base_fee: u64,
+) -> Result<U256, BuildError> {
+    let gas_cost = EU256::from(config.payout_gas_reserve) * EU256::from(base_fee);
+    let funded = ctx.block_value + EU256::from(config.subsidy_wei);
+    let payout = funded.checked_sub(gas_cost).ok_or(BuildError::NoPayout)?;
+    if payout.is_zero() {
+        return Err(BuildError::NoPayout);
+    }
+    Ok(au256(payout))
+}
+
+fn signed_payout(
+    signer: &PrivateKeySigner,
+    chain_id: u64,
+    nonce: u64,
+    to: Address,
+    value: U256,
+    gas_limit: u64,
+    base_fee: u128,
+) -> Result<Transaction, BuildError> {
+    let tx = TxEip1559 {
+        chain_id,
+        nonce,
+        gas_limit,
+        max_fee_per_gas: base_fee,
+        // A tip would pay the builder out of its own payout, and the relay's
+        // payment check refuses one.
+        max_priority_fee_per_gas: 0,
+        to: to.into(),
+        value,
+        access_list: Default::default(),
+        input: Default::default(),
+    };
+    let signature = signer
+        .sign_hash_sync(&tx.signature_hash())
+        .map_err(|e| BuildError::Internal(format!("payout signature: {e}")))?;
+    let encoded = alloy_consensus::TxEnvelope::from(tx.into_signed(signature)).encoded_2718();
+    Transaction::decode_canonical(&encoded)
+        .map_err(|e| BuildError::Internal(format!("payout decode: {e}")))
+}
+
+/// The consensus withdrawal type, not the alloy one `convert` bridges.
+fn ewithdrawal_lh(w: &helix_types::Withdrawal) -> ethrex_common::types::Withdrawal {
+    ethrex_common::types::Withdrawal {
+        index: w.index,
+        validator_index: w.validator_index,
+        address: eaddr(w.address),
+        amount: w.amount,
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/builder/src/building/assemble/tests.rs
+++ b/crates/builder/src/building/assemble/tests.rs
@@ -1,0 +1,338 @@
+use std::sync::Arc;
+
+use alloy_primitives::{Address, B256, U256};
+use ethrex_blockchain::{Blockchain, BlockchainOptions, BlockchainType};
+use ethrex_common::types::Transaction;
+use ethrex_storage::Store;
+use ethrex_vm::VmDatabase;
+use helix_types::{BlsPublicKeyBytes, Withdrawal, Withdrawals};
+
+use super::*;
+use crate::testing::{ETH, GWEI, dev_genesis_store, funded_signers, signed_transfer};
+
+const PROPOSER: Address = Address::repeat_byte(0x77);
+/// Must clear the payout's own gas cost, ~21000 * base fee.
+const SUBSIDY: u128 = ETH / 1000;
+
+struct Fixture {
+    store: Store,
+    blockchain: Arc<Blockchain>,
+    signers: Vec<alloy_signer_local::PrivateKeySigner>,
+    parent_hash: B256,
+    parent_timestamp: u64,
+    parent_gas_limit: u64,
+    chain_id: u64,
+}
+
+impl Fixture {
+    async fn new() -> Self {
+        let (store, genesis) = dev_genesis_store().await;
+        let genesis_block = genesis.get_block();
+        let blockchain = Arc::new(Blockchain::new(store.clone(), BlockchainOptions {
+            r#type: BlockchainType::L1,
+            ..Default::default()
+        }));
+        Self {
+            signers: funded_signers(&genesis, 8),
+            parent_hash: crate::engine::convert::b256(genesis_block.hash()),
+            parent_timestamp: genesis_block.header.timestamp,
+            parent_gas_limit: genesis_block.header.gas_limit,
+            chain_id: genesis.config.chain_id,
+            store,
+            blockchain,
+        }
+    }
+
+    /// `signers[0]` is the builder: it holds the coinbase and signs the payout.
+    fn builder(&self) -> &alloy_signer_local::PrivateKeySigner {
+        &self.signers[0]
+    }
+
+    fn config(&self) -> BuildingConfig {
+        serde_yaml::from_str(&format!(
+            "relay_url: \"http://localhost:4040\"\napi_key: \"key\"\n\
+             beacon_url: \"http://localhost:3500\"\nsubsidy_wei: {SUBSIDY}\n"
+        ))
+        .unwrap()
+    }
+
+    fn slot(&self) -> SlotContext {
+        SlotContext {
+            slot: 1,
+            parent_hash: self.parent_hash,
+            parent_block_number: 0,
+            timestamp: self.parent_timestamp + 12,
+            prev_randao: B256::repeat_byte(0xcc),
+            withdrawals: Withdrawals::default(),
+            parent_beacon_block_root: B256::repeat_byte(0xdd),
+            proposer_pubkey: BlsPublicKeyBytes::default(),
+            proposer_fee_recipient: PROPOSER,
+            registered_gas_limit: self.parent_gas_limit,
+        }
+    }
+
+    /// Admits a transfer from `signers[index]` to the mempool.
+    async fn pool_transfer(&self, index: usize, nonce: u64, tip: u128) {
+        let encoded = signed_transfer(
+            &self.signers[index],
+            self.chain_id,
+            nonce,
+            Address::repeat_byte(0x55),
+            U256::from(GWEI),
+            100 * GWEI,
+            tip,
+        );
+        let tx = Transaction::decode_canonical(&encoded).unwrap();
+        self.blockchain.add_transaction_to_pool(tx).await.unwrap();
+    }
+
+    fn build(&self, slot: &SlotContext, config: &BuildingConfig) -> Result<BuiltBlock, BuildError> {
+        build(&self.store, &self.blockchain, slot, config, self.builder(), self.chain_id)
+    }
+
+    fn build_default(&self) -> Result<BuiltBlock, BuildError> {
+        self.build(&self.slot(), &self.config())
+    }
+
+    fn parent_header(&self) -> ethrex_common::types::BlockHeader {
+        self.store
+            .get_block_header_by_hash(crate::engine::convert::h256(self.parent_hash))
+            .unwrap()
+            .unwrap()
+    }
+}
+
+/// The trailing transaction, decoded.
+fn payout_tx(built: &BuiltBlock) -> &Transaction {
+    built.block.body.transactions.last().expect("a block always ends with the payout")
+}
+
+#[tokio::test]
+async fn mempool_transactions_are_included() {
+    let fixture = Fixture::new().await;
+    fixture.pool_transfer(1, 0, GWEI).await;
+    fixture.pool_transfer(2, 0, GWEI).await;
+
+    let built = fixture.build_default().unwrap();
+
+    assert_eq!(built.block.body.transactions.len(), 3, "two mempool txs plus the payout");
+}
+
+#[tokio::test]
+async fn the_block_extends_the_parent() {
+    let fixture = Fixture::new().await;
+    let slot = fixture.slot();
+
+    let built = fixture.build(&slot, &fixture.config()).unwrap();
+
+    let header = &built.block.header;
+    assert_eq!(crate::engine::convert::b256(header.parent_hash), fixture.parent_hash);
+    assert_eq!(header.number, 1);
+    assert_eq!(header.timestamp, slot.timestamp);
+    assert_eq!(crate::engine::convert::b256(header.prev_randao), slot.prev_randao);
+    assert_eq!(header.extra_data.as_ref(), b"helix-builder");
+    assert_eq!(
+        header.coinbase,
+        eaddr(fixture.builder().address()),
+        "the builder is the coinbase, so tips fund the bid"
+    );
+}
+
+#[tokio::test]
+async fn the_header_gas_limit_follows_the_registered_limit() {
+    let fixture = Fixture::new().await;
+    let mut slot = fixture.slot();
+    // Far below the parent, so the 1/1024 clamp binds.
+    slot.registered_gas_limit = 1;
+
+    let built = fixture.build(&slot, &fixture.config()).unwrap();
+
+    let delta = fixture.parent_gas_limit / 1024 - 1;
+    assert_eq!(
+        built.block.header.gas_limit,
+        fixture.parent_gas_limit - delta,
+        "ethrex's calc_gas_limit clamps the registered limit against the parent"
+    );
+}
+
+#[tokio::test]
+async fn the_payout_is_the_last_transaction_and_pays_the_bid() {
+    let fixture = Fixture::new().await;
+    fixture.pool_transfer(1, 0, GWEI).await;
+
+    let built = fixture.build_default().unwrap();
+
+    let payout = payout_tx(&built);
+    assert_eq!(payout.to(), ethrex_common::types::TxKind::Call(eaddr(PROPOSER)));
+    assert_eq!(payout.value(), eu256(built.value));
+    assert!(payout.data().is_empty(), "a plain transfer, which the relay recognises");
+    assert_eq!(payout.max_priority_fee(), Some(0), "a tip would be refused");
+}
+
+#[tokio::test]
+async fn the_bid_equals_tips_plus_subsidy_less_the_payout_gas() {
+    let fixture = Fixture::new().await;
+    fixture.pool_transfer(1, 0, GWEI).await;
+    let config = fixture.config();
+
+    let built = fixture.build_default().unwrap();
+
+    let base_fee = built.block.header.base_fee_per_gas.unwrap();
+    let tips = EU256::from(21_000u64) * EU256::from(GWEI);
+    let gas_cost = EU256::from(config.payout_gas_reserve) * EU256::from(base_fee);
+    let expected = tips + EU256::from(SUBSIDY) - gas_cost;
+
+    assert_eq!(eu256(built.value), expected);
+}
+
+#[tokio::test]
+async fn the_fee_recipient_balance_rises_by_the_bid() {
+    let fixture = Fixture::new().await;
+    fixture.pool_transfer(1, 0, GWEI).await;
+
+    let built = fixture.build_default().unwrap();
+
+    // The check the relay's simulator makes in `paid_by_balance`.
+    let db =
+        ethrex_blockchain::vm::StoreVmDatabase::new(fixture.store.clone(), fixture.parent_header())
+            .unwrap();
+    let before = db
+        .get_account_state(eaddr(PROPOSER))
+        .unwrap()
+        .map(|account| account.balance)
+        .unwrap_or_default();
+    let after = built
+        .account_updates
+        .iter()
+        .find(|update| update.address == eaddr(PROPOSER))
+        .and_then(|update| update.info.as_ref().map(|info| info.balance))
+        .expect("the payout must touch the fee recipient");
+
+    assert_eq!(after, before + eu256(built.value));
+    assert!(!built.value.is_zero(), "the relay rejects a zero-value block");
+}
+
+#[tokio::test]
+async fn the_payout_gas_reserve_survives_a_full_block() {
+    let fixture = Fixture::new().await;
+    let mut slot = fixture.slot();
+    // Room for a handful of transfers, so the fill exhausts the block.
+    slot.registered_gas_limit = fixture.parent_gas_limit;
+    for index in 1..8 {
+        for nonce in 0..40 {
+            fixture.pool_transfer(index, nonce, GWEI).await;
+        }
+    }
+
+    let built = fixture.build(&slot, &fixture.config()).unwrap();
+
+    let payout = payout_tx(&built);
+    assert_eq!(
+        payout.to(),
+        ethrex_common::types::TxKind::Call(eaddr(PROPOSER)),
+        "the reserve must outlast the fill",
+    );
+    assert!(
+        built.block.header.gas_used <= built.block.header.gas_limit,
+        "the restored reserve must not overrun the limit",
+    );
+}
+
+#[tokio::test]
+async fn an_empty_mempool_still_bids_the_subsidy() {
+    let fixture = Fixture::new().await;
+
+    let built = fixture.build_default().unwrap();
+
+    assert_eq!(built.block.body.transactions.len(), 1, "the payout alone");
+    assert!(!built.value.is_zero(), "an idle testnet must still produce a bid");
+}
+
+#[tokio::test]
+async fn a_zero_subsidy_and_no_tips_is_refused() {
+    let fixture = Fixture::new().await;
+    let mut config = fixture.config();
+    config.subsidy_wei = 0;
+
+    let err = fixture.build(&fixture.slot(), &config).expect_err("there is nothing to bid");
+
+    assert!(matches!(err, BuildError::NoPayout), "got: {err}");
+}
+
+#[tokio::test]
+async fn a_payout_the_builder_cannot_afford_is_refused() {
+    let fixture = Fixture::new().await;
+    let mut config = fixture.config();
+    // Beyond anything the dev genesis funds.
+    config.subsidy_wei = u128::MAX;
+
+    let err = fixture.build(&fixture.slot(), &config).expect_err("the builder is not that rich");
+
+    assert!(matches!(err, BuildError::PayoutUnaffordable), "got: {err}");
+}
+
+#[tokio::test]
+async fn a_payout_to_the_builder_itself_is_refused() {
+    let fixture = Fixture::new().await;
+    let mut slot = fixture.slot();
+    slot.proposer_fee_recipient = fixture.builder().address();
+
+    let err = fixture.build(&slot, &fixture.config()).expect_err("paying ourselves proves nothing");
+
+    assert!(matches!(err, BuildError::PayoutToSelf), "got: {err}");
+}
+
+#[tokio::test]
+async fn withdrawals_are_applied() {
+    let fixture = Fixture::new().await;
+    let mut slot = fixture.slot();
+    let recipient = Address::repeat_byte(0x66);
+    slot.withdrawals = Withdrawals::new(vec![Withdrawal {
+        index: 1,
+        validator_index: 2,
+        address: recipient,
+        amount: 32_000_000_000,
+    }])
+    .unwrap();
+
+    let built = fixture.build(&slot, &fixture.config()).unwrap();
+
+    assert!(built.block.header.withdrawals_root.is_some());
+    assert_eq!(built.block.body.withdrawals.as_ref().unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn blob_transactions_carry_their_sidecar() {
+    let fixture = Fixture::new().await;
+    let bundle = crate::testing::blob_bundle(1);
+    let hashes: Vec<B256> = bundle
+        .generate_versioned_hashes()
+        .iter()
+        .map(|hash| crate::engine::convert::b256(*hash))
+        .collect();
+    let encoded = crate::testing::signed_blob_transfer(
+        &fixture.signers[1],
+        fixture.chain_id,
+        0,
+        Address::repeat_byte(0x55),
+        hashes,
+    );
+    let Transaction::EIP4844Transaction(blob_tx) = Transaction::decode_canonical(&encoded).unwrap()
+    else {
+        panic!("expected a blob transaction");
+    };
+    fixture.blockchain.add_blob_transaction_to_pool(blob_tx, bundle).await.unwrap();
+
+    let built = fixture.build_default().unwrap();
+
+    assert_eq!(built.block.body.transactions.len(), 2, "the blob tx plus the payout");
+    assert_eq!(
+        built.blobs_bundle.blobs.len(),
+        1,
+        "the sidecar must come through the mempool, not be rebuilt",
+    );
+    assert_eq!(
+        built.block.header.blob_gas_used,
+        Some(u64::from(ethrex_common::constants::GAS_PER_BLOB))
+    );
+}

--- a/crates/builder/src/building/mod.rs
+++ b/crates/builder/src/building/mod.rs
@@ -1,9 +1,52 @@
 //! The building role: builds a block for the next slot and submits it to the
 //! relay. Shares the embedded ethrex node with the other roles.
 
+mod assemble;
 mod keys;
 mod slot;
 mod watcher;
 
+use std::sync::Arc;
+
+use alloy_signer_local::PrivateKeySigner;
+use ethrex_blockchain::Blockchain;
+use ethrex_storage::Store;
 pub use keys::BuildingKeys;
-pub use watcher::run;
+use tokio::sync::mpsc;
+use tracing::{error, info, warn};
+pub use watcher::run as watch_slots;
+
+use crate::{building::slot::SlotContext, config::BuildingConfig};
+
+/// Builds a block for every slot the watcher publishes.
+pub async fn build_blocks(
+    config: BuildingConfig,
+    store: Store,
+    blockchain: Arc<Blockchain>,
+    payout_signer: PrivateKeySigner,
+    chain_id: u64,
+    mut contexts: mpsc::Receiver<SlotContext>,
+) {
+    while let Some(slot) = contexts.recv().await {
+        let (config, store, blockchain, signer) =
+            (config.clone(), store.clone(), blockchain.clone(), payout_signer.clone());
+        // Building is CPU-bound and must not stall the runtime.
+        let built = tokio::task::spawn_blocking(move || {
+            assemble::build(&store, &blockchain, &slot, &config, &signer, chain_id)
+        })
+        .await;
+
+        match built {
+            Ok(Ok(block)) => info!(
+                number = block.block.header.number,
+                txs = block.block.body.transactions.len(),
+                gas_used = block.block.header.gas_used,
+                value = %block.value,
+                "built a block",
+            ),
+            // Step 4 submits; until then a built block is only reported.
+            Ok(Err(e)) => warn!(err = %e, "skipping slot"),
+            Err(e) => error!(err = %e, "build task panicked"),
+        }
+    }
+}

--- a/crates/builder/src/config.rs
+++ b/crates/builder/src/config.rs
@@ -241,7 +241,7 @@ fn check_http_url(field: &str, raw: &str) -> eyre::Result<()> {
 }
 
 fn default_subsidy_wei() -> u128 {
-    1_000_000_000
+    1_000_000_000_000_000
 }
 fn default_payout_gas_reserve() -> u64 {
     TX_GAS_COST
@@ -443,7 +443,7 @@ mod building_config_tests {
 
         assert_eq!(config.relay_url, "http://localhost:4040");
         assert_eq!(config.beacon_url, "http://localhost:3500");
-        assert_eq!(config.subsidy_wei, 1_000_000_000);
+        assert_eq!(config.subsidy_wei, 1_000_000_000_000_000);
         assert_eq!(config.payout_gas_reserve, 21_000);
         assert_eq!(config.extra_data, "helix-builder");
         assert_eq!(config.submit_offsets_ms, vec![500, 2000]);
@@ -455,7 +455,10 @@ mod building_config_tests {
         let config: BuildingConfig = serde_yaml::from_str(MINIMAL_BUILDING_YAML).unwrap();
         config.validate().unwrap();
 
-        assert_eq!(config.subsidy_wei, 1_000_000_000, "an idle chain still gets a non-zero bid");
+        assert_eq!(
+            config.subsidy_wei, 1_000_000_000_000_000,
+            "an idle chain still gets a non-zero bid"
+        );
         assert_eq!(config.payout_gas_reserve, 21_000);
         assert_eq!(config.extra_data, "helix-builder");
         assert_eq!(config.submit_offsets_ms, vec![500, 2000]);

--- a/crates/builder/src/main.rs
+++ b/crates/builder/src/main.rs
@@ -45,17 +45,20 @@ fn main() -> eyre::Result<()> {
         EngineConfig::load_relay_signer()
     });
 
-    // Same, for the building role's own two keys. They are consumed once the
-    // role signs and pays; loading here fails fast on a bad key.
-    if let Some(building_config) = roles.building() {
-        let keys = BuildingKeys::load()?;
-        info!(
-            relay_url = %building_config.relay_url,
-            builder_pubkey = %keys.pubkey(),
-            payout_address = %keys.payout_address(),
-            "Loaded building config; register the pubkey and fund the payout address",
-        );
-    }
+    // Same, for the building role's own two keys.
+    let building_keys = match roles.building() {
+        Some(building_config) => {
+            let keys = BuildingKeys::load()?;
+            info!(
+                relay_url = %building_config.relay_url,
+                builder_pubkey = %keys.pubkey(),
+                payout_address = %keys.payout_address(),
+                "Loaded building config; register the pubkey and fund the payout address",
+            );
+            Some(keys)
+        }
+        None => None,
+    };
 
     let runtime = tokio::runtime::Builder::new_multi_thread().enable_all().build()?;
 
@@ -82,10 +85,19 @@ fn main() -> eyre::Result<()> {
     }
 
     if let Some(building_config) = roles.building() {
-        let (contexts, mut rx) = tokio::sync::mpsc::channel(4);
-        runtime.spawn(building::run(building_config.clone(), contexts));
-        // Steps 3 to 5 build and submit from these.
-        runtime.spawn(async move { while rx.recv().await.is_some() {} });
+        let keys = building_keys.expect("the building role loads its keys");
+        let chain_id = node.store.get_chain_config().chain_id;
+
+        let (contexts, rx) = tokio::sync::mpsc::channel(4);
+        runtime.spawn(building::watch_slots(building_config.clone(), contexts));
+        runtime.spawn(building::build_blocks(
+            building_config.clone(),
+            node.store.clone(),
+            node.blockchain.clone(),
+            keys.payout,
+            chain_id,
+            rx,
+        ));
         info!("Building role active");
     }
 


### PR DESCRIPTION
Issue: #550 (step 3 of 6)

## What this PR does

Builds a block for each slot the watcher publishes. The role now runs end to
end up to the point of submission: it fills from the node's mempool, pays the
proposer, and logs the block and its value.

```
create_payload(gas_ceil = registered_gas_limit)   // ethrex applies the 1/1024 clamp
PayloadBuildContext::new -> apply_system_operations
ctx.remaining_gas -= payout_gas_reserve           // reserve
fill_transactions                                  // tip-sorted, from the mempool
ctx.remaining_gas += payout_gas_reserve            // restore
apply_tx_to_payload(payout)                        // trailing transfer
extract_requests -> apply_withdrawals -> finalize_payload
```

The coinbase is the builder, so tips accrue here and the bid is

```
payout = ctx.block_value + subsidy_wei - payout_gas_reserve * base_fee
```

Reserving the full `payout_gas_reserve` rather than the actual 21000 is
deliberate: it under-credits the builder slightly and can never overdraw it.

`fill_transactions` gates only on `ctx.remaining_gas`, which is `pub`, so the
reservation needs no ethrex change.

## Two fixes to earlier steps

- **The default subsidy was unusable.** At 1 gwei it could not cover the
  payout's own gas (21000 x base fee, around 2e13 wei), so every build with an
  idle mempool failed. Raised to 0.001 ETH. `an_empty_mempool_still_bids_the_subsidy`
  caught this; step 1's assertions are updated to match.
- The step 2 `SlotContext` drain in `main.rs` is replaced by the real consumer,
  so nothing is dead.

## What this PR deliberately does not do

No signing and no submission — `BuiltBlock`'s `blobs_bundle`, `requests` and
`account_updates` carry `#[allow(dead_code)]` until step 4 consumes them. No
custom ordering: this uses ethrex's tip-sorted `fill_transactions`. No in-slot
rebuilding; the block is built once per slot event.

## Tests

13 new, written before the implementation and signed off first, all against a
real chain (`dev_genesis_store` + `funded_signers`) with transactions admitted
through `add_transaction_to_pool`.

- The block (3): mempool txs are included; the block extends the parent with
  the builder as coinbase; the header gas limit follows the registered limit
  through ethrex's clamp.
- The payout (4): it is last, is a plain zero-tip transfer to the fee
  recipient, and pays exactly the bid; the bid matches the formula; **the fee
  recipient's balance rises by the bid**, checked against the parent state the
  way the relay's `paid_by_balance` does; and the reserve survives a full block
  — without it that test fails, which is the point.
- Refusals (4): an idle mempool still bids the subsidy; zero subsidy with no
  tips is refused; an unaffordable payout is refused; paying ourselves is
  refused. A bad slot is skipped with a typed error, never submitted broken.
- Consensus (2): withdrawals are applied; a blob transaction reaches the block
  with the sidecar the mempool holds.

127 pass in the crate.

## Reviewer checklist
- [ ] CI (`lint`, `unit-test`) is green
- [ ] Matches the linked issue/step
- [ ] No unexplained scope creep or unrelated files touched
