### PR TITLE
Build and submit a Gloas/Amsterdam block

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6465,6 +6465,7 @@ dependencies = [
  "ethrex-common",
  "ethrex-config",
  "ethrex-crypto",
+ "ethrex-levm",
  "ethrex-metrics",
  "ethrex-p2p",
  "ethrex-rlp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,9 @@ ethrex-common = { git = "https://github.com/lambdaclass/ethrex", rev = "b4d56778
 ethrex-config = { git = "https://github.com/lambdaclass/ethrex", rev = "b4d5677812fdf58cb3e439c77906dda4d9b6f91a" }
 # default features minus `aws-lc-rs` (see note above); P-256 verify uses the portable fallback
 ethrex-crypto = { git = "https://github.com/lambdaclass/ethrex", rev = "b4d5677812fdf58cb3e439c77906dda4d9b6f91a", default-features = false, features = ["std", "kzg-rs", "secp256k1", "blst", "c-kzg"] }
+# Only for the EIP-8037 state-gas constants the payout reserve needs; already in
+# the tree via ethrex-vm.
+ethrex-levm = { git = "https://github.com/lambdaclass/ethrex", rev = "b4d5677812fdf58cb3e439c77906dda4d9b6f91a", default-features = false, features = ["secp256k1", "c-kzg"] }
 ethrex-metrics = { git = "https://github.com/lambdaclass/ethrex", rev = "b4d5677812fdf58cb3e439c77906dda4d9b6f91a" }
 ethrex-p2p = { git = "https://github.com/lambdaclass/ethrex", rev = "b4d5677812fdf58cb3e439c77906dda4d9b6f91a", features = ["c-kzg", "rocksdb", "metrics"] }
 ethrex-rlp = { git = "https://github.com/lambdaclass/ethrex", rev = "b4d5677812fdf58cb3e439c77906dda4d9b6f91a" }

--- a/crates/builder/Cargo.toml
+++ b/crates/builder/Cargo.toml
@@ -24,6 +24,7 @@ ethrex-blockchain.workspace = true
 ethrex-common.workspace = true
 ethrex-config.workspace = true
 ethrex-crypto.workspace = true
+ethrex-levm.workspace = true
 ethrex-metrics.workspace = true
 ethrex-p2p.workspace = true
 ethrex-rlp.workspace = true

--- a/crates/builder/README.md
+++ b/crates/builder/README.md
@@ -167,9 +167,11 @@ with `ssz_url` set to this role's `ssz_addr` (see the repo-root
 ## Limitations
 
 - Merging protocol v1 carries `ExecutionPayloadV3`; post-Amsterdam blocks
-  (EIP-7928 block access lists) are rejected as merge bases. The simulation
-  role has the same gap: the payload carries no block-access-list hash, so
-  Amsterdam needs a newer payload version.
+  (EIP-7928 block access lists) are rejected as merge bases, and the merged
+  validation route refuses Gloas for the same reason. The simulation and
+  building roles do handle Amsterdam: the block access list travels beside the
+  payload on a Gloas submission, and the header's list hash and slot number are
+  derived from it.
 - The simulation role serves no JSON-RPC, so a relay without `ssz_url` cannot
   use it.
 - A blob is 128 KiB and crosses the stack several times in a debug build, which
@@ -177,7 +179,9 @@ with `ssz_url` set to this role's `ssz_addr` (see the repo-root
   the simulation and building roles in release.
 - The building role's payout uses a fixed `payout_gas_reserve`, 21000 by
   default. A contract fee recipient needing more makes the payout fail and the
-  slot is skipped.
+  slot is skipped. From Amsterdam the builder adds EIP-8037's state gas for a
+  recipient that does not exist yet (183600 at the pinned ethrex revision),
+  because a fee recipient's first payment creates its account.
 - The building role includes a blob transaction only when its sidecar reached
   the node's mempool over devp2p; it does not rebuild sidecars.
 - The base block's declared `block_hash` is trusted as the pool key; the wire

--- a/crates/builder/build-config.example.yml
+++ b/crates/builder/build-config.example.yml
@@ -20,7 +20,9 @@ beacon_url: "http://localhost:3500"
 subsidy_wei: 1000000000000000
 
 # Gas held back from the fill for the trailing payout transaction. A contract
-# fee recipient that needs more than this makes the payout fail.
+# fee recipient that needs more than this makes the payout fail. From Amsterdam
+# the builder adds EIP-8037's state gas on top when the recipient does not exist
+# yet, so this covers the transfer alone.
 payout_gas_reserve: 21000
 
 extra_data: "helix-builder"

--- a/crates/builder/src/building/assemble.rs
+++ b/crates/builder/src/building/assemble.rs
@@ -15,6 +15,7 @@ use ethrex_common::{
     },
 };
 use ethrex_crypto::native::NativeCrypto;
+use ethrex_rlp::encode::RLPEncode;
 use ethrex_storage::Store;
 use thiserror::Error;
 
@@ -37,6 +38,8 @@ pub enum BuildError {
     PayoutReverted,
     #[error("the payout recipient is the builder itself")]
     PayoutToSelf,
+    #[error("an Amsterdam block was built without a block access list")]
+    MissingBlockAccessList,
     #[error("build failed: {0}")]
     Internal(String),
 }
@@ -53,6 +56,9 @@ pub struct BuiltBlock {
     /// The changed accounts, for checking the payment the way the relay does.
     #[allow(dead_code)]
     pub account_updates: Vec<AccountUpdate>,
+    /// The encoded EIP-7928 list, from Amsterdam onwards. The header commits to
+    /// these exact bytes, so the submission has to carry them unchanged.
+    pub block_access_list: Option<Vec<u8>>,
     /// Paid to the proposer by the trailing transaction, and the value the
     /// `BidTrace` claims.
     pub value: U256,
@@ -83,6 +89,10 @@ pub fn build(
         return Err(BuildError::MissingParent);
     }
 
+    // EIP-7843 puts the proposal slot in the header, and only from Amsterdam:
+    // setting it earlier would change every pre-Amsterdam block hash.
+    let is_amsterdam = store.get_chain_config().is_amsterdam_activated(slot.timestamp);
+
     let args = BuildPayloadArgs {
         parent: h256(slot.parent_hash),
         timestamp: slot.timestamp,
@@ -90,7 +100,7 @@ pub fn build(
         random: h256(slot.prev_randao),
         withdrawals: Some(slot.withdrawals.iter().map(ewithdrawal_lh).collect()),
         beacon_root: Some(h256(slot.parent_beacon_block_root)),
-        slot_number: None,
+        slot_number: is_amsterdam.then_some(slot.slot),
         version: 3,
         elasticity_multiplier: ELASTICITY_MULTIPLIER,
         // `create_payload` runs this through `calc_gas_limit`, which applies
@@ -107,16 +117,20 @@ pub fn build(
         .map_err(|e| BuildError::Internal(format!("system operations: {e}")))?;
 
     // `fill_transactions` spends every last drop of `remaining_gas`, so hold
-    // the payout's share back and restore it once the fill is done.
-    let reserve = config.payout_gas_reserve.min(ctx.remaining_gas);
+    // the payout's share back and restore it once the fill is done. The reserve
+    // is sized before the fill and the transaction after it, so a recipient the
+    // fill creates is not charged for twice.
+    let reserve = payout_gas_limit(config, is_amsterdam, recipient_exists(&mut ctx, slot)?)
+        .min(ctx.remaining_gas);
     ctx.remaining_gas -= reserve;
     blockchain
         .fill_transactions(&mut ctx)
         .map_err(|e| BuildError::Internal(format!("fill transactions: {e}")))?;
     ctx.remaining_gas += reserve;
 
+    let payout_gas = payout_gas_limit(config, is_amsterdam, recipient_exists(&mut ctx, slot)?);
     let base_fee = ctx.payload.header.base_fee_per_gas.unwrap_or_default();
-    let payout = payout_value(&ctx, config, base_fee)?;
+    let payout = payout_value(&ctx, config, payout_gas, base_fee)?;
 
     let nonce = ctx
         .vm
@@ -132,7 +146,7 @@ pub fn build(
         .map_err(|e| BuildError::Internal(e.to_string()))?
         .info
         .balance;
-    let gas_cost = EU256::from(config.payout_gas_reserve) * EU256::from(base_fee);
+    let gas_cost = EU256::from(payout_gas) * EU256::from(base_fee);
     if balance < eu256(payout) + gas_cost {
         return Err(BuildError::PayoutUnaffordable);
     }
@@ -143,7 +157,7 @@ pub fn build(
         nonce,
         slot.proposer_fee_recipient,
         payout,
-        config.payout_gas_reserve,
+        payout_gas,
         base_fee as u128,
     )?;
     let sender = payout_tx
@@ -169,22 +183,64 @@ pub fn build(
         .finalize_payload(&mut ctx)
         .map_err(|e| BuildError::Internal(format!("finalize: {e}")))?;
 
+    // `finalize_payload` hashed this into the header, so the submission has to
+    // carry the same encoding rather than re-deriving one.
+    let block_access_list = ctx.block_access_list.as_ref().map(|bal| bal.encode_to_vec());
+    if is_amsterdam && block_access_list.is_none() {
+        return Err(BuildError::MissingBlockAccessList);
+    }
+
     Ok(BuiltBlock {
         block: ctx.payload,
         blobs_bundle: ctx.blobs_bundle,
         requests: ctx.requests.unwrap_or_default(),
         account_updates: ctx.account_updates,
+        block_access_list,
         value: payout,
     })
+}
+
+/// Whether the payout recipient already has an account, read from in-block
+/// state so a payment earlier in the same block counts.
+fn recipient_exists(ctx: &mut PayloadBuildContext, slot: &SlotContext) -> Result<bool, BuildError> {
+    Ok(ctx
+        .vm
+        .db
+        .get_account(eaddr(slot.proposer_fee_recipient))
+        .map_err(|e| BuildError::Internal(e.to_string()))?
+        .info !=
+        Default::default())
+}
+
+/// The gas the payout transaction needs. `payout_gas_reserve` covers the
+/// transfer; paying an address for the first time also creates it, and from
+/// Amsterdam that costs state gas (EIP-8037). A fee recipient's first payment
+/// is exactly that case, and it is the normal case on a fresh testnet, so the
+/// reserve has to cover it or every block is lost.
+fn payout_gas_limit(config: &BuildingConfig, is_amsterdam: bool, recipient_exists: bool) -> u64 {
+    if is_amsterdam && !recipient_exists {
+        config.payout_gas_reserve + new_account_state_gas()
+    } else {
+        config.payout_gas_reserve
+    }
+}
+
+/// EIP-8037's charge for the state a new account occupies. Read from ethrex so
+/// it cannot drift from the rules the simulator enforces.
+fn new_account_state_gas() -> u64 {
+    use ethrex_levm::gas_cost::{STATE_BYTES_PER_NEW_ACCOUNT, cost_per_state_byte};
+    // `cost_per_state_byte` ignores its argument at this ethrex revision.
+    STATE_BYTES_PER_NEW_ACCOUNT * cost_per_state_byte(0)
 }
 
 /// Tips earned plus the subsidy, less the gas the payout itself will burn.
 fn payout_value(
     ctx: &PayloadBuildContext,
     config: &BuildingConfig,
+    payout_gas: u64,
     base_fee: u64,
 ) -> Result<U256, BuildError> {
-    let gas_cost = EU256::from(config.payout_gas_reserve) * EU256::from(base_fee);
+    let gas_cost = EU256::from(payout_gas) * EU256::from(base_fee);
     let funded = ctx.block_value + EU256::from(config.subsidy_wei);
     let payout = funded.checked_sub(gas_cost).ok_or(BuildError::NoPayout)?;
     if payout.is_zero() {

--- a/crates/builder/src/building/assemble/tests.rs
+++ b/crates/builder/src/building/assemble/tests.rs
@@ -8,7 +8,9 @@ use ethrex_vm::VmDatabase;
 use helix_types::{BlsPublicKeyBytes, Withdrawal, Withdrawals};
 
 use super::*;
-use crate::testing::{ETH, GWEI, dev_genesis_store, funded_signers, signed_transfer};
+use crate::testing::{
+    ETH, GWEI, deploy_amsterdam_predeploys, dev_genesis_store_with, funded_signers, signed_transfer,
+};
 
 const PROPOSER: Address = Address::repeat_byte(0x77);
 /// Must clear the payout's own gas cost, ~21000 * base fee.
@@ -22,11 +24,26 @@ struct Fixture {
     parent_timestamp: u64,
     parent_gas_limit: u64,
     chain_id: u64,
+    is_amsterdam: bool,
 }
 
 impl Fixture {
     async fn new() -> Self {
-        let (store, genesis) = dev_genesis_store().await;
+        Self::with_genesis(|_| {}).await
+    }
+
+    /// Amsterdam from genesis, so every block carries a block access list and a
+    /// slot number. The EIP-8282 predeploys are required, not optional.
+    async fn amsterdam() -> Self {
+        Self::with_genesis(|genesis| {
+            genesis.config.amsterdam_time = Some(0);
+            deploy_amsterdam_predeploys(genesis);
+        })
+        .await
+    }
+
+    async fn with_genesis(edit: impl FnOnce(&mut ethrex_common::types::Genesis)) -> Self {
+        let (store, genesis) = dev_genesis_store_with(edit).await;
         let genesis_block = genesis.get_block();
         let blockchain = Arc::new(Blockchain::new(store.clone(), BlockchainOptions {
             r#type: BlockchainType::L1,
@@ -38,6 +55,7 @@ impl Fixture {
             parent_timestamp: genesis_block.header.timestamp,
             parent_gas_limit: genesis_block.header.gas_limit,
             chain_id: genesis.config.chain_id,
+            is_amsterdam: genesis.config.is_amsterdam_activated(genesis_block.header.timestamp),
             store,
             blockchain,
         }
@@ -49,11 +67,7 @@ impl Fixture {
     }
 
     fn config(&self) -> BuildingConfig {
-        serde_yaml::from_str(&format!(
-            "relay_url: \"http://localhost:4040\"\napi_key: \"key\"\n\
-             beacon_url: \"http://localhost:3500\"\nsubsidy_wei: {SUBSIDY}\n"
-        ))
-        .unwrap()
+        test_config()
     }
 
     fn slot(&self) -> SlotContext {
@@ -86,6 +100,30 @@ impl Fixture {
         self.blockchain.add_transaction_to_pool(tx).await.unwrap();
     }
 
+    /// A transfer with enough gas to create its recipient under Amsterdam,
+    /// which the flat 21000 of `pool_transfer` cannot do.
+    async fn pool_transfer_creating(&self, index: usize, to: Address) {
+        use alloy_consensus::SignableTransaction;
+        use alloy_signer::SignerSync;
+        let tx = alloy_consensus::TxEip1559 {
+            chain_id: self.chain_id,
+            nonce: 0,
+            gas_limit: 300_000,
+            max_fee_per_gas: 100 * GWEI,
+            max_priority_fee_per_gas: GWEI,
+            to: to.into(),
+            value: U256::from(GWEI),
+            access_list: Default::default(),
+            input: Default::default(),
+        };
+        let signature = self.signers[index].sign_hash_sync(&tx.signature_hash()).unwrap();
+        let encoded = alloy_eips::eip2718::Encodable2718::encoded_2718(
+            &alloy_consensus::TxEnvelope::from(tx.into_signed(signature)),
+        );
+        let tx = Transaction::decode_canonical(&encoded).unwrap();
+        self.blockchain.add_transaction_to_pool(tx).await.unwrap();
+    }
+
     fn build(&self, slot: &SlotContext, config: &BuildingConfig) -> Result<BuiltBlock, BuildError> {
         build(&self.store, &self.blockchain, slot, config, self.builder(), self.chain_id)
     }
@@ -94,12 +132,57 @@ impl Fixture {
         self.build(&self.slot(), &self.config())
     }
 
+    /// A signing context whose spec puts the fixture's fork at genesis, so the
+    /// submission shape matches the block shape.
+    fn signing(&self) -> helix_common::signing::RelaySigningContext {
+        let mut spec = helix_types::ChainSpec::mainnet();
+        match self.fork() {
+            helix_types::ForkName::Gloas => {
+                spec.gloas_fork_epoch = Some(helix_types::Epoch::new(0))
+            }
+            _ => spec.fulu_fork_epoch = Some(helix_types::Epoch::new(0)),
+        }
+        helix_common::signing::RelaySigningContext::new(
+            helix_types::BlsKeypair::random(),
+            Arc::new(helix_common::chain_info::ChainInfo::new(spec, B256::ZERO, 0)),
+        )
+    }
+
+    fn fork(&self) -> helix_types::ForkName {
+        if self.is_amsterdam { helix_types::ForkName::Gloas } else { helix_types::ForkName::Fulu }
+    }
+
+    /// The simulation role, over the same store the block was built on.
+    fn validator(&self) -> crate::validation::BlockValidator {
+        let parent = self.parent_header();
+        let (head, _) = tokio::sync::watch::channel(crate::node::HeadInfo {
+            number: parent.number,
+            hash: parent.hash(),
+            timestamp: parent.timestamp,
+            is_synced: true,
+        });
+        crate::validation::BlockValidator::new(
+            self.store.clone(),
+            head.subscribe(),
+            8,
+            Arc::new(dashmap::DashSet::new()),
+        )
+    }
+
     fn parent_header(&self) -> ethrex_common::types::BlockHeader {
         self.store
             .get_block_header_by_hash(crate::engine::convert::h256(self.parent_hash))
             .unwrap()
             .unwrap()
     }
+}
+
+fn test_config() -> BuildingConfig {
+    serde_yaml::from_str(&format!(
+        "relay_url: \"http://localhost:4040\"\napi_key: \"key\"\n\
+         beacon_url: \"http://localhost:3500\"\nsubsidy_wei: {SUBSIDY}\n"
+    ))
+    .unwrap()
 }
 
 /// The trailing transaction, decoded.
@@ -335,4 +418,192 @@ async fn blob_transactions_carry_their_sidecar() {
         built.block.header.blob_gas_used,
         Some(u64::from(ethrex_common::constants::GAS_PER_BLOB))
     );
+}
+
+// --- Amsterdam ---
+
+#[tokio::test]
+async fn an_amsterdam_block_carries_a_block_access_list_and_a_slot_number() {
+    let fixture = Fixture::amsterdam().await;
+
+    let built = fixture.build_default().unwrap();
+
+    let bal = built.block_access_list.as_deref().expect("Amsterdam records a list");
+    assert!(!bal.is_empty(), "even an idle block touches accounts");
+    assert_eq!(
+        built.block.header.block_access_list_hash,
+        Some(ethrex_common::utils::keccak(bal)),
+        "the submission has to carry the bytes the header committed to",
+    );
+    assert_eq!(built.block.header.slot_number, Some(fixture.slot().slot));
+}
+
+/// Setting either field before Amsterdam would change every block hash.
+#[tokio::test]
+async fn a_pre_amsterdam_block_carries_neither() {
+    let fixture = Fixture::new().await;
+
+    let built = fixture.build_default().unwrap();
+
+    assert!(built.block_access_list.is_none());
+    assert!(built.block.header.block_access_list_hash.is_none());
+    assert!(built.block.header.slot_number.is_none());
+}
+
+/// EIP-7843 wants the proposal slot, which is neither the block number nor zero.
+#[tokio::test]
+async fn the_header_slot_number_is_the_proposal_slot() {
+    let fixture = Fixture::amsterdam().await;
+    let mut slot = fixture.slot();
+    slot.slot = 4_242;
+
+    let built = fixture.build(&slot, &fixture.config()).unwrap();
+
+    assert_eq!(built.block.header.slot_number, Some(4_242));
+    assert_ne!(built.block.header.number, 4_242, "not the block number");
+}
+
+/// The proposer keeps being paid in-block under Gloas, so the trailing payout
+/// is unchanged.
+#[tokio::test]
+async fn an_amsterdam_block_still_pays_the_proposer_in_block() {
+    let fixture = Fixture::amsterdam().await;
+    fixture.pool_transfer(1, 0, GWEI).await;
+
+    let built = fixture.build_default().unwrap();
+
+    let payout = payout_tx(&built);
+    assert_eq!(payout.to(), ethrex_common::types::TxKind::Call(eaddr(PROPOSER)));
+    assert_eq!(payout.value(), eu256(built.value));
+    assert!(!built.value.is_zero(), "the relay rejects a zero-value block");
+}
+
+/// Amsterdam charges gas for the list's items out of the same block budget the
+/// payout reserve is taken from, so the fill can still starve the payout.
+#[tokio::test]
+async fn an_amsterdam_block_includes_mempool_transactions() {
+    let fixture = Fixture::amsterdam().await;
+    fixture.pool_transfer(1, 0, GWEI).await;
+    fixture.pool_transfer(2, 0, GWEI).await;
+
+    let built = fixture.build_default().unwrap();
+
+    assert_eq!(built.block.body.transactions.len(), 3, "two mempool txs plus the payout");
+}
+
+/// A fee recipient's first payment creates its account, and EIP-8037 charges
+/// state gas for that. It is the normal case on a fresh testnet: with only the
+/// transfer's own 21000 reserved, the payout runs out of gas and every block is
+/// lost. Pre-Amsterdam the same payment costs nothing extra.
+#[tokio::test]
+async fn paying_a_new_account_reserves_the_amsterdam_state_gas() {
+    let config = BuildingConfig { payout_gas_reserve: 21_000, ..test_config() };
+
+    assert_eq!(payout_gas_limit(&config, false, false), 21_000, "no such charge before Amsterdam");
+    assert_eq!(payout_gas_limit(&config, true, true), 21_000, "an existing account is a transfer");
+    assert_eq!(
+        payout_gas_limit(&config, true, false),
+        204_600,
+        "measured against ethrex: 21000 transfer + 120 state bytes at 1530 each",
+    );
+}
+
+/// The reserve is only useful if the payment it sizes actually succeeds.
+#[tokio::test]
+async fn a_first_payment_to_a_new_account_succeeds_under_amsterdam() {
+    let fixture = Fixture::amsterdam().await;
+    let slot = fixture.slot();
+    assert!(
+        fixture
+            .store
+            .get_account_info_by_hash(
+                crate::engine::convert::h256(fixture.parent_hash),
+                eaddr(slot.proposer_fee_recipient),
+            )
+            .unwrap()
+            .is_none(),
+        "the fixture's proposer must start absent, or this proves nothing",
+    );
+
+    let built = fixture.build(&slot, &fixture.config()).unwrap();
+
+    let payout = payout_tx(&built);
+    assert_eq!(payout.gas_limit(), 204_600);
+    assert_eq!(payout.value(), eu256(built.value));
+}
+
+/// The recipient's account is read from in-block state, so a payment earlier in
+/// the same block already counts as creating it.
+#[tokio::test]
+async fn a_recipient_created_earlier_in_the_block_needs_no_extra_reserve() {
+    let fixture = Fixture::amsterdam().await;
+    let mut slot = fixture.slot();
+    slot.proposer_fee_recipient = Address::repeat_byte(0x55);
+    fixture.pool_transfer_creating(1, slot.proposer_fee_recipient).await;
+
+    let built = fixture.build(&slot, &fixture.config()).unwrap();
+
+    assert_eq!(built.block.body.transactions.len(), 2, "the transfer plus the payout");
+    let balance = built
+        .account_updates
+        .iter()
+        .find(|update| update.address == eaddr(slot.proposer_fee_recipient))
+        .and_then(|update| update.info.as_ref().map(|info| info.balance))
+        .expect("both payments must touch the recipient");
+    assert_eq!(
+        balance,
+        eu256(built.value) + ethrex_common::U256::from(GWEI),
+        "the earlier transfer has to land, or it created nothing",
+    );
+    assert_eq!(payout_tx(&built).gas_limit(), 21_000, "already created, so no state charge");
+}
+
+/// The strongest check available without a relay: build a block, submit it the
+/// way the relay would receive it, and validate it with our own simulation
+/// role. A disagreement between steps 3 and 4 shows up here and nowhere else.
+async fn our_simulator_accepts_our_own_block(fixture: &Fixture) {
+    use axum::http::StatusCode;
+    use tower::ServiceExt;
+
+    let slot = fixture.slot();
+    let built = fixture.build(&slot, &fixture.config()).unwrap();
+    let bid = crate::building::submit::Submitter::new(
+        "http://localhost:1",
+        "key".to_string(),
+        fixture.signing(),
+    )
+    .sign(&built, &slot)
+    .expect("a block we built must be submittable");
+
+    let request = helix_common::simulator::SszValidationRequest {
+        apply_blacklist: false,
+        registered_gas_limit: slot.registered_gas_limit,
+        parent_beacon_block_root: slot.parent_beacon_block_root,
+        inclusion_list: Default::default(),
+        decoder_params: Some(helix_common::decoder::SubmissionDecoderParams::plain(fixture.fork())),
+        signed_bid_submission: bid.as_ssz_bytes(),
+    };
+
+    let response = crate::validation::server::router(fixture.validator(), 1)
+        .oneshot(
+            axum::http::Request::post("/validate")
+                .body(axum::body::Body::from(ssz::Encode::as_ssz_bytes(&request)))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let status = response.status();
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+
+    assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+}
+
+#[tokio::test]
+async fn our_simulation_role_accepts_our_gloas_block() {
+    our_simulator_accepts_our_own_block(&Fixture::amsterdam().await).await;
+}
+
+#[tokio::test]
+async fn our_simulation_role_accepts_our_fulu_block() {
+    our_simulator_accepts_our_own_block(&Fixture::new().await).await;
 }

--- a/crates/builder/src/building/mod.rs
+++ b/crates/builder/src/building/mod.rs
@@ -90,18 +90,18 @@ pub async fn build_blocks(
                 continue;
             }
 
-            let submission = match submitter.sign(&built, &slot) {
-                Ok(submission) => submission,
+            let bid = match submitter.sign(&built, &slot) {
+                Ok(bid) => bid,
                 Err(e) => {
                     warn!(slot = slot.slot, err = %e, "cannot sign the block");
                     continue;
                 }
             };
 
-            match submitter.submit(&submission).await {
+            match submitter.submit(&bid).await {
                 Ok(()) => info!(
                     slot = slot.slot,
-                    block_hash = %submission.message.block_hash,
+                    block_hash = %bid.message().block_hash,
                     txs = built.block.body.transactions.len(),
                     value = %built.value,
                     "submitted a block",

--- a/crates/builder/src/building/submit.rs
+++ b/crates/builder/src/building/submit.rs
@@ -6,7 +6,8 @@ use helix_common::{
     signing::RelaySigningContext,
 };
 use helix_types::{
-    BidTrace, BlobsBundle, KzgCommitments, SignedBidSubmission, payload_from_v3, requests_from_v4,
+    BidTrace, BlobsBundle, BlockAccessListBytes, ForkName, KzgCommitments, SignedBidSubmission,
+    SignedBidSubmissionGloas, Slot, payload_from_v3, requests_from_v4,
 };
 use ssz::Encode;
 use thiserror::Error;
@@ -20,6 +21,10 @@ use crate::{
 pub enum SubmitError {
     #[error("blobs bundle: {0}")]
     Blobs(String),
+    #[error("a Gloas submission needs a block access list, and the block has none")]
+    MissingBlockAccessList,
+    #[error("the {0} submission shape cannot carry a block access list")]
+    UnsubmittableBlockAccessList(ForkName),
     #[error("payload exceeds the consensus limits")]
     OversizedPayload,
     #[error("requests: {0}")]
@@ -28,6 +33,30 @@ pub enum SubmitError {
     Rejected { status: u16, body: String },
     #[error("relay request failed: {0}")]
     Transport(String),
+}
+
+/// The submission in the shape its fork uses. Only Gloas has room for the
+/// block access list, so the choice of shape is the choice of fork.
+#[derive(Debug)]
+pub enum Bid {
+    Fulu(SignedBidSubmission),
+    Gloas(SignedBidSubmissionGloas),
+}
+
+impl Bid {
+    pub fn message(&self) -> &BidTrace {
+        match self {
+            Bid::Fulu(bid) => &bid.message,
+            Bid::Gloas(bid) => &bid.message,
+        }
+    }
+
+    pub fn as_ssz_bytes(&self) -> Vec<u8> {
+        match self {
+            Bid::Fulu(bid) => bid.as_ssz_bytes(),
+            Bid::Gloas(bid) => bid.as_ssz_bytes(),
+        }
+    }
 }
 
 pub struct Submitter {
@@ -51,11 +80,7 @@ impl Submitter {
     }
 
     /// Builds the `BidTrace` and signs it under the builder domain.
-    pub fn sign(
-        &self,
-        built: &BuiltBlock,
-        slot: &SlotContext,
-    ) -> Result<SignedBidSubmission, SubmitError> {
+    pub fn sign(&self, built: &BuiltBlock, slot: &SlotContext) -> Result<Bid, SubmitError> {
         let payload_v3 = block_to_payload_v3(&built.block);
         let payload = payload_from_v3(payload_v3).ok_or(SubmitError::OversizedPayload)?;
 
@@ -80,16 +105,32 @@ impl Submitter {
         };
         let signature = self.signing.sign_builder_message(&message);
 
-        Ok(SignedBidSubmission {
+        let submission = SignedBidSubmission {
             message,
             execution_payload: Arc::new(payload),
             blobs_bundle: Arc::new(blobs),
             execution_requests: Arc::new(requests),
             signature: signature.serialize().into(),
-        })
+        };
+
+        // The relay decodes by the fork its own clock reports, so the shape has
+        // to be chosen from the same spec rather than from the block.
+        let fork = self.signing.chain_info.fork_at_slot(Slot::new(slot.slot));
+        match (fork, &built.block_access_list) {
+            (ForkName::Gloas, Some(bal)) => Ok(Bid::Gloas(SignedBidSubmissionGloas::join(
+                submission,
+                BlockAccessListBytes(bal.clone().into()),
+            ))),
+            (ForkName::Gloas, None) => Err(SubmitError::MissingBlockAccessList),
+            // Sending it anyway drops the list, and the simulator then rebuilds
+            // a header whose hash is not the one signed here. Every bid would
+            // die as a hash mismatch, with nothing to point at.
+            (fork, Some(_)) => Err(SubmitError::UnsubmittableBlockAccessList(fork)),
+            (_, None) => Ok(Bid::Fulu(submission)),
+        }
     }
 
-    pub async fn submit(&self, submission: &SignedBidSubmission) -> Result<(), SubmitError> {
+    pub async fn submit(&self, submission: &Bid) -> Result<(), SubmitError> {
         let response = self
             .http
             .post(&self.url)

--- a/crates/builder/src/building/submit/tests.rs
+++ b/crates/builder/src/building/submit/tests.rs
@@ -46,7 +46,16 @@ fn built_block(bundle: EthrexBlobsBundle) -> BuiltBlock {
         blobs_bundle: bundle,
         requests: Vec::new(),
         account_updates: Vec::new(),
+        block_access_list: None,
         value: U256::from(1_234_567_u64),
+    }
+}
+
+/// The pre-Gloas shape, which is what a default `ChainInfo` selects.
+fn fulu(bid: Bid) -> SignedBidSubmission {
+    match bid {
+        Bid::Fulu(bid) => bid,
+        Bid::Gloas(_) => panic!("a mainnet spec is not on Gloas"),
     }
 }
 
@@ -102,7 +111,7 @@ fn the_bid_trace_mirrors_the_payload() {
     let submitter = submitter("http://localhost:1");
     let built = built_block(EthrexBlobsBundle::default());
 
-    let submission = submitter.sign(&built, &slot_context()).unwrap();
+    let submission = fulu(submitter.sign(&built, &slot_context()).unwrap());
 
     // `payload.validate()` on the relay rejects any disagreement here.
     let payload = &submission.execution_payload;
@@ -118,7 +127,7 @@ fn the_bid_trace_carries_the_slot_and_proposer() {
     let built = built_block(EthrexBlobsBundle::default());
     let slot = slot_context();
 
-    let submission = submitter.sign(&built, &slot).unwrap();
+    let submission = fulu(submitter.sign(&built, &slot).unwrap());
 
     assert_eq!(submission.message.slot, 42);
     assert_eq!(submission.message.proposer_pubkey, slot.proposer_pubkey);
@@ -134,7 +143,7 @@ fn the_signature_verifies_under_the_builder_domain() {
     let submitter = Submitter::new("http://localhost:1", "key".to_string(), signing);
     let built = built_block(EthrexBlobsBundle::default());
 
-    let submission = submitter.sign(&built, &slot_context()).unwrap();
+    let submission = fulu(submitter.sign(&built, &slot_context()).unwrap());
 
     // The exact check the relay's decoder tile makes.
     submission.verify_signature(domain).expect("the relay must accept our signature");
@@ -144,9 +153,9 @@ fn the_signature_verifies_under_the_builder_domain() {
 fn the_submission_round_trips_through_ssz() {
     let submitter = submitter("http://localhost:1");
     let built = built_block(EthrexBlobsBundle::default());
-    let submission = submitter.sign(&built, &slot_context()).unwrap();
+    let submission = fulu(submitter.sign(&built, &slot_context()).unwrap());
 
-    let encoded = submission.as_ssz_bytes();
+    let encoded = ssz::Encode::as_ssz_bytes(&submission);
     let decoded = SignedBidSubmission::from_ssz_bytes(&encoded).expect("the wire format");
 
     assert_eq!(decoded.message.block_hash, submission.message.block_hash);
@@ -159,8 +168,8 @@ fn a_submission_with_blobs_round_trips() {
         let submitter = submitter("http://localhost:1");
         let built = built_block(blob_bundle(1));
 
-        let submission = submitter.sign(&built, &slot_context()).unwrap();
-        let encoded = submission.as_ssz_bytes();
+        let submission = fulu(submitter.sign(&built, &slot_context()).unwrap());
+        let encoded = ssz::Encode::as_ssz_bytes(&submission);
         let decoded = SignedBidSubmission::from_ssz_bytes(&encoded)
             .expect("a bundle decodes only with 128 proofs per blob");
 
@@ -239,4 +248,93 @@ async fn a_relay_rejection_is_reported_with_its_body() {
     // This text is how an operator learns the builder is producing bad blocks.
     assert!(err.to_string().contains("invalid state root"), "got: {err}");
     assert!(matches!(err, SubmitError::Rejected { status: 400, .. }), "got: {err}");
+}
+
+// --- the Gloas shape ---
+
+/// Gloas from genesis, so `fork_at_slot` reports it for every slot.
+fn gloas_signing() -> RelaySigningContext {
+    let mut spec = helix_types::ChainSpec::mainnet();
+    spec.gloas_fork_epoch = Some(helix_types::Epoch::new(0));
+    RelaySigningContext::new(BlsKeypair::random(), Arc::new(ChainInfo::new(spec, B256::ZERO, 0)))
+}
+
+fn built_with_bal(bal: Vec<u8>) -> BuiltBlock {
+    BuiltBlock { block_access_list: Some(bal), ..built_block(EthrexBlobsBundle::default()) }
+}
+
+#[test]
+fn a_gloas_submission_carries_the_block_access_list() {
+    let submitter = Submitter::new("http://localhost:1", "key".to_string(), gloas_signing());
+    let bal = vec![9u8; 64];
+
+    let bid = submitter.sign(&built_with_bal(bal.clone()), &slot_context()).unwrap();
+
+    // Decoded the way the relay's own decoder will, rather than by field access.
+    let params = helix_common::decoder::SubmissionDecoderParams::plain(ForkName::Gloas);
+    let mut buf = Vec::new();
+    let (_, _, _, decoded) = helix_common::decoder::SubmissionDecoder::new(&params)
+        .decode(&bid.as_ssz_bytes(), &mut buf)
+        .expect("the relay must be able to decode what we send");
+    assert_eq!(decoded.expect("Gloas carries a list").to_vec(), bal);
+}
+
+#[test]
+fn a_fulu_submission_keeps_its_shape() {
+    let submitter = submitter("http://localhost:1");
+    let built = built_block(EthrexBlobsBundle::default());
+
+    let bid = submitter.sign(&built, &slot_context()).unwrap();
+
+    assert!(matches!(bid, Bid::Fulu(_)));
+    let params = helix_common::decoder::SubmissionDecoderParams::plain(ForkName::Fulu);
+    let mut buf = Vec::new();
+    let (_, _, _, decoded) = helix_common::decoder::SubmissionDecoder::new(&params)
+        .decode(&bid.as_ssz_bytes(), &mut buf)
+        .expect("the Fulu shape must be unchanged");
+    assert!(decoded.is_none(), "only Gloas carries one");
+}
+
+/// Refused rather than sent with an empty list, which the simulator would
+/// reject as a block hash mismatch with nothing to point at.
+#[test]
+fn a_gloas_submission_without_a_list_is_refused() {
+    let submitter = Submitter::new("http://localhost:1", "key".to_string(), gloas_signing());
+
+    let err = submitter
+        .sign(&built_block(EthrexBlobsBundle::default()), &slot_context())
+        .expect_err("Gloas needs a list");
+
+    assert!(matches!(err, SubmitError::MissingBlockAccessList), "got: {err}");
+}
+
+/// The other direction: an Amsterdam block cannot go out in a pre-Gloas
+/// submission, because the shape has nowhere to put its list.
+#[test]
+fn an_amsterdam_block_in_a_fulu_submission_is_refused() {
+    let mut spec = helix_types::ChainSpec::mainnet();
+    spec.fulu_fork_epoch = Some(helix_types::Epoch::new(0));
+    let signing = RelaySigningContext::new(
+        BlsKeypair::random(),
+        Arc::new(ChainInfo::new(spec, B256::ZERO, 0)),
+    );
+    let submitter = Submitter::new("http://localhost:1", "key".to_string(), signing);
+
+    let err = submitter
+        .sign(&built_with_bal(vec![1u8; 32]), &slot_context())
+        .expect_err("the list would be dropped");
+
+    assert!(matches!(err, SubmitError::UnsubmittableBlockAccessList(ForkName::Fulu)), "got: {err}");
+}
+
+/// Step 3 derives the header's slot number from the bid trace, so these two
+/// must name the same slot or the simulator rebuilds a different block.
+#[test]
+fn the_bid_trace_slot_matches_the_slot_the_block_was_built_for() {
+    let submitter = Submitter::new("http://localhost:1", "key".to_string(), gloas_signing());
+    let slot = slot_context();
+
+    let bid = submitter.sign(&built_with_bal(vec![2u8; 16]), &slot).unwrap();
+
+    assert_eq!(bid.message().slot, slot.slot);
 }

--- a/crates/builder/src/config.rs
+++ b/crates/builder/src/config.rs
@@ -149,7 +149,9 @@ pub struct BuildingConfig {
     #[allow(dead_code)]
     #[serde(default = "default_subsidy_wei")]
     pub subsidy_wei: u128,
-    /// Gas held back from the fill for the trailing payout transaction.
+    /// Gas held back from the fill for the trailing payout transaction. Covers
+    /// the transfer only: from Amsterdam, creating a recipient that does not
+    /// exist yet is charged on top. See `assemble::payout_gas_limit`.
     #[serde(default = "default_payout_gas_reserve")]
     pub payout_gas_reserve: u64,
     #[serde(default = "default_extra_data")]


### PR DESCRIPTION
Issue: #561 (step 4 of 6)

## What this PR does

The building role now produces Amsterdam blocks and submits them in the Gloas
shape. Two fork decisions drive it, and they are independent:

- **Block shape** comes from the EL: `is_amsterdam_activated(slot.timestamp)`
  sets the header's EIP-7843 slot number and keeps the EIP-7928 list ethrex
  already records but which `BuiltBlock` was discarding.
- **Submission shape** comes from the CL: `chain_info.fork_at_slot(slot)`
  selects `SignedBidSubmissionGloas`. The relay decodes by the fork *its* clock
  reports, so the builder reads the same spec or its bytes are undecodable.

When the two disagree the submission is refused rather than sent. An Amsterdam
block in a Fulu shape silently drops the list; the simulator then rebuilds a
header whose hash is not the one signed, and every bid dies as a hash mismatch
with nothing to point at.

## The finding that made this more than plumbing

**Under Amsterdam the trailing payout needs 204600 gas, not 21000, whenever the
proposer's fee recipient does not yet exist on chain.** EIP-8037 charges state
gas for the account the payment creates: 120 state bytes at 1530 each = 183600,
on top of the transfer's 21000.

With the old fixed reserve every such block was lost — `PayoutReverted`, from an
out-of-gas that consumed the whole limit. On a fresh testnet fee recipients
generally *don't* exist yet, so this would have broken the builder on the exact
network step 4 exists to enable, and the error message pointed at the payout
rather than at gas.

The reserve is now sized from state: `payout_gas_reserve` covers the transfer,
and the creation charge is added only when the recipient is absent. It is read
twice — before the fill to size the reserve, and after it for the transaction —
so a recipient created earlier in the same block is not charged for twice. The
constants come from `ethrex-levm` rather than being hardcoded, so they cannot
drift from the rules the simulator enforces when the ethrex pin moves.

A related property worth knowing, which this PR does not change: under Amsterdam
an ordinary 21000-gas transfer to a fresh address also fails. That is EIP-8037
applying to all traffic, not something the builder can fix; such transactions
are included with failed receipts, which is correct.

## What this PR deliberately does not do

- **The proposer is still paid in-block**, as you decided. ePBS's own payment
  path is untouched.
- **No merging.** The merged route still refuses Gloas; that is step 5.
- **No binary search on the payout gas.** A contract fee recipient needing more
  than the reserve still fails and the slot is skipped, as before. rbuilder
  searches for this; it stays a stage-2 item.
- **The reserve is not lowered after the first payment.** It does not need to
  be: the in-block read already reports the account as existing from the next
  block on.

## Tests

Tests were written first, as in every earlier step. 15 new tests; 414 pass in
total (399 before).

The end-to-end pair is the one that matters: build a block, sign it the way the
relay will receive it, and validate it with our own step 3 simulation role,
asserting 200. I checked it is not vacuous by flipping one byte of the list —
the test then fails with the expected block hash mismatch. Both forks are
covered.

Also covered: an Amsterdam block carries both header fields and the exact bytes
the header hashed; a pre-Amsterdam block carries neither, guarding against
changing every Fulu block hash; the slot number is the proposal slot, not the
block number; the in-block payout is unchanged; mempool transactions still fit
alongside the larger reserve; the three payout-gas cases as a unit; a first
payment to an absent recipient really succeeds; a recipient created earlier in
the block needs no extra reserve; the Gloas submission decodes through the
relay's own decoder; the Fulu shape is unchanged; both fork-mismatch directions
are refused by name; and the bid trace's slot matches the header's, which is the
contract step 3 relies on.

## Reviewer checklist
- [ ] CI (`lint`, `unit-test`) is green
- [ ] Matches the linked issue/step
- [ ] No unexplained scope creep or unrelated files touched