### PR TITLE
Build at each configured offset and resubmit only on a higher value

### DIFF
--- a/crates/builder/build-config.example.yml
+++ b/crates/builder/build-config.example.yml
@@ -27,6 +27,3 @@ extra_data: "helix-builder"
 
 # Points into the slot, in milliseconds, at which to build and submit.
 submit_offsets_ms: [500, 2000]
-
-# Validate our own block before submitting it.
-self_validate: true

--- a/crates/builder/src/building/mod.rs
+++ b/crates/builder/src/building/mod.rs
@@ -3,6 +3,7 @@
 
 mod assemble;
 mod keys;
+mod schedule;
 mod slot;
 mod submit;
 mod watcher;
@@ -15,10 +16,13 @@ use ethrex_storage::Store;
 use helix_common::signing::RelaySigningContext;
 pub use keys::BuildingKeys;
 use tokio::sync::mpsc;
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 pub use watcher::run as watch_slots;
 
-use crate::{building::slot::SlotContext, config::BuildingConfig};
+use crate::{
+    building::{schedule::BestBid, slot::SlotContext},
+    config::BuildingConfig,
+};
 
 /// Reads the network's spec and genesis from the beacon node, so the builder
 /// domain is never a hardcoded per-network constant.
@@ -45,51 +49,73 @@ pub async fn build_blocks(
     mut contexts: mpsc::Receiver<SlotContext>,
 ) {
     let submitter = submit::Submitter::new(&config.relay_url, config.api_key.clone(), signing);
+    let mut best = BestBid::default();
 
     while let Some(slot) = contexts.recv().await {
-        let (build_config, store, blockchain, signer, build_slot) = (
-            config.clone(),
-            store.clone(),
-            blockchain.clone(),
-            payout_signer.clone(),
-            slot.clone(),
-        );
-        // Building is CPU-bound and must not stall the runtime.
-        let built = tokio::task::spawn_blocking(move || {
-            assemble::build(&store, &blockchain, &build_slot, &build_config, &signer, chain_id)
-        })
-        .await;
+        best.prune(slot.slot);
 
-        let built = match built {
-            Ok(Ok(built)) => built,
-            Ok(Err(e)) => {
-                warn!(slot = slot.slot, err = %e, "skipping slot");
+        // Each delay is measured from the same instant, so they must not be
+        // slept end to end.
+        let base = tokio::time::Instant::now();
+        for delay in schedule::delays(slot.timestamp, &config.submit_offsets_ms, now_ms()) {
+            tokio::time::sleep_until(base + delay).await;
+
+            let (build_config, store, blockchain, signer, build_slot) = (
+                config.clone(),
+                store.clone(),
+                blockchain.clone(),
+                payout_signer.clone(),
+                slot.clone(),
+            );
+            // Building is CPU-bound and must not stall the runtime.
+            let built = tokio::task::spawn_blocking(move || {
+                assemble::build(&store, &blockchain, &build_slot, &build_config, &signer, chain_id)
+            })
+            .await;
+
+            let built = match built {
+                Ok(Ok(built)) => built,
+                Ok(Err(e)) => {
+                    warn!(slot = slot.slot, err = %e, "skipping slot");
+                    continue;
+                }
+                Err(e) => {
+                    error!(slot = slot.slot, err = %e, "build task panicked");
+                    continue;
+                }
+            };
+
+            if !best.improves(slot.slot, slot.parent_hash, built.value) {
+                debug!(slot = slot.slot, value = %built.value, "not an improvement");
                 continue;
             }
-            Err(e) => {
-                error!(slot = slot.slot, err = %e, "build task panicked");
-                continue;
-            }
-        };
 
-        let submission = match submitter.sign(&built, &slot) {
-            Ok(submission) => submission,
-            Err(e) => {
-                warn!(slot = slot.slot, err = %e, "cannot sign the block");
-                continue;
-            }
-        };
+            let submission = match submitter.sign(&built, &slot) {
+                Ok(submission) => submission,
+                Err(e) => {
+                    warn!(slot = slot.slot, err = %e, "cannot sign the block");
+                    continue;
+                }
+            };
 
-        match submitter.submit(&submission).await {
-            Ok(()) => info!(
-                slot = slot.slot,
-                block_hash = %submission.message.block_hash,
-                txs = built.block.body.transactions.len(),
-                value = %built.value,
-                "submitted a block",
-            ),
-            // The relay's reason is how an operator learns the blocks are bad.
-            Err(e) => warn!(slot = slot.slot, err = %e, "the relay refused the block"),
+            match submitter.submit(&submission).await {
+                Ok(()) => info!(
+                    slot = slot.slot,
+                    block_hash = %submission.message.block_hash,
+                    txs = built.block.body.transactions.len(),
+                    value = %built.value,
+                    "submitted a block",
+                ),
+                // The relay's reason is how an operator learns the blocks are bad.
+                Err(e) => warn!(slot = slot.slot, err = %e, "the relay refused the block"),
+            }
         }
     }
+}
+
+fn now_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("the clock is after the unix epoch")
+        .as_millis() as u64
 }

--- a/crates/builder/src/building/schedule.rs
+++ b/crates/builder/src/building/schedule.rs
@@ -1,0 +1,140 @@
+use std::{collections::HashMap, time::Duration};
+
+use alloy_primitives::{B256, U256};
+
+/// How long to wait before each build attempt, measured from `now_ms`.
+///
+/// Every entry is relative to the same instant, so a caller must sleep to an
+/// absolute deadline rather than sleeping each in turn.
+///
+/// A slot learned about late still gets one immediate attempt: dropping it
+/// would mean no bid at all for that slot.
+pub fn delays(slot_timestamp: u64, offsets: &[u64], now_ms: u64) -> Vec<Duration> {
+    let start_ms = slot_timestamp * 1_000;
+    let mut sorted: Vec<u64> = offsets.to_vec();
+    sorted.sort_unstable();
+
+    let upcoming: Vec<Duration> = sorted
+        .iter()
+        .filter_map(|offset| start_ms.checked_add(*offset)?.checked_sub(now_ms))
+        .map(Duration::from_millis)
+        .collect();
+
+    if upcoming.is_empty() { vec![Duration::ZERO] } else { upcoming }
+}
+
+/// The best bid already sent, per slot and parent.
+///
+/// The relay treats every submission as a new bid, so resending a lower value
+/// would replace a better one.
+#[derive(Debug, Default)]
+pub struct BestBid {
+    best: HashMap<(u64, B256), U256>,
+}
+
+impl BestBid {
+    /// Records `value` and reports whether it is worth submitting.
+    pub fn improves(&mut self, slot: u64, parent: B256, value: U256) -> bool {
+        match self.best.entry((slot, parent)) {
+            std::collections::hash_map::Entry::Occupied(mut entry) => {
+                if value <= *entry.get() {
+                    return false;
+                }
+                entry.insert(value);
+                true
+            }
+            std::collections::hash_map::Entry::Vacant(entry) => {
+                entry.insert(value);
+                true
+            }
+        }
+    }
+
+    /// Drops slots below `slot`, so the map does not grow without bound.
+    pub fn prune(&mut self, slot: u64) {
+        self.best.retain(|(best_slot, _), _| *best_slot >= slot);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SLOT_TIMESTAMP: u64 = 1_700_000_000;
+    const START_MS: u64 = SLOT_TIMESTAMP * 1_000;
+
+    #[test]
+    fn offsets_become_delays_from_the_slot_start() {
+        let delays = delays(SLOT_TIMESTAMP, &[500, 2000], START_MS);
+
+        assert_eq!(delays, vec![Duration::from_millis(500), Duration::from_millis(2000)]);
+    }
+
+    #[test]
+    fn unsorted_offsets_are_ordered() {
+        let delays = delays(SLOT_TIMESTAMP, &[2000, 500], START_MS);
+
+        assert_eq!(
+            delays,
+            vec![Duration::from_millis(500), Duration::from_millis(2000)],
+            "the config is a plain list and nothing else sorts it",
+        );
+    }
+
+    #[test]
+    fn an_offset_already_past_is_skipped() {
+        let delays = delays(SLOT_TIMESTAMP, &[500, 2000], START_MS + 1_000);
+
+        assert_eq!(delays, vec![Duration::from_millis(1000)], "only the 2000ms offset is ahead");
+    }
+
+    #[test]
+    fn a_late_event_still_gets_one_attempt() {
+        let delays = delays(SLOT_TIMESTAMP, &[500, 2000], START_MS + 5_000);
+
+        assert_eq!(
+            delays,
+            vec![Duration::ZERO],
+            "a late payload_attributes must not mean no bid for the slot",
+        );
+    }
+
+    #[test]
+    fn a_higher_value_is_submitted() {
+        let mut best = BestBid::default();
+        let parent = B256::repeat_byte(0x11);
+
+        assert!(best.improves(1, parent, U256::from(10)));
+        assert!(best.improves(1, parent, U256::from(11)));
+    }
+
+    #[test]
+    fn an_equal_or_lower_value_is_not_resubmitted() {
+        let mut best = BestBid::default();
+        let parent = B256::repeat_byte(0x11);
+        assert!(best.improves(1, parent, U256::from(10)));
+
+        assert!(!best.improves(1, parent, U256::from(10)), "an equal bid replaces a good one");
+        assert!(!best.improves(1, parent, U256::from(9)));
+    }
+
+    #[test]
+    fn a_new_slot_resets_the_best_value() {
+        let mut best = BestBid::default();
+        let parent = B256::repeat_byte(0x11);
+        assert!(best.improves(1, parent, U256::from(10)));
+
+        assert!(best.improves(2, parent, U256::from(1)), "a new slot starts a new auction");
+    }
+
+    #[test]
+    fn a_new_parent_for_the_same_slot_resets_the_best_value() {
+        let mut best = BestBid::default();
+        assert!(best.improves(1, B256::repeat_byte(0x11), U256::from(10)));
+
+        assert!(
+            best.improves(1, B256::repeat_byte(0x22), U256::from(1)),
+            "after a re-org the earlier bid sits on a dead parent",
+        );
+    }
+}

--- a/crates/builder/src/config.rs
+++ b/crates/builder/src/config.rs
@@ -157,11 +157,6 @@ pub struct BuildingConfig {
     /// Points into the slot, in milliseconds, at which to build and submit.
     #[serde(default = "default_submit_offsets_ms")]
     pub submit_offsets_ms: Vec<u64>,
-    /// Validate our own block before submitting it.
-    // Read once the slot loop exists.
-    #[allow(dead_code)]
-    #[serde(default = "default_true")]
-    pub self_validate: bool,
 }
 
 impl BuildingConfig {
@@ -447,7 +442,6 @@ mod building_config_tests {
         assert_eq!(config.payout_gas_reserve, 21_000);
         assert_eq!(config.extra_data, "helix-builder");
         assert_eq!(config.submit_offsets_ms, vec![500, 2000]);
-        assert!(config.self_validate);
     }
 
     #[test]
@@ -462,7 +456,6 @@ mod building_config_tests {
         assert_eq!(config.payout_gas_reserve, 21_000);
         assert_eq!(config.extra_data, "helix-builder");
         assert_eq!(config.submit_offsets_ms, vec![500, 2000]);
-        assert!(config.self_validate);
     }
 
     #[test]


### PR DESCRIPTION
Issue: #550 (step 5 of 6)

## What this PR does

Builds at each configured offset into the slot instead of once when the event
arrives, and submits only when the value beats what was already sent for that
slot and parent.

Two pieces are kept pure so the timing is testable without sleeping:
`schedule::delays` decides when to build, and `BestBid::improves` decides
whether to send.

## Scope change

**`self_validate` is dropped**, as agreed. The config field and its example
entry are removed rather than left unread.

Re-simulating a block we just built is duplicated work: assembly already
executes every transaction and computes the state root. Paying for a second
full validation inside the slot would cost latency for nothing. Correctness
here is the job of the tests and of running on a testnet before deploying.

## What this PR deliberately does not do

No bidding strategy — the bid is always the full block value, never held back.
No cancellations. No multi-relay fan-out. A slot's attempts run in sequence, so
a context arriving mid-slot waits for the previous slot's last attempt; with
12s slots and the default offsets this cannot bite, but it is a real bound.

## Tests

8 new, written before the implementation and signed off first.

- Scheduling (4): offsets become delays from the slot start; an unsorted list
  is ordered, since nothing else sorts it; an offset already past is skipped;
  and **a late event still gets one immediate attempt** — otherwise a late
  `payload_attributes` means no bid at all for that slot.
- The improvement gate (4): a higher value is sent; an equal or lower one is
  not, because the relay treats each submission as a new bid and a worse one
  would replace a better; a new slot resets; and **a new parent for the same
  slot resets**, because after a re-org the earlier bid sits on a dead parent.
  That last one pairs with step 2's rule that a new parent is not a duplicate.

147 pass in the crate.

## A bug these tests did not catch

Wiring the loop, I first slept the delays end to end, which puts the second
attempt at 2500ms rather than 2000ms. `delays` is correct and its tests pass
either way — the fault was in the caller. It now sleeps to an absolute deadline
from a single base instant, and the doc comment says why. The loop's own timing
remains untested; only the schedule it consumes is.

## Reviewer checklist
- [ ] CI (`lint`, `unit-test`) is green
- [ ] Matches the linked issue/step
- [ ] No unexplained scope creep or unrelated files touched

