### PR TITLE
Fix duplicate migration version 49, add merged_blocks.region_id (#572 step 1)

### DIFF
--- a/crates/database/src/postgres/migrations/V49__merged_block_split_fields.sql
+++ b/crates/database/src/postgres/migrations/V49__merged_block_split_fields.sql
@@ -1,7 +1,0 @@
-ALTER TABLE merged_blocks ADD COLUMN base_builder_revenue NUMERIC(78, 0);
-ALTER TABLE merged_blocks ADD COLUMN relay_revenue NUMERIC(78, 0);
-ALTER TABLE merged_blocks ADD COLUMN original_gas_used BIGINT;
-ALTER TABLE merged_blocks ADD COLUMN merged_gas_used BIGINT;
-ALTER TABLE merged_blocks ADD COLUMN total_merged_value NUMERIC(78, 0);
-ALTER TABLE merged_blocks ADD COLUMN was_top_builder BOOLEAN;
-ALTER TABLE merged_blocks ADD COLUMN top_bid NUMERIC(78, 0);

--- a/crates/database/src/postgres/migrations/V51__merged_block_split_fields.sql
+++ b/crates/database/src/postgres/migrations/V51__merged_block_split_fields.sql
@@ -1,0 +1,8 @@
+-- Was V49, colliding with V49__validator_prefs_api_key; IF NOT EXISTS keeps it a no-op where the columns already landed.
+ALTER TABLE merged_blocks ADD COLUMN IF NOT EXISTS base_builder_revenue NUMERIC(78, 0);
+ALTER TABLE merged_blocks ADD COLUMN IF NOT EXISTS relay_revenue NUMERIC(78, 0);
+ALTER TABLE merged_blocks ADD COLUMN IF NOT EXISTS original_gas_used BIGINT;
+ALTER TABLE merged_blocks ADD COLUMN IF NOT EXISTS merged_gas_used BIGINT;
+ALTER TABLE merged_blocks ADD COLUMN IF NOT EXISTS total_merged_value NUMERIC(78, 0);
+ALTER TABLE merged_blocks ADD COLUMN IF NOT EXISTS was_top_builder BOOLEAN;
+ALTER TABLE merged_blocks ADD COLUMN IF NOT EXISTS top_bid NUMERIC(78, 0);

--- a/crates/database/src/postgres/migrations/V52__merged_block_region.sql
+++ b/crates/database/src/postgres/migrations/V52__merged_block_region.sql
@@ -1,0 +1,2 @@
+ALTER TABLE merged_blocks
+ADD COLUMN IF NOT EXISTS region_id smallint;

--- a/crates/database/src/postgres/postgres_db_init.rs
+++ b/crates/database/src/postgres/postgres_db_init.rs
@@ -18,3 +18,22 @@ where
 {
     Ok(embedded_migrations::migrations::runner().run_async(conn).await?)
 }
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use super::embedded_migrations;
+
+    /// Two files at one version make refinery depend on directory read order.
+    #[test]
+    fn migration_versions_are_unique() {
+        let mut by_version: BTreeMap<u32, Vec<String>> = BTreeMap::new();
+        for migration in embedded_migrations::migrations::runner().get_migrations() {
+            by_version.entry(migration.version()).or_default().push(migration.name().to_string());
+        }
+
+        let duplicated: Vec<_> = by_version.iter().filter(|(_, names)| names.len() > 1).collect();
+        assert!(duplicated.is_empty(), "migration versions must be unique, found {duplicated:?}");
+    }
+}

--- a/crates/database/src/postgres/postgres_db_service.rs
+++ b/crates/database/src/postgres/postgres_db_service.rs
@@ -2909,6 +2909,7 @@ impl PostgresDatabaseService {
             was_top_builder: Option<bool>,
             top_bid: Option<PostgresNumeric>,
             inserted_at: SystemTime,
+            region_id: i16,
         }
 
         let mut structured_blocks = Vec::with_capacity(merged_blocks.len());
@@ -2941,11 +2942,12 @@ impl PostgresDatabaseService {
                 was_top_builder: block.trace.was_top_builder,
                 top_bid: block.trace.top_bid.map(PostgresNumeric::from),
                 inserted_at: SystemTime::now(),
+                region_id: self.region,
             });
         }
 
         // Flatten into SQL params
-        const FIELD_COUNT: usize = 24;
+        const FIELD_COUNT: usize = 25;
         let mut params: Vec<&(dyn ToSql + Sync)> =
             Vec::with_capacity(structured_blocks.len() * FIELD_COUNT);
         for block in &structured_blocks {
@@ -2973,6 +2975,7 @@ impl PostgresDatabaseService {
             params.push(&block.was_top_builder);
             params.push(&block.top_bid);
             params.push(&block.inserted_at);
+            params.push(&block.region_id);
         }
 
         let mut sql = String::from(
@@ -3000,7 +3003,8 @@ impl PostgresDatabaseService {
                 header_served_time_ns,
                 was_top_builder,
                 top_bid,
-                inserted_at
+                inserted_at,
+                region_id
             ) VALUES ",
         );
 

--- a/crates/database/tests/postgres_integration.rs
+++ b/crates/database/tests/postgres_integration.rs
@@ -1,0 +1,64 @@
+//! Postgres-backed tests, `#[ignore]`d so `just test` and CI skip them; run with `just
+//! test-integration`.
+
+use alloy_primitives::B256;
+use deadpool_postgres::{Config, ManagerConfig, Pool, RecyclingMethod};
+use helix_common::PostgresConfig;
+use helix_database::PostgresDatabaseService;
+use helix_types::MergedBlock;
+use rand::{Rng, rng};
+use tokio_postgres::NoTls;
+
+const REGION: i16 = 1;
+
+fn test_config() -> Config {
+    let mut cfg = Config::new();
+    cfg.host = Some("localhost".to_string());
+    cfg.port = Some(5432);
+    cfg.dbname = Some("postgres".to_string());
+    cfg.user = Some("postgres".to_string());
+    cfg.password = Some("password".to_string());
+    cfg.manager = Some(ManagerConfig { recycling_method: RecyclingMethod::Fast });
+    cfg
+}
+
+fn test_postgres_config() -> PostgresConfig {
+    PostgresConfig {
+        hostname: "localhost".to_string(),
+        port: 5432,
+        db_name: "postgres".to_string(),
+        user: "postgres".to_string(),
+        region: REGION,
+        region_name: "LOCAL".to_string(),
+        pool_size: None,
+    }
+}
+
+/// `merged_blocks.region_id` references `region`, so that row must exist first.
+async fn setup() -> Result<(PostgresDatabaseService, Pool), Box<dyn std::error::Error>> {
+    let db = PostgresDatabaseService::new(&test_config(), REGION)?;
+    db.run_migrations().await?;
+    db.init_region(&test_postgres_config()).await;
+    Ok((db, test_config().create_pool(None, NoTls)?))
+}
+
+#[tokio::test]
+#[ignore = "needs local postgres: just local-postgres"]
+async fn save_merged_blocks_records_region() -> Result<(), Box<dyn std::error::Error>> {
+    let (db, pool) = setup().await?;
+
+    let block_hash = B256::from(rng().random::<[u8; 32]>());
+    db.save_merged_blocks(&[MergedBlock { slot: 1, block_hash, ..Default::default() }]).await?;
+
+    let region_id: i16 = pool
+        .get()
+        .await?
+        .query_one("SELECT region_id FROM merged_blocks WHERE block_hash = $1", &[
+            &block_hash.as_slice()
+        ])
+        .await?
+        .get(0);
+
+    assert_eq!(region_id, REGION);
+    Ok(())
+}

--- a/justfile
+++ b/justfile
@@ -14,6 +14,10 @@ clippy:
 test:
   cargo test --workspace --all-features
 
+# Tests that need a real postgres (just local-postgres). Not run by `just test` or CI.
+test-integration:
+  cargo test --workspace --all-features -- --ignored
+
 admin-frontend-build:
   cd crates/admin/frontend && npm ci && npm run build
 


### PR DESCRIPTION
Issue: #572 (step 1 of 1)

## What this PR does

Renumbers `V49__merged_block_split_fields.sql` to V51 so migration version 49 is unique, and guards its seven `ADD COLUMN`s with `IF NOT EXISTS` so it is a no-op on databases where those columns already landed. Adds a unit test asserting that migration versions are unique, using `Runner::get_migrations()` — the same list the binary compiles in.

Also adds `merged_blocks.region_id` and writes it. The table had no region column while `get_header` does, so any join between them silently crossed regions and counted merged blocks produced by other instances.

## What this PR deliberately does not do

- **Does not renumber `V49__validator_prefs_api_key.sql`.** That is the name recorded at version 49 in production; changing it would diverge every deployed database.
- **Does not repair any database.** A database whose version 49 row names `merged_block_split_fields` still diverges and needs rows 49 **and** 50 deleted once — both, because `abort_missing` rejects a gap. Mainnet FR is not in that state. Devnet and staging should be checked. After this change that recovery is clean rather than lucky: 49, 50 and 51 all become guarded no-ops.
- **Does not backfill `region_id`.** Existing rows stay `NULL`, and rows written by instances still on the old binary during a rolling deploy will be `NULL` too. Treat `NULL` as "unknown region", not as a region.
- **No foreign key on `region_id`**, matching `block_submission` and `get_header` rather than `delivered_payload`. `save_merged_blocks` inserts a whole slot as one multi-row statement with no `ON CONFLICT`, so a missing `region` row would lose every merged block for that slot. The value comes from config, not user input.
- **No index on `region_id`.** None of the existing region columns have one; add it if these queries become routine.
- Does not touch the orphaned `postgres_db_service_tests.rs`, which is unreferenced by any `mod` and imports a path that has not existed since #300. Separate issue.

## Tests

Written before the implementation.

- `migration_versions_are_unique` (unit, no I/O). Verified failing on `develop` first, with `migration versions must be unique, found [(49, ["merged_block_split_fields", "validator_prefs_api_key"])]`. `embed_migrations!` bakes the SQL in via `include_str!`, so the test reads a list compiled into the binary.
- `save_merged_blocks_records_region` in the new `crates/database/tests/postgres_integration.rs`, marked `#[ignore]` so `just test` and CI skip it, runnable with the new `just test-integration`. A cargo feature would not work as the gate, since `just test` passes `--all-features`.

The integration test could not be executed locally — this machine's docker publishes the port but the host gets `ConnectionReset`, on a fresh container too. The migrations were instead validated with psql inside the container:

- Full chain V1 → V52 on an empty database, exit 0.
- `merged_blocks` comes out with 25 columns; `region_id` is `smallint`, nullable, no default, no foreign key.
- Re-running V51 and V52 is idempotent — `NOTICE: column … already exists, skipping`, exit 0. That is the production path.
- Static check of the write path: 25 `INSERT` columns, 25 params pushed in the same order, 25 struct fields, `FIELD_COUNT` 25.

`ADD COLUMN` with no default is metadata-only since PG 11, so V52 will not rewrite the 102 GB table.

## Reviewer checklist
- [ ] CI (`lint`, `unit-test`) is green
- [ ] Matches the linked issue/step
- [ ] No unexplained scope creep or unrelated files touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)
