### PR TITLE
Document the builder's third role

### DIFF
--- a/crates/builder/README.md
+++ b/crates/builder/README.md
@@ -1,15 +1,18 @@
 # helix-builder
 
 An embedded [ethrex](https://github.com/lambdaclass/ethrex) execution node
-running one or both of two roles, selected by which config file is supplied:
+running any combination of three roles, selected by which config files are
+supplied:
 
 | role | config | what it does |
 | --- | --- | --- |
 | merging | `--merging.config` | external block-merging builder: the TCP server counterpart of the relay's block-merging tile (`crates/relay/src/block_merging/`) |
 | simulation | `--sim.config` | block validator: the ethrex counterpart of `crates/simulator`, serving the relay's SSZ validation routes |
+| building | `--build.config` | block builder: fills a block from the node's mempool and submits it to the relay |
 
-Supplying neither is a startup error. Both share one node, and `RELAY_KEY` is
-only needed for the merging role.
+Supplying none is a startup error. The roles share one node. `RELAY_KEY` is
+needed only for merging, and `BUILDER_BLS_KEY` / `BUILDER_PAYOUT_KEY` only for
+building.
 
 ## The merging role
 
@@ -46,12 +49,50 @@ the relay must reach it through the simulator's `ssz_url`. Differences from
   block that merely *reads* one, so it rejects strictly more blocks.
 - Only Fulu (V5) and the relay-internal merged method are served.
 
+## The building role
+
+Builds a block for the next slot and submits it to the relay. It is meant for
+testnets: it lets the relay's whole path -- submit, simulate, `get_header`,
+`get_payload`, publish -- be exercised with a builder you control.
+
+Two sources are merged into one slot context, because neither is sufficient
+alone. The beacon node's `payload_attributes` SSE topic gives the parent,
+timestamp, `prev_randao`, withdrawals and `parent_beacon_block_root`; the
+relay's `get_validators` gives the proposer's pubkey, fee recipient and
+registered gas limit. A slot whose proposer has not registered is skipped.
+
+The block itself is ethrex's own payload machinery, with the builder as the
+coinbase, so tips accrue to the builder and the bid is funded from them:
+
+```
+payout = tips + subsidy_wei - payout_gas_reserve * base_fee
+```
+
+The block ends with a plain transfer of `payout` to the proposer's registered
+fee recipient. `subsidy_wei` exists because the relay rejects a zero-value
+block: without it an idle testnet would produce no bids at all, which is when
+the builder is least useful. Set it to 0 to bid only what the block earns.
+
+Gas for that transfer is held back from the fill by lowering ethrex's
+`remaining_gas` before `fill_transactions` and restoring it afterwards.
+
+The builder signs under the domain read from the beacon node's own spec and
+genesis, never a compiled-in fork version. It builds at each
+`submit_offsets_ms` point in the slot and submits only when the value beats
+what it already sent for that slot and parent -- a new parent, after a re-org,
+starts a fresh auction.
+
+What it does not do: no bundles or `eth_sendBundle`, no ordering of its own
+(ethrex's tip-sorted fill), no cancellations, no bidding strategy (it always
+bids the full block value), and one relay only.
+
 ## Architecture
 
 ```
 tokio runtime    embedded ethrex node: store (rocksdb), devp2p + snap sync,
                  Engine API (authrpc) for the operator's beacon node, head watcher
                  simulation role: SSZ validation server, disallow-list refresh
+                 building role: payload_attributes SSE, duty poll, build + submit
 flux tile        merging TCP server (listen, handshake, framing, routing)
 engine thread    merge worker: order pool, base replay, presim (rayon), emission
 ```
@@ -98,6 +139,26 @@ helix-builder \
   [sim-config.example.yml](sim-config.example.yml). Until
   `blacklist_endpoint` answers, the list is empty and no block is filtered.
 
+Building:
+
+```sh
+BUILDER_BLS_KEY=0x... BUILDER_PAYOUT_KEY=0x... helix-builder \
+  --network hoodi \
+  --datadir /data/helix-builder \
+  --authrpc.addr 0.0.0.0 --authrpc.jwtsecret /secrets/jwt.hex \
+  --build.config build.yml
+```
+
+- `--build.config` points at the building YAML; see
+  [build-config.example.yml](build-config.example.yml).
+- `BUILDER_BLS_KEY` signs the submission. Register its pubkey with the relay,
+  under `builders`, with the `api_key` the config sends.
+- `BUILDER_PAYOUT_KEY` signs the payment to the proposer and **must be
+  funded**: every bid is paid from this account. Both the pubkey and the
+  address are logged at startup.
+- These are separate from `RELAY_KEY`, which the merging role reads as a
+  secp256k1 key and `helix-common` reads as a BLS one.
+
 On the relay side, add a merging builder to
 `block_merging_config.tcp.builders`, and a simulator as a `simulators` entry
 with `ssz_url` set to this role's `ssz_addr` (see the repo-root
@@ -113,7 +174,12 @@ with `ssz_url` set to this role's `ssz_addr` (see the repo-root
   use it.
 - A blob is 128 KiB and crosses the stack several times in a debug build, which
   overflows tokio's default worker stack. Release builds elide the copies; run
-  the simulation role in release.
+  the simulation and building roles in release.
+- The building role's payout uses a fixed `payout_gas_reserve`, 21000 by
+  default. A contract fee recipient needing more makes the payout fail and the
+  slot is skipped.
+- The building role includes a blob transaction only when its sidecar reached
+  the node's mempool over devp2p; it does not rebuild sidecars.
 - The base block's declared `block_hash` is trusted as the pool key; the wire
   format carries no `requests_hash` to fully recompute it.
 - P-256 (`P256VERIFY`) uses ethrex's portable fallback rather than the


### PR DESCRIPTION
Issue: #550 (step 6 of 6)

## What this PR does

Documents the building role in the crate README: a three-role table, a section
covering the two slot-data sources and the payout formula, how to run it, the
two new env vars, and the relay-side registration it needs.

Records two limitations an operator would otherwise meet in production: the
fixed `payout_gas_reserve` skips a slot whose fee recipient is a contract
needing more than 21000 gas, and blob transactions are only included when their
sidecar arrived over devp2p.

## What this PR deliberately does not do

Documentation only. No code changes.

## Tests

None; no behaviour changes. 147 still pass.

## Reviewer checklist
- [ ] CI (`lint`, `unit-test`) is green
- [ ] Matches the linked issue/step
- [ ] No unexplained scope creep or unrelated files touched
