### PR TITLE
operator: log gossiped payloads by slot and block hash

### DIFF
--- a/crates/operator/src/pubsub.rs
+++ b/crates/operator/src/pubsub.rs
@@ -185,7 +185,15 @@ pub(super) async fn run_operator_connection(
                                         _ => true,
                                     };
 
-                                    tracing::info!(?operator_msg, operator=operator.name, "new operator message");
+                                    match &operator_msg {
+                                        OperatorMessage::Payload(p) => tracing::info!(
+                                            slot = p.slot,
+                                            block_hash = %p.execution_payload.execution_payload.block_hash,
+                                            operator = operator.name,
+                                            "new operator payload"
+                                        ),
+                                        _ => tracing::info!(?operator_msg, operator = operator.name, "new operator message"),
+                                    }
                                     if forward && matches!(mode, OperatorP2pMode::On) {
                                         let _ = incoming.send((operator.clone(), operator_msg)).await;
                                     }


### PR DESCRIPTION
`new operator message` Debug-printed the whole `OperatorMessage`; for `Payload` that is the full execution payload and blobs, up to 6.5 MB per line and ~700 MB/day (30% of the log) on FR. Payloads now log slot, block hash and operator; other variants unchanged.