### PR TITLE
Treat a missing parent state as a temporary sim failure

### DIFF
--- a/crates/builder/src/validation/error.rs
+++ b/crates/builder/src/validation/error.rs
@@ -30,6 +30,7 @@ pub enum ValidationError {
     PostExecution(String),
     #[error("block state root mismatch: got {got}, expected {expected}")]
     StateRootMismatch { got: B256, expected: B256 },
+    // Text matched by `BlockSimError::is_temporary`; changing it demotes builders.
     #[error("parent state is not available")]
     MissingParentState,
     #[error("could not verify proposer payment")]

--- a/crates/common/src/simulator.rs
+++ b/crates/common/src/simulator.rs
@@ -64,6 +64,8 @@ const BLOCK_ALREADY_KNOWN: &str = "block already known";
 const BLOCK_TOO_OLD: &str = "block is too old, outside validation window";
 const BLOCK_REQ_REORG: &str = "block requires a reorg";
 const PARENT_BLOCK_NOT_FOUND: &str = "could not find parent block: parent block not found";
+const NO_STATE_FOR_BLOCK: &str = "no state found for block";
+const MISSING_PARENT_STATE: &str = "parent state is not available";
 
 #[derive(Debug, Clone, Error)]
 pub enum BlockSimError {
@@ -110,7 +112,9 @@ impl BlockSimError {
                 PARENT_NOT_FOUND => true,
                 PARENT_BLOCK_NOT_FOUND => true,
                 BLOCK_REQ_REORG => true,
+                MISSING_PARENT_STATE => true,
                 r if r.starts_with(MISSING_TRIE_NODE) => true,
+                r if r.starts_with(NO_STATE_FOR_BLOCK) => true,
                 _ => false,
             },
             BlockSimError::Timeout => true,
@@ -236,6 +240,20 @@ mod tests {
             BlockSimError::InvalidTxRoot { got: Default::default(), expected: Default::default() }
                 .is_demotable()
         )
+    }
+
+    /// The parent state can be missing while the simulator lags or reorgs, so it must not demote.
+    #[test]
+    fn missing_parent_state_never_demotes() {
+        for reason in [
+            "no state found for block 0xf9d64b1e6815113d8a761cac2d094802520a082b19221dcbeff2940b469adb7d",
+            "parent state is not available",
+        ] {
+            let err = BlockSimError::BlockValidationFailed(reason.to_string());
+
+            assert!(err.is_temporary(), "{err}");
+            assert!(!err.is_demotable(), "{err}");
+        }
     }
 
     /// A relay-side hydration failure is never the builder's fault, so it must not demote.


### PR DESCRIPTION
Issue: none (small bug fix; say the word and I draft one)

## What this PR does

The simulator returns `no state found for block <hash>` when its node knows the parent header but does not have that block on its head chain (`state_by_block_hash` in `crates/simulator/src/validation/mod.rs`). A late parent block, a reorg, or a lagging node causes this. `BlockSimError::is_temporary` did not match the text, so `is_demotable` returned `true` and the relay demoted the builder for a sim-side condition. This was seen on mainnet FR, slot 15185181, builder Titan.

The fix matches the reth text with `starts_with`, because the message carries the parent hash. It also matches our own builder validator's `parent state is not available`, which is the same condition.

## What this PR deliberately does not do

It does not change the retry or pause behaviour: a temporary error already pauses the simulator tile and the submission retries. It does not touch the simulator node's own head-chain tracking, and it does not remove any past demotion from the database.

## Tests

`missing_parent_state_never_demotes` in `crates/common/src/simulator.rs` holds the invariant: both texts are temporary and not demotable. The test came before the match arms. The change is a one-line-per-text classification fix, so no new integration test.

## Reviewer checklist
- [ ] CI (`lint`, `unit-test`) is green
- [ ] Matches the linked issue/step
- [ ] No unexplained scope creep or unrelated files touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)
