### PR TITLE
Sign the built block and submit it to the relay

### DIFF
--- a/crates/builder/src/building/mod.rs
+++ b/crates/builder/src/building/mod.rs
@@ -4,6 +4,7 @@
 mod assemble;
 mod keys;
 mod slot;
+mod submit;
 mod watcher;
 
 use std::sync::Arc;
@@ -11,6 +12,7 @@ use std::sync::Arc;
 use alloy_signer_local::PrivateKeySigner;
 use ethrex_blockchain::Blockchain;
 use ethrex_storage::Store;
+use helix_common::signing::RelaySigningContext;
 pub use keys::BuildingKeys;
 use tokio::sync::mpsc;
 use tracing::{error, info, warn};
@@ -18,35 +20,76 @@ pub use watcher::run as watch_slots;
 
 use crate::{building::slot::SlotContext, config::BuildingConfig};
 
-/// Builds a block for every slot the watcher publishes.
+/// Reads the network's spec and genesis from the beacon node, so the builder
+/// domain is never a hardcoded per-network constant.
+pub async fn signing_context(beacon_url: &str) -> eyre::Result<RelaySigningContext> {
+    let url = beacon_url
+        .parse()
+        .map_err(|e| eyre::eyre!("building config: beacon_url is not a URL: {e}"))?;
+    let chain_info =
+        helix_common::beacon::BeaconClient::new(helix_common::config::BeaconClientConfig { url })
+            .get_chain_info()
+            .await
+            .map_err(|e| eyre::eyre!("cannot read the chain spec from the beacon node: {e:?}"))?;
+    Ok(RelaySigningContext::new(BuildingKeys::load()?.bls, Arc::new(chain_info)))
+}
+
+/// Builds and submits a block for every slot the watcher publishes.
 pub async fn build_blocks(
     config: BuildingConfig,
     store: Store,
     blockchain: Arc<Blockchain>,
     payout_signer: PrivateKeySigner,
+    signing: RelaySigningContext,
     chain_id: u64,
     mut contexts: mpsc::Receiver<SlotContext>,
 ) {
+    let submitter = submit::Submitter::new(&config.relay_url, config.api_key.clone(), signing);
+
     while let Some(slot) = contexts.recv().await {
-        let (config, store, blockchain, signer) =
-            (config.clone(), store.clone(), blockchain.clone(), payout_signer.clone());
+        let (build_config, store, blockchain, signer, build_slot) = (
+            config.clone(),
+            store.clone(),
+            blockchain.clone(),
+            payout_signer.clone(),
+            slot.clone(),
+        );
         // Building is CPU-bound and must not stall the runtime.
         let built = tokio::task::spawn_blocking(move || {
-            assemble::build(&store, &blockchain, &slot, &config, &signer, chain_id)
+            assemble::build(&store, &blockchain, &build_slot, &build_config, &signer, chain_id)
         })
         .await;
 
-        match built {
-            Ok(Ok(block)) => info!(
-                number = block.block.header.number,
-                txs = block.block.body.transactions.len(),
-                gas_used = block.block.header.gas_used,
-                value = %block.value,
-                "built a block",
+        let built = match built {
+            Ok(Ok(built)) => built,
+            Ok(Err(e)) => {
+                warn!(slot = slot.slot, err = %e, "skipping slot");
+                continue;
+            }
+            Err(e) => {
+                error!(slot = slot.slot, err = %e, "build task panicked");
+                continue;
+            }
+        };
+
+        let submission = match submitter.sign(&built, &slot) {
+            Ok(submission) => submission,
+            Err(e) => {
+                warn!(slot = slot.slot, err = %e, "cannot sign the block");
+                continue;
+            }
+        };
+
+        match submitter.submit(&submission).await {
+            Ok(()) => info!(
+                slot = slot.slot,
+                block_hash = %submission.message.block_hash,
+                txs = built.block.body.transactions.len(),
+                value = %built.value,
+                "submitted a block",
             ),
-            // Step 4 submits; until then a built block is only reported.
-            Ok(Err(e)) => warn!(err = %e, "skipping slot"),
-            Err(e) => error!(err = %e, "build task panicked"),
+            // The relay's reason is how an operator learns the blocks are bad.
+            Err(e) => warn!(slot = slot.slot, err = %e, "the relay refused the block"),
         }
     }
 }

--- a/crates/builder/src/building/submit.rs
+++ b/crates/builder/src/building/submit.rs
@@ -1,0 +1,156 @@
+use std::sync::Arc;
+
+use alloy_eips::eip7594::CELLS_PER_EXT_BLOB;
+use helix_common::{
+    api::{PATH_BUILDER_API, PATH_SUBMIT_BLOCK},
+    signing::RelaySigningContext,
+};
+use helix_types::{
+    BidTrace, BlobsBundle, KzgCommitments, SignedBidSubmission, payload_from_v3, requests_from_v4,
+};
+use ssz::Encode;
+use thiserror::Error;
+
+use crate::{
+    building::{assemble::BuiltBlock, slot::SlotContext},
+    engine::convert::{block_to_payload_v3, requests_to_v4},
+};
+
+#[derive(Debug, Error)]
+pub enum SubmitError {
+    #[error("blobs bundle: {0}")]
+    Blobs(String),
+    #[error("payload exceeds the consensus limits")]
+    OversizedPayload,
+    #[error("requests: {0}")]
+    Requests(String),
+    #[error("relay rejected the submission ({status}): {body}")]
+    Rejected { status: u16, body: String },
+    #[error("relay request failed: {0}")]
+    Transport(String),
+}
+
+pub struct Submitter {
+    http: reqwest::Client,
+    url: String,
+    api_key: String,
+    signing: RelaySigningContext,
+}
+
+impl Submitter {
+    pub fn new(relay_url: &str, api_key: String, signing: RelaySigningContext) -> Self {
+        Self {
+            http: reqwest::Client::new(),
+            url: format!(
+                "{}{PATH_BUILDER_API}{PATH_SUBMIT_BLOCK}",
+                relay_url.trim_end_matches('/')
+            ),
+            api_key,
+            signing,
+        }
+    }
+
+    /// Builds the `BidTrace` and signs it under the builder domain.
+    pub fn sign(
+        &self,
+        built: &BuiltBlock,
+        slot: &SlotContext,
+    ) -> Result<SignedBidSubmission, SubmitError> {
+        let payload_v3 = block_to_payload_v3(&built.block);
+        let payload = payload_from_v3(payload_v3).ok_or(SubmitError::OversizedPayload)?;
+
+        let requests_v4 = requests_to_v4(&built.requests).map_err(SubmitError::Requests)?;
+        let requests = requests_from_v4(requests_v4)
+            .ok_or_else(|| SubmitError::Requests("exceeds the consensus limits".into()))?;
+
+        let blobs = wire_blobs(&built.blobs_bundle)?;
+
+        // Every field the relay cross-checks against the payload comes from the
+        // payload itself, not from the build.
+        let message = BidTrace {
+            slot: slot.slot,
+            parent_hash: payload.parent_hash,
+            block_hash: payload.block_hash,
+            builder_pubkey: *self.signing.pubkey(),
+            proposer_pubkey: slot.proposer_pubkey,
+            proposer_fee_recipient: slot.proposer_fee_recipient,
+            gas_limit: payload.gas_limit,
+            gas_used: payload.gas_used,
+            value: built.value,
+        };
+        let signature = self.signing.sign_builder_message(&message);
+
+        Ok(SignedBidSubmission {
+            message,
+            execution_payload: Arc::new(payload),
+            blobs_bundle: Arc::new(blobs),
+            execution_requests: Arc::new(requests),
+            signature: signature.serialize().into(),
+        })
+    }
+
+    pub async fn submit(&self, submission: &SignedBidSubmission) -> Result<(), SubmitError> {
+        let response = self
+            .http
+            .post(&self.url)
+            .header("content-type", "application/octet-stream")
+            .header("x-api-key", &self.api_key)
+            .body(submission.as_ssz_bytes())
+            .send()
+            .await
+            .map_err(|e| SubmitError::Transport(e.to_string()))?;
+
+        let status = response.status();
+        if status.is_success() {
+            return Ok(());
+        }
+        // The relay's message is how an operator learns the blocks are bad.
+        let body = response.text().await.unwrap_or_default();
+        Err(SubmitError::Rejected { status: status.as_u16(), body })
+    }
+}
+
+/// Inverse of [`crate::engine::convert::eblobs`].
+///
+/// ethrex's `AddAssign` for `BlobsBundle` does not propagate `version`, so an
+/// aggregated bundle always claims version 0. The proof count is the only
+/// trustworthy signal that these are EIP-7594 cell proofs.
+fn wire_blobs(bundle: &ethrex_common::types::BlobsBundle) -> Result<BlobsBundle, SubmitError> {
+    let expected = bundle.blobs.len() * CELLS_PER_EXT_BLOB;
+    if bundle.proofs.len() != expected {
+        return Err(SubmitError::Blobs(format!(
+            "expected {expected} cell proofs for {} blobs, got {}",
+            bundle.blobs.len(),
+            bundle.proofs.len()
+        )));
+    }
+    if bundle.commitments.len() != bundle.blobs.len() {
+        return Err(SubmitError::Blobs(format!(
+            "expected {} commitments, got {}",
+            bundle.blobs.len(),
+            bundle.commitments.len()
+        )));
+    }
+
+    // A blob is 128 KiB. Write into the allocation rather than returning one
+    // by value, which would move it across the stack.
+    let mut blobs = Vec::with_capacity(bundle.blobs.len());
+    for blob in &bundle.blobs {
+        let mut out = Box::new(alloy_consensus::Blob::ZERO);
+        out.0.copy_from_slice(blob.as_slice());
+        blobs.push(Arc::from(out));
+    }
+
+    // `helix_types::fields::Kzg*` are `Bytes48`, not lighthouse's same-named types.
+    let commitments: Vec<alloy_consensus::Bytes48> =
+        bundle.commitments.iter().map(|c| alloy_consensus::Bytes48::from(*c)).collect();
+    Ok(BlobsBundle {
+        commitments: KzgCommitments::new(commitments)
+            .map_err(|e| SubmitError::Blobs(format!("too many commitments: {e:?}")))?,
+        proofs: bundle.proofs.iter().map(|p| alloy_consensus::Bytes48::from(*p)).collect(),
+        blobs,
+    })
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/builder/src/building/submit/tests.rs
+++ b/crates/builder/src/building/submit/tests.rs
@@ -1,0 +1,242 @@
+use std::sync::Arc;
+
+use alloy_primitives::{Address, B256, U256};
+use ethrex_common::types::BlobsBundle as EthrexBlobsBundle;
+use helix_common::chain_info::ChainInfo;
+use helix_types::{BlsKeypair, BlsPublicKeyBytes, Withdrawals};
+use ssz::Decode;
+
+use super::*;
+use crate::testing::blob_bundle;
+
+const PROPOSER: Address = Address::repeat_byte(0x77);
+
+fn signing() -> RelaySigningContext {
+    RelaySigningContext::new(BlsKeypair::random(), Arc::new(ChainInfo::default()))
+}
+
+fn submitter(url: &str) -> Submitter {
+    Submitter::new(url, "test-key".to_string(), signing())
+}
+
+fn slot_context() -> SlotContext {
+    SlotContext {
+        slot: 42,
+        parent_hash: B256::repeat_byte(0x11),
+        parent_block_number: 41,
+        timestamp: 1_700_000_000,
+        prev_randao: B256::repeat_byte(0xcc),
+        withdrawals: Withdrawals::default(),
+        parent_beacon_block_root: B256::repeat_byte(0xdd),
+        proposer_pubkey: BlsPublicKeyBytes::from([7u8; 48]),
+        proposer_fee_recipient: PROPOSER,
+        registered_gas_limit: 30_000_000,
+    }
+}
+
+/// A minimal finalized block, enough to convert and sign.
+fn built_block(bundle: EthrexBlobsBundle) -> BuiltBlock {
+    let mut block = ethrex_common::types::Block::default();
+    block.header.gas_limit = 30_000_000;
+    block.header.gas_used = 21_000;
+    block.header.base_fee_per_gas = Some(7);
+    block.body.withdrawals = Some(Vec::new());
+    BuiltBlock {
+        block,
+        blobs_bundle: bundle,
+        requests: Vec::new(),
+        account_updates: Vec::new(),
+        value: U256::from(1_234_567_u64),
+    }
+}
+
+// --- blobs conversion ---
+
+#[test]
+fn a_blobs_bundle_converts_to_the_wire_type() {
+    let bundle = blob_bundle(1);
+
+    let wire = wire_blobs(&bundle).expect("a cell-proof bundle must convert");
+
+    assert_eq!(wire.blobs.len(), 1);
+    assert_eq!(wire.commitments.len(), 1);
+    assert_eq!(wire.proofs.len(), CELLS_PER_EXT_BLOB, "128 cell proofs per blob");
+    assert_eq!(wire.commitments[0].0, bundle.commitments[0]);
+    assert_eq!(wire.blobs[0].as_slice(), bundle.blobs[0].as_slice());
+}
+
+#[test]
+fn a_bundle_without_cell_proofs_is_refused() {
+    let mut bundle = blob_bundle(1);
+    // A pre-EIP-7594 bundle: one proof per blob. `version` still reads 0 either
+    // way, so only the count distinguishes them.
+    bundle.proofs.truncate(1);
+
+    let err = wire_blobs(&bundle).expect_err("the relay requires cell proofs");
+
+    assert!(err.to_string().contains("cell proofs"), "got: {err}");
+}
+
+#[test]
+fn a_bundle_with_mismatched_commitments_is_refused() {
+    let mut bundle = blob_bundle(1);
+    bundle.commitments.clear();
+
+    let err = wire_blobs(&bundle).expect_err("commitments must match the blobs");
+
+    assert!(err.to_string().contains("commitments"), "got: {err}");
+}
+
+#[test]
+fn an_empty_bundle_converts() {
+    let wire = wire_blobs(&EthrexBlobsBundle::default()).expect("the common case");
+
+    assert!(wire.blobs.is_empty());
+    assert!(wire.proofs.is_empty());
+}
+
+// --- the submission ---
+
+#[test]
+fn the_bid_trace_mirrors_the_payload() {
+    let submitter = submitter("http://localhost:1");
+    let built = built_block(EthrexBlobsBundle::default());
+
+    let submission = submitter.sign(&built, &slot_context()).unwrap();
+
+    // `payload.validate()` on the relay rejects any disagreement here.
+    let payload = &submission.execution_payload;
+    assert_eq!(submission.message.parent_hash, payload.parent_hash);
+    assert_eq!(submission.message.block_hash, payload.block_hash);
+    assert_eq!(submission.message.gas_limit, payload.gas_limit);
+    assert_eq!(submission.message.gas_used, payload.gas_used);
+}
+
+#[test]
+fn the_bid_trace_carries_the_slot_and_proposer() {
+    let submitter = submitter("http://localhost:1");
+    let built = built_block(EthrexBlobsBundle::default());
+    let slot = slot_context();
+
+    let submission = submitter.sign(&built, &slot).unwrap();
+
+    assert_eq!(submission.message.slot, 42);
+    assert_eq!(submission.message.proposer_pubkey, slot.proposer_pubkey);
+    assert_eq!(submission.message.proposer_fee_recipient, PROPOSER);
+    assert_eq!(submission.message.value, built.value);
+    assert!(!submission.message.value.is_zero(), "the relay rejects a zero-value block");
+}
+
+#[test]
+fn the_signature_verifies_under_the_builder_domain() {
+    let signing = signing();
+    let domain = signing.chain_info.builder_domain;
+    let submitter = Submitter::new("http://localhost:1", "key".to_string(), signing);
+    let built = built_block(EthrexBlobsBundle::default());
+
+    let submission = submitter.sign(&built, &slot_context()).unwrap();
+
+    // The exact check the relay's decoder tile makes.
+    submission.verify_signature(domain).expect("the relay must accept our signature");
+}
+
+#[test]
+fn the_submission_round_trips_through_ssz() {
+    let submitter = submitter("http://localhost:1");
+    let built = built_block(EthrexBlobsBundle::default());
+    let submission = submitter.sign(&built, &slot_context()).unwrap();
+
+    let encoded = submission.as_ssz_bytes();
+    let decoded = SignedBidSubmission::from_ssz_bytes(&encoded).expect("the wire format");
+
+    assert_eq!(decoded.message.block_hash, submission.message.block_hash);
+    assert_eq!(decoded.message.value, submission.message.value);
+}
+
+#[test]
+fn a_submission_with_blobs_round_trips() {
+    with_large_stack(|| {
+        let submitter = submitter("http://localhost:1");
+        let built = built_block(blob_bundle(1));
+
+        let submission = submitter.sign(&built, &slot_context()).unwrap();
+        let encoded = submission.as_ssz_bytes();
+        let decoded = SignedBidSubmission::from_ssz_bytes(&encoded)
+            .expect("a bundle decodes only with 128 proofs per blob");
+
+        assert_eq!(decoded.blobs_bundle.blobs.len(), 1);
+        assert_eq!(decoded.blobs_bundle.proofs.len(), CELLS_PER_EXT_BLOB);
+    });
+}
+
+/// 128 KiB blobs overflow the default stack in debug builds.
+fn with_large_stack(test: impl FnOnce() + Send + 'static) {
+    std::thread::Builder::new().stack_size(32 * 1024 * 1024).spawn(test).unwrap().join().unwrap();
+}
+
+// --- the HTTP call ---
+
+/// Serves one canned response and records what the builder sent.
+async fn stub_relay(
+    status: axum::http::StatusCode,
+    body: &'static str,
+) -> (String, tokio::sync::oneshot::Receiver<axum::http::HeaderMap>) {
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    let seen = Arc::new(std::sync::Mutex::new(Some(tx)));
+    let app = axum::Router::new().route(
+        &format!("{PATH_BUILDER_API}{PATH_SUBMIT_BLOCK}"),
+        axum::routing::post(move |headers: axum::http::HeaderMap| {
+            let seen = seen.clone();
+            async move {
+                if let Some(tx) = seen.lock().unwrap().take() {
+                    let _ = tx.send(headers);
+                }
+                (status, body)
+            }
+        }),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    (format!("http://{addr}"), rx)
+}
+
+#[tokio::test]
+async fn the_request_carries_the_ssz_headers() {
+    let (url, headers) = stub_relay(axum::http::StatusCode::OK, "").await;
+    let submitter = submitter(&url);
+    let submission =
+        submitter.sign(&built_block(EthrexBlobsBundle::default()), &slot_context()).unwrap();
+
+    submitter.submit(&submission).await.unwrap();
+
+    let headers = headers.await.unwrap();
+    assert_eq!(headers["content-type"], "application/octet-stream", "SSZ, not JSON");
+    assert_eq!(headers["x-api-key"], "test-key");
+}
+
+#[tokio::test]
+async fn a_success_is_reported() {
+    let (url, _headers) = stub_relay(axum::http::StatusCode::OK, "").await;
+    let submitter = submitter(&url);
+    let submission =
+        submitter.sign(&built_block(EthrexBlobsBundle::default()), &slot_context()).unwrap();
+
+    submitter.submit(&submission).await.expect("a 200 is success");
+}
+
+#[tokio::test]
+async fn a_relay_rejection_is_reported_with_its_body() {
+    let (url, _headers) =
+        stub_relay(axum::http::StatusCode::BAD_REQUEST, "simulation failed: invalid state root")
+            .await;
+    let submitter = submitter(&url);
+    let submission =
+        submitter.sign(&built_block(EthrexBlobsBundle::default()), &slot_context()).unwrap();
+
+    let err = submitter.submit(&submission).await.expect_err("a 400 is not success");
+
+    // This text is how an operator learns the builder is producing bad blocks.
+    assert!(err.to_string().contains("invalid state root"), "got: {err}");
+    assert!(matches!(err, SubmitError::Rejected { status: 400, .. }), "got: {err}");
+}

--- a/crates/builder/src/main.rs
+++ b/crates/builder/src/main.rs
@@ -88,6 +88,15 @@ fn main() -> eyre::Result<()> {
         let keys = building_keys.expect("the building role loads its keys");
         let chain_id = node.store.get_chain_config().chain_id;
 
+        // The builder domain must come from the network's own spec. A wrong
+        // genesis fork version makes the relay drop every bid, silently.
+        let signing = runtime.block_on(building::signing_context(&building_config.beacon_url))?;
+        info!(
+            chain = %signing.chain_info.name,
+            builder_domain = %signing.chain_info.builder_domain,
+            "Resolved the builder signing domain",
+        );
+
         let (contexts, rx) = tokio::sync::mpsc::channel(4);
         runtime.spawn(building::watch_slots(building_config.clone(), contexts));
         runtime.spawn(building::build_blocks(
@@ -95,6 +104,7 @@ fn main() -> eyre::Result<()> {
             node.store.clone(),
             node.blockchain.clone(),
             keys.payout,
+            signing,
             chain_id,
             rx,
         ));


### PR DESCRIPTION
Issue: #550 (step 4 of 6)

## What this PR does

Signs each built block and POSTs it to the relay as SSZ. **The builder is now
functionally complete**: it watches slots, builds, pays the proposer, signs and
submits. Step 5 only adds in-slot timing and the optional self-check.

The conversion chain reuses what already exists — `block_to_payload_v3` ->
`payload_from_v3`, `requests_to_v4` -> `requests_from_v4`. Only the blobs
bundle is new, as the inverse of `convert::eblobs`.

Two details worth review:

- **The builder domain comes from the beacon node**, through
  `BeaconClient::get_chain_info()` reading `eth/v1/config/spec` and
  `eth/v1/beacon/genesis`. No hardcoded per-network fork versions. Getting this
  wrong makes the relay drop every bid with no useful error, so the role fails
  at startup rather than signing incorrectly.
- **The blobs bundle is checked by proof count, not by `version`.** ethrex's
  `impl AddAssign for BlobsBundle` does not propagate `version`, so an
  aggregated bundle always reports 0 even when its sidecars carry EIP-7594 cell
  proofs. The count of 128 per blob is the only trustworthy signal, and
  `helix_types::BlobsBundle` refuses to decode without it.

Every `BidTrace` field the relay cross-checks is read back off the converted
payload rather than from the build, so the two cannot drift.

## What this PR deliberately does not do

One submission per slot event, at the moment the event arrives — no timing
offsets, no resubmission on a higher value, and no self-validation. Those are
step 5, which is why `submit_offsets_ms` and `self_validate` are still unread.
No optimistic v3, no bid adjustments, no multi-relay fan-out.

## Tests

12 new, written before the implementation and signed off first.

- Blobs (4): a cell-proof bundle converts; a bundle with one proof per blob is
  refused; mismatched commitments are refused; an empty bundle converts.
- The submission (5): the `BidTrace` mirrors the payload on the four fields
  `payload.validate()` checks; it carries the slot and proposer; **the
  signature verifies under the builder domain**, using `verify_signature` —
  the same call the relay's decoder makes; the submission round-trips through
  SSZ, with and without a blob.
- HTTP (3), against a small axum stub on an ephemeral port: the request carries
  `application/octet-stream` and `X-Api-Key`; a 2xx is success; **a 400 surfaces
  the relay's message**, since that text is how an operator learns the builder
  is producing bad blocks.

139 pass in the crate.

## Reviewer checklist
- [ ] CI (`lint`, `unit-test`) is green
- [ ] Matches the linked issue/step
- [ ] No unexplained scope creep or unrelated files touched
