### PR TITLE
Meter the per-slot order budget against the deduped pool (#567 step 1)

### DIFF
--- a/crates/builder/src/engine/mod.rs
+++ b/crates/builder/src/engine/mod.rs
@@ -521,9 +521,6 @@ impl MergeEngine {
         if msg.merge_orders.len() > MAX_ORDERS_PER_BLOCK {
             return Err(fail(MergeError::LimitExceeded("max orders per block".into())));
         }
-        if state.orders_admitted + msg.merge_orders.len() > self.config.max_orders_per_slot {
-            return Err(fail(MergeError::LimitExceeded("max orders per slot".into())));
-        }
         for order in &msg.merge_orders {
             order
                 .validate(tx_bytes.len())
@@ -537,10 +534,10 @@ impl MergeEngine {
             .map_err(|err| fail(MergeError::InvalidOrder(err)))?;
         let txs = Arc::new(decoded);
 
-        // Extract the order pool entries.
+        // Budget counts distinct pooled orders, as the relay's `orders_sent` does.
+        let mut pool_full = false;
         for order_ref in &msg.merge_orders {
             let prepared = prepare_order(&msg, order_ref, &txs, block_hash);
-            state.orders_admitted += 1;
             match state.order_ids.get(&prepared.order_id) {
                 Some(&existing_ix) => {
                     // Duplicate order: attribution goes to the highest-value
@@ -551,6 +548,10 @@ impl MergeEngine {
                     }
                 }
                 None => {
+                    if state.orders.len() >= self.config.max_orders_per_slot {
+                        pool_full = true;
+                        break;
+                    }
                     state.order_ids.insert(prepared.order_id, state.orders.len());
                     state.orders.push(prepared);
                 }
@@ -567,6 +568,7 @@ impl MergeEngine {
             "mergeable block pooled"
         );
 
+        let slot = state.slot;
         state.blocks.insert(block_hash, PreparedBlock {
             block_hash,
             builder_pubkey: msg.builder_pubkey,
@@ -576,6 +578,20 @@ impl MergeEngine {
             txs,
             recv_ns,
         });
+
+        // Dropped orders still leave a usable base candidate, so keep the block.
+        if pool_full {
+            let err = MergeError::LimitExceeded("max orders per slot".into());
+            if let Some((code, subject)) = err.reject(Some(block_hash)) {
+                let _ = self.out.send(EngineOutput::reject(
+                    self.generation,
+                    slot,
+                    code,
+                    subject,
+                    err.to_string(),
+                ));
+            }
+        }
         Ok(())
     }
 }

--- a/crates/builder/src/engine/tests.rs
+++ b/crates/builder/src/engine/tests.rs
@@ -16,6 +16,7 @@ use ethrex_common::types::ELASTICITY_MULTIPLIER;
 use ethrex_config::networks::Network;
 use ethrex_storage::{EngineType, Store};
 use helix_tcp_types::merging::{
+    builder_to_relay::RejectCode,
     control::{BuilderCollateral, RelayConfigV1},
     order::{MergeOrderRef, TxOrderRef},
     relay_to_builder::{MergeableBlockV1, RevokeOrderV1, SlotStartV1},
@@ -302,6 +303,16 @@ impl Fixture {
             relay_config: None,
             slot: None,
         };
+        (engine, output_rx)
+    }
+
+    /// A direct-drive engine with a small per-slot order budget.
+    fn direct_engine_with_order_cap(
+        &self,
+        max_orders_per_slot: usize,
+    ) -> (MergeEngine, crossbeam_channel::Receiver<EngineOutput>) {
+        let (mut engine, output_rx) = self.direct_engine(Duration::ZERO);
+        engine.config.max_orders_per_slot = max_orders_per_slot;
         (engine, output_rx)
     }
 }
@@ -668,4 +679,58 @@ async fn throttled_emission_is_retried() {
         first.proposer_value
     );
     assert_eq!(second.included_order_ids.len(), 2);
+}
+
+/// A repeat announcement of a pooled order must not consume the per-slot budget.
+#[tokio::test(flavor = "multi_thread")]
+async fn repeat_announcements_do_not_consume_the_order_budget() {
+    let fixture = Fixture::new().await;
+    let (base_msg, _base_block_hash) = fixture.build_base(U256::from(ETH));
+
+    // One order, re-announced in six blocks with distinct block hashes.
+    let donors: Vec<MergeableBlockV1> =
+        (0u8..6).map(|i| fixture.donor(&base_msg, 3, U256::from(ETH / 5), 0xd0 + i)).collect();
+
+    let (mut engine, output_rx) = fixture.direct_engine_with_order_cap(3);
+    engine.handle_event(EngineEvent::RelayConfig(fixture.relay_config.clone()));
+    engine.handle_event(EngineEvent::SlotStart(fixture.slot_start()));
+    for (i, donor) in donors.iter().enumerate() {
+        engine.handle_event(mergeable_event(donor, i as u64 + 1));
+    }
+
+    assert!(output_rx.try_recv().is_err(), "a repeat order must not trip the per-slot cap");
+    let state = engine.slot.as_ref().unwrap();
+    assert_eq!(state.blocks.len(), donors.len(), "every resubmission must be pooled");
+    assert_eq!(state.orders.len(), 1, "the six announcements are one distinct order");
+}
+
+/// The per-slot budget still binds on distinct orders.
+#[tokio::test(flavor = "multi_thread")]
+async fn distinct_orders_still_hit_the_per_slot_cap() {
+    let fixture = Fixture::new().await;
+    let (base_msg, _base_block_hash) = fixture.build_base(U256::from(ETH));
+
+    // Four distinct orders against a budget of three.
+    let donors: Vec<MergeableBlockV1> = (0u8..4)
+        .map(|i| fixture.donor(&base_msg, 3, U256::from(ETH / 5 + u128::from(i)), 0xd0 + i))
+        .collect();
+
+    let (mut engine, output_rx) = fixture.direct_engine_with_order_cap(3);
+    engine.handle_event(EngineEvent::RelayConfig(fixture.relay_config.clone()));
+    engine.handle_event(EngineEvent::SlotStart(fixture.slot_start()));
+    for (i, donor) in donors.iter().enumerate() {
+        engine.handle_event(mergeable_event(donor, i as u64 + 1));
+    }
+
+    match output_rx.try_recv().expect("the fourth distinct order must be rejected") {
+        EngineOutput::Reject { msg, .. } => assert_eq!(msg.code, RejectCode::LimitExceeded),
+        EngineOutput::Merged { .. } => panic!("expected a reject, got a merged block"),
+    }
+    let state = engine.slot.as_ref().unwrap();
+    assert_eq!(state.orders.len(), 3, "the pool must stop at the cap");
+    assert_eq!(
+        state.blocks.len(),
+        donors.len(),
+        "a block whose orders hit the cap is still stored as a base candidate"
+    );
 }

--- a/crates/builder/src/engine/types.rs
+++ b/crates/builder/src/engine/types.rs
@@ -118,8 +118,6 @@ pub struct SlotState {
     /// order_id -> index into `orders` (dedup; attribution goes to the
     /// highest-value source block).
     pub order_ids: FxHashMap<B256, usize>,
-    /// Total orders admitted this slot (enforces `max_orders_per_slot`).
-    pub orders_admitted: usize,
     /// Sender-recovery cache: incremental submissions share most txs.
     pub recovery_cache: FxHashMap<B256, ethrex_common::Address>,
     /// Decoded txs already seen whole on this connection this slot, keyed by
@@ -172,7 +170,6 @@ impl SlotState {
             blocks: FxHashMap::default(),
             orders: Vec::new(),
             order_ids: FxHashMap::default(),
-            orders_admitted: 0,
             recovery_cache: FxHashMap::default(),
             tx_cache: FxHashMap::default(),
             session: None,


### PR DESCRIPTION
Issue: #567 (step 1 of 1)

## What this PR does

Counts the per-slot order budget against the deduped pool instead of against
announcements. Drops `orders_admitted` and the whole-block pre-check, and gates
on `state.orders.len()` inside the extraction loop, only where the order is
new, so a resubmission never consumes budget. A block whose orders hit the cap
is still pooled as a base candidate and reports the drop with one
`LimitExceeded` reject.

## What this PR deliberately does not do

Does not align order identity between the two sides. The relay keys on the
order hash, the builder on `keccak(order_hash || builder_pubkey)`, so one
public tx from N builders counts 1 against the relay's budget and N against the
builder's. That gap is bounded by builder count, not resubmission rate — see
the open question on #567.

## Tests

Tests written first. `repeat_announcements_do_not_consume_the_order_budget`
fails on the old code; `distinct_orders_still_hit_the_per_slot_cap` guards that
the cap still binds and that an over-cap block stays a base candidate.

## Reviewer checklist
- [ ] CI (`lint`, `unit-test`) is green
- [ ] Matches the linked issue/step
- [ ] No unexplained scope creep or unrelated files touched
