### PR TITLE
disable payload share on getHeader by default

### DIFF
--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -770,6 +770,8 @@ pub struct OperatorConfig {
     /// Operator group or company.
     #[serde(default)]
     pub operator_group: Option<String>,
+    #[serde(default)]
+    pub share_get_header_payloads: bool,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/crates/operator/src/lib.rs
+++ b/crates/operator/src/lib.rs
@@ -53,6 +53,7 @@ pub struct OperatorPubSub {
     outgoing_msgs: Sender<(Option<String>, OperatorMessage)>,
     incoming_msgs: Receiver<(Operator, OperatorMessage)>,
     task_handle: AbortHandle,
+    share_get_header_payloads: bool,
 }
 
 impl Drop for OperatorPubSub {
@@ -67,6 +68,7 @@ impl OperatorPubSub {
         local_keypair: Keypair,
         operators: Vec<Operator>,
         mode: OperatorP2pMode,
+        share_get_header_payloads: bool,
     ) -> Self {
         let (outgoing_msgs, out_recv) = bounded(128);
         let (in_send, incoming_msgs) = bounded(128);
@@ -81,7 +83,12 @@ impl OperatorPubSub {
             mode,
         ));
 
-        Self { outgoing_msgs, incoming_msgs, task_handle: handle.abort_handle() }
+        Self {
+            outgoing_msgs,
+            incoming_msgs,
+            task_handle: handle.abort_handle(),
+            share_get_header_payloads,
+        }
     }
 
     pub async fn send(
@@ -111,6 +118,10 @@ impl OperatorPubSub {
             Err(e) => Err(e.into()),
         }
     }
+
+    pub fn share_get_header_payloads(&self) -> bool {
+        self.share_get_header_payloads
+    }
 }
 
 pub fn spawn_operator_connection<F>(
@@ -134,6 +145,7 @@ where
         operator_keypair,
         config.operators,
         config.mode,
+        config.share_get_header_payloads,
     ));
 
     // spawn a task to load initial db state
@@ -305,6 +317,7 @@ mod tests {
             keypair_a,
             vec![operator_b],
             helix_common::OperatorP2pMode::On,
+            false,
         );
         // Ensure A is listening before B initiates its dial.
         tokio::time::sleep(Duration::from_millis(100)).await;
@@ -313,6 +326,7 @@ mod tests {
             keypair_b,
             vec![operator_a],
             helix_common::OperatorP2pMode::On,
+            false,
         );
         // Wait for the gossipsub subscription exchange before publishing. Messages are
         // intentionally best-effort and are not queued for peers that have not subscribed yet.

--- a/crates/relay/src/api/proposer/get_header.rs
+++ b/crates/relay/src/api/proposer/get_header.rs
@@ -197,6 +197,7 @@ impl<A: Api> ProposerApi<A> {
                             Cow::Owned(payload_and_blobs),
                             fork,
                             Cow::Owned(bid_data),
+                            true,
                         )
                         .await;
                 }

--- a/crates/relay/src/api/proposer/get_payload.rs
+++ b/crates/relay/src/api/proposer/get_payload.rs
@@ -369,6 +369,7 @@ impl<A: Api> ProposerApi<A> {
             Cow::Borrowed(&to_proposer.data),
             fork,
             Cow::Borrowed(&bid),
+            false,
         )
         .await;
 
@@ -546,6 +547,7 @@ impl<A: Api> ProposerApi<A> {
         execution_payload: Cow<'_, PayloadAndBlobs>,
         fork_name: ForkName,
         bid: Cow<'_, PayloadBidData>,
+        header: bool,
     ) {
         let params = BroadcastPayloadParams::to_proto(
             &execution_payload,
@@ -557,6 +559,7 @@ impl<A: Api> ProposerApi<A> {
         self.gossiper.broadcast_payload(params).await;
 
         if let Some(operator_pubsub) = self.operator_api.as_ref() &&
+            (!header || operator_pubsub.share_get_header_payloads()) &&
             let Err(e) = operator_pubsub
                 .send(
                     None,


### PR DESCRIPTION
there are too many get_header calls resulting in payload sharing swamping the p2p
