### PR TITLE
Build and publish a helix-builder image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,3 +135,44 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/helix-simulator:${{ env.IMAGE_NAME }}
           cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/helix-simulator:buildcache
           cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/helix-simulator:buildcache,mode=max
+
+  build-builder:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set IMAGE_NAME
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            BRANCH=$(echo "${{ github.head_ref }}" | tr '[:upper:]' '[:lower:]' | tr '/' '-')
+            SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
+            IMAGE_NAME="${BRANCH}_${SHORT_SHA}"
+          else
+            REF_BRANCH=$(echo "${{ github.ref_name }}" | tr '[:upper:]' '[:lower:]' | tr '/' '-')
+            IMAGE_NAME="${REF_BRANCH}"
+          fi
+          echo "IMAGE_NAME=$IMAGE_NAME" >> $GITHUB_ENV
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          file: ./builder.Dockerfile
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/helix-builder:${{ env.IMAGE_NAME }}
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/helix-builder:buildcache
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/helix-builder:buildcache,mode=max


### PR DESCRIPTION
Issue: none (CI only)

## What this PR does

Adds a `build-builder` job to `.github/workflows/build.yml`, publishing
`ghcr.io/<owner>/helix-builder`. `builder.Dockerfile` has been in the tree since
#456 but was wired to nothing, so the only image you could not pull was the one
for `crates/builder`.

Cherry-picked from #578 so it does not wait behind the 11-PR Gloas stack — the
job is independent of that work and useful now.

The job is byte-identical to `build-simulator` apart from the component name,
including the `pull_request` branch in `Set IMAGE_NAME`, which is unreachable
given the workflow's triggers but is what the other three jobs carry. Diverging
from them seemed worse than carrying the dead branch.

## What this PR deliberately does not do

- **No matrix refactor.** Four near-identical 40-line jobs invite drift, but
  collapsing them would rewrite the three existing jobs. Worth doing separately.
- **`admin.Dockerfile` still has no job.** Left alone; worth a follow-up if that
  image is meant to be published.
- **No change to `builder.Dockerfile`.** #578 adds `8552` to its `EXPOSE` line
  for the simulation role's SSZ port; that belongs with the stack, and `EXPOSE`
  is documentation rather than enforcement, so the image builds the same either
  way.

## Tests

Not exercised by CI on this PR: the workflow fires only on pushes to
`main`/`develop` and on `workflow_dispatch`. Dispatch it against this branch to
see it pass before merging.

Checked instead by building the Dockerfile's `chef` and `planner` stages, which
is where a manifest change would break it, and by diffing the new job against
`build-simulator` structurally. I did not run the full `cook`/build — that is an
ethrex plus rocksdb compile, and CI is the right place for it.

## Reviewer checklist
- [ ] CI (`lint`, `unit-test`) is green
- [ ] Matches the linked issue/step
- [ ] No unexplained scope creep or unrelated files touched